### PR TITLE
Fixed layout of dictionary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,56 @@ jobs:
         - name: check_syntax
           uses: COMCIFS/cif_syntax_check_action@master
           id: cif_syntax_check
+  layout:
+    runs-on: ubuntu-latest
+    needs: syntax
+
+    steps:
+      - name: Get the cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+                 path: ~/.julia
+                 key: ${{ runner.os }}-julia-v2
+                 
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+                version: '1.6'
+
+      - name: Install Julia packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+               julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("FilePaths");Pkg.add("ArgParse")'
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+                path: main
+      - name: checkout julia tools
+        uses: actions/checkout@v2
+        with:
+                repository: jamesrhester/julia_cif_tools
+                path: julia_cif_tools
+
+      - name: Checkout CIF master files
+        uses: actions/checkout@v2
+        with:
+                repository: COMCIFS/cif_core
+                path: cif_core
+      - name: Diagnostics
+        run: |
+            ls -a
+            pwd
+            which julia
+      - name: one_dict_layout
+        run: |
+               julia -e 'using Pkg; Pkg.status()'
+               for file in main/*.dic
+               do      
+                  echo "Checking $file"
+                  julia -O0 ./julia_cif_tools/linter.jl -i $PWD/cif_core $file cif_core/ddl.dic
+                  if [ $? != 0 ] 
+                  then 
+                    exit 1 ;
+                  fi 
+               done

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -748,52 +748,6 @@ save_pd_char.atten_coef_mu_obs
 
 save_
 
-save_pd_char.mass_atten_coef_mu_calc
-
-    _definition.id               '_pd_char.mass_atten_coef_mu_calc'
-    _definition.update           2022-09-15
-    _description.text                   
-;
-	The calculated mass attenuation coefficient, \\m*, in 
-	units of square millimetres per gram, also known as the
-	mass absorption coefficient. The calculated \\m* will 
-	be obtained from the atomic content of each phase and 
-	the radiation wavelength.    
-;
-    _name.category_id            pd_char
-    _name.object_id              mass_atten_coef_mu_calc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-	_units.code                  millimetres_squared_per_gram
-
-save_
-
-save_pd_char.mass_atten_coef_mu_obs
-
-    _definition.id               '_pd_char.mass_atten_coef_mu_obs'
-    _definition.update           2022-09-15
-    _description.text                   
-;
-	The observed mass attenuation coefficient, \\m*, in 
-	units of square millimetres per gram, also known as the
-	mass absorption coefficient. The observed \\m* will be 
-	determined by a transmission measurement coupled with 
-	a density measurement.
-;
-    _name.category_id            pd_char
-    _name.object_id              atten_coef_mu_obs
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                  millimetres_squared_per_gram
-
-save_
-
 save_pd_char.colour
 
     _definition.id                '_pd_char.colour'
@@ -840,6 +794,52 @@ save_pd_char.colour
          orange_red
          brownish_red
          yellow_metallic
+
+save_
+
+save_pd_char.mass_atten_coef_mu_calc
+
+    _definition.id               '_pd_char.mass_atten_coef_mu_calc'
+    _definition.update           2022-09-15
+    _description.text                   
+;
+    The calculated mass attenuation coefficient, \\m*, in 
+    units of square millimetres per gram, also known as the
+    mass absorption coefficient. The calculated \\m* will 
+    be obtained from the atomic content of each phase and 
+    the radiation wavelength.    
+;
+    _name.category_id            pd_char
+    _name.object_id              mass_atten_coef_mu_calc
+    _type.purpose                Number
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           0.0:
+    _units.code                  millimetres_squared_per_gram
+
+save_
+
+save_pd_char.mass_atten_coef_mu_obs
+
+    _definition.id               '_pd_char.mass_atten_coef_mu_obs'
+    _definition.update           2022-09-15
+    _description.text                   
+;
+    The observed mass attenuation coefficient, \\m*, in 
+    units of square millimetres per gram, also known as the
+    mass absorption coefficient. The observed \\m* will be 
+    determined by a transmission measurement coupled with 
+    a density measurement.
+;
+    _name.category_id            pd_char
+    _name.object_id              atten_coef_mu_obs
+    _type.purpose                Number
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           0.0:
+    _units.code                  millimetres_squared_per_gram
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -705,14 +705,14 @@ save_pd_char.atten_coef_mu_calc
     _definition.update            2014-06-20
     _description.text
 ;
-    The calculated linear attenuation coefficient, \\m, in units 
-	of inverse millimetres, also known as the linear absorption 
-	coefficient. The value is obtained from the atomic content of 
-	each of the phases in the specimen, the average density 
+    The calculated linear attenuation coefficient, \\m, in units
+    of inverse millimetres, also known as the linear absorption
+    coefficient. The value is obtained from the atomic content of
+    each of the phases in the specimen, the average density
     (allowing for specimen packing), and the radiation wavelength.
-    Note that _pd_char.atten_coef_mu_calc will differ from the value 
-	based on phase quantities and _exptl_absorpt.coefficient_mu for 
-	each phase if the packing density is not unity.
+    Note that _pd_char.atten_coef_mu_calc will differ from the value
+    based on phase quantities and _exptl_absorpt.coefficient_mu for
+    each phase if the packing density is not unity.
 ;
     _name.category_id             pd_char
     _name.object_id               atten_coef_mu_calc
@@ -732,10 +732,10 @@ save_pd_char.atten_coef_mu_obs
     _definition.update            2014-06-20
     _description.text
 ;
-	The observed linear attenuation coefficient, \\m, in units 
-	of inverse millimetres, also known as the linear absorption 
-	coefficient. The value is determined by a transmission 
-	measurement.
+    The observed linear attenuation coefficient, \\m, in units
+    of inverse millimetres, also known as the linear absorption
+    coefficient. The value is determined by a transmission
+    measurement.
 ;
     _name.category_id             pd_char
     _name.object_id               atten_coef_mu_obs
@@ -799,14 +799,14 @@ save_
 
 save_pd_char.mass_atten_coef_mu_calc
 
-    _definition.id               '_pd_char.mass_atten_coef_mu_calc'
-    _definition.update           2022-09-15
-    _description.text                   
+    _definition.id                '_pd_char.mass_atten_coef_mu_calc'
+    _definition.update            2022-09-15
+    _description.text
 ;
-    The calculated mass attenuation coefficient, \\m*, in 
+    The calculated mass attenuation coefficient, \\m*, in
     units of square millimetres per gram, also known as the
-    mass absorption coefficient. The calculated \\m* will 
-    be obtained from the atomic content of each phase and 
+    mass absorption coefficient. The calculated \\m* will
+    be obtained from the atomic content of each phase and
     the radiation wavelength.    
 ;
     _name.category_id            pd_char
@@ -822,14 +822,14 @@ save_
 
 save_pd_char.mass_atten_coef_mu_obs
 
-    _definition.id               '_pd_char.mass_atten_coef_mu_obs'
-    _definition.update           2022-09-15
-    _description.text                   
+    _definition.id                '_pd_char.mass_atten_coef_mu_obs'
+    _definition.update            2022-09-15
+    _description.text
 ;
-    The observed mass attenuation coefficient, \\m*, in 
+    The observed mass attenuation coefficient, \\m*, in
     units of square millimetres per gram, also known as the
-    mass absorption coefficient. The observed \\m* will be 
-    determined by a transmission measurement coupled with 
+    mass absorption coefficient. The observed \\m* will be
+    determined by a transmission measurement coupled with
     a density measurement.
 ;
     _name.category_id            pd_char

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -11,6138 +11,5414 @@
 
 data_CIF_POW
 
-    _dictionary.title            CIF_POW
-    _dictionary.formalism        Powder
-    _dictionary.class            Instance
-    _dictionary.version          2.4.1
-    _dictionary.date             2021-12-06
-    _dictionary.uri              www.iucr.org/cif/dic/cif_pow.dic
-    _dictionary.ddl_conformance  3.11.10
-    _dictionary.namespace        CifPow
-    _description.text                   
+    _dictionary.title             CIF_POW
+    _dictionary.formalism         Powder
+    _dictionary.class             Instance
+    _dictionary.version           2.4.1
+    _dictionary.date              2021-12-06
+    _dictionary.uri               www.iucr.org/cif/dic/cif_pow.dic
+    _dictionary.ddl_conformance   3.11.10
+    _dictionary.namespace         CifPow
+    _description.text
 ;
-
     The CIF_POW dictionary records the definitions of data items needed in
     powder diffraction studies. Note that unlike most IUCr CIF
     dictionaries, the dataname is not always constructed as
     <category>.<object>
-
 ;
 
 save_PD_GROUP
 
-    _definition.id               PD_GROUP
-    _definition.scope            Category
-    _definition.class            Head
-    _definition.update           2014-06-20
-    _description.text                   
+    _definition.id                PD_GROUP
+    _definition.scope             Category
+    _definition.class             Head
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Groups all of the categories of definitions in the powder
+    diffraction study of materials.
+;
+    _name.category_id             CIF_POW
+    _name.object_id               PD_GROUP
 
-      Groups all of the categories of definitions in the powder
-      diffraction study of materials.
-;
-    _name.category_id            CIF_POW
-    _name.object_id              PD_GROUP
-    _import.get                 [{"file":"cif_core.dic" "save":"CIF_CORE" "mode":"Full" "dupl":"Ignore"}]
-    
+    _import.get
+        [{'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE}]
+
 save_
-
 
 save_PD_BLOCK
 
-    _definition.id               PD_BLOCK
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2016-10-18
-    _description.text                   
+    _definition.id                PD_BLOCK
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-18
+    _description.text
 ;
+    _pd_block.id is used to assign a unique ID code to a data block.
+    This code is then used for references between different blocks
+    (see _pd_block.diffractogram_id, _pd_calib.std_external_block_id
+    and _pd_phase.block_id).
 
-      _pd_block.id is used to assign a unique ID code to a data block.
-      This code is then used for references between different blocks
-      (see _pd_block_diffractogram.id, _pd_calib_std.external_block_id
-      and _pd_phase.block_id).
- 
-      Note that a data block may contain only a single diffraction
-      data set or information about a single crystalline phase.
-      However, a single diffraction measurement may yield structural
-      information on more than one phase, or a single structure
-      determination may use more than one data set. Alternatively,
-      results from a single data set, such as calibration parameters
-      from measurements of a standard, may be used for many subsequent
-      analyses. Through use of the ID code, a reference made between
-      data sets may be preserved when the file is exported from the
-      laboratory from which the CIF originated.
- 
-      The ID code assigned to each data block should be unique with
-      respect to an ID code assigned for any other data block in the
-      world. The naming scheme chosen for the block-ID format is
-      designed to ensure uniqueness.
- 
-      It is the responsibility of a data archive site or local
-      laboratory to create a catalogue of block ID's if that site
-      wishes to resolve these references.
+    Note that a data block may contain only a single diffraction
+    data set or information about a single crystalline phase.
+    However, a single diffraction measurement may yield structural
+    information on more than one phase, or a single structure
+    determination may use more than one data set. Alternatively,
+    results from a single data set, such as calibration parameters
+    from measurements of a standard, may be used for many subsequent
+    analyses. Through use of the ID code, a reference made between
+    data sets may be preserved when the file is exported from the
+    laboratory from which the CIF originated.
+
+    The ID code assigned to each data block should be unique with
+    respect to an ID code assigned for any other data block in the
+    world. The naming scheme chosen for the block-ID format is
+    designed to ensure uniqueness.
+
+    It is the responsibility of a data archive site or local
+    laboratory to create a catalogue of block ID's if that site
+    wishes to resolve these references.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_BLOCK
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_BLOCK
 
 save_
 
+save_pd_block.id
 
-save__pd_block.id
-
-    _definition.id               '_pd_block.id'
-    _definition.update           2016-10-17
-    loop_
-      _alias.definition_id
-          '_pd_block_id' 
-    _description.text                   
+    _definition.id                '_pd_block.id'
+    _alias.definition_id          '_pd_block_id'
+    _definition.update            2016-10-17
+    _description.text
 ;
+    Used to assign a unique character string to a block.
+    Note that this code is not intended to be parsed; the
+    concatenation of several strings is used in order to
+    generate a string that can reasonably be expected to
+    be unique.
 
-      Used to assign a unique character string to a block.
-      Note that this code is not intended to be parsed; the
-      concatenation of several strings is used in order to
-      generate a string that can reasonably be expected to
-      be unique.
- 
-      This code is assigned by the originator of the data set and
-      is used for references between different CIF blocks.
-      The ID will normally be created when the block is first
-      created. It is possible to loop more than one ID for a
-      block: if changes or additions are made to the
-      block later, a new ID may be assigned, but the original name
-      should be retained.
- 
-      The suggested format for the ID code is:
-        <date-time>|<block_name>|<creator_name>|<instr_name>
- 
-       <date-time>    is the date and time the CIF was created
-                      or modified.
- 
-       <block_name>   is an arbitrary name assigned by the
-                      originator of the data set. It will
-                      usually match the name of the phase
-                      and possibly the name of the current CIF
-                      data block (i.e. the string xxxx in a
-                      data_xxxx identifier). It may be a sample name.
- 
-       <creator_name> is the name of the person who measured the
-                      diffractogram, or prepared or modified the CIF.
- 
-       <instr_name>  is a unique name (as far as possible) for
-                      the data-collection instrument, preferably
-                      containing the instrument serial number for
-                      commercial instruments. It is also possible to
-                      use the Internet name or address for the
-                      instrument computer as a unique name.
- 
-      As blocks are created in a CIF, the original sample identifier
-      (i.e. <block_name>) should be retained, but the <creator_name>
-      may be changed and the <date-time> will always change.
-      The <date-time> will usually match either the
-      _pd_meas.datetime_initiated or the _pd_proc.info_datetime
-      entry.
- 
-      Within each section of the code, the following characters
-      may be used:
-                    A-Z a-z 0-9 # & * . : , - _ + / ( ) \ [ ]\
- 
-      The sections are separated with vertical rules '|' which are
-      not allowed within the sections. Blank spaces may also
-      not be used.  Capitalization may be used within the ID code
-      but should not be considered significant - searches for
-      data-set ID names should be case-insensitive.
- 
-      Date-time entries follow the standard RFC 3339 ABNF format
-      'yyyy-mm-ddThh:mm{:ss}{[+-]zz:zz}'. Use of seconds and a 
-      time zone is optional, but use of hours and minutes is strongly
-      encouraged, as this will help ensure that the ID code is unique.
- 
-      An archive site that wishes to make CIFs available via
-      the web may substitute the URL for the file containing the
-      appropriate block for the final two sections of the ID
-      (<creator_name> and <instr_name>). Note that this should
-      not be done unless the archive site is prepared to keep the
-      file available online indefinitely.
+    This code is assigned by the originator of the data set and
+    is used for references between different CIF blocks.
+    The ID will normally be created when the block is first
+    created. It is possible to loop more than one ID for a
+    block: if changes or additions are made to the
+    block later, a new ID may be assigned, but the original name
+    should be retained.
+
+    The suggested format for the ID code is:
+      <date-time>|<block_name>|<creator_name>|<instr_name>
+
+     <date-time>    is the date and time the CIF was created
+                    or modified.
+
+     <block_name>   is an arbitrary name assigned by the
+                    originator of the data set. It will
+                    usually match the name of the phase
+                    and possibly the name of the current CIF
+                    data block (i.e. the string xxxx in a
+                    data_xxxx identifier). It may be a sample name.
+
+     <creator_name> is the name of the person who measured the
+                    diffractogram, or prepared or modified the CIF.
+
+     <instr_name>  is a unique name (as far as possible) for
+                    the data-collection instrument, preferably
+                    containing the instrument serial number for
+                    commercial instruments. It is also possible to
+                    use the Internet name or address for the
+                    instrument computer as a unique name.
+
+    As blocks are created in a CIF, the original sample identifier
+    (i.e. <block_name>) should be retained, but the <creator_name>
+    may be changed and the <date-time> will always change.
+    The <date-time> will usually match either the
+    _pd_meas_datetime_initiated or the _pd_proc_info_datetime
+    entry.
+
+    Within each section of the code, the following characters
+    may be used:
+                  A-Z a-z 0-9 # & * . : , - _ + / ( ) \ [ ]\
+
+    The sections are separated with vertical rules '|' which are
+    not allowed within the sections. Blank spaces may also
+    not be used.  Capitalization may be used within the ID code
+    but should not be considered significant - searches for
+    data-set ID names should be case-insensitive.
+
+    Date-time entries follow the standard RFC 3339 ABNF format
+    'yyyy-mm-ddThh:mm{:ss}{[+-]zz:zz}'. Use of seconds and a
+    time zone is optional, but use of hours and minutes is strongly
+    encouraged, as this will help ensure that the ID code is unique.
+
+    An archive site that wishes to make CIFs available via
+    the web may substitute the URL for the file containing the
+    appropriate block for the final two sections of the ID
+    (<creator_name> and <instr_name>). Note that this should
+    not be done unless the archive site is prepared to keep the
+    file available online indefinitely.
 ;
-    _name.category_id            pd_block
-    _name.object_id              id
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_block
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
     loop_
-    _description_example.case
-            "1991-15-09T16:54|Si-std|B.Toby|D500#1234-987"
-            '1991-15-09T16:54|SEPD7234|B.Toby|SEPD.IPNS.ANL.GOV'
+      _description_example.case
+         1991-15-09T16:54|Si-std|B.Toby|D500#1234-987
+         1991-15-09T16:54|SEPD7234|B.Toby|SEPD.IPNS.ANL.GOV
+
 save_
 
 save_PD_BLOCK_DIFFRACTOGRAM
-    _definition.id               PD_BLOCK_DIFFRACTOGRAM
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-18
-    _description.text                   
-;
 
+    _definition.id                PD_BLOCK_DIFFRACTOGRAM
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-18
+    _description.text
+;
     A number of diffractograms may contribute to the
     determination of the structure of a single phase.
     The _pd_block.ids of those diffractograms should
     be listed here.
-    
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_BLOCK_DIFFRACTOGRAM
-    loop_
-    _category_key.name           '_pd_block_diffractogram.id'
-    
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_BLOCK_DIFFRACTOGRAM
+    _category_key.name            '_pd_block_diffractogram.id'
+
 save_
 
-save__pd_block_diffractogram.id
+save_pd_block_diffractogram.id
 
-    _definition.id               '_pd_block_diffractogram.id'
-    _definition.update           2016-10-18
-    loop_
-      _alias.definition_id
-          '_pd_block_diffractogram_id' 
-    _description.text                   
+    _definition.id                '_pd_block_diffractogram.id'
+    _alias.definition_id          '_pd_block_diffractogram_id'
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      A block ID code (see _pd_block.id) that identifies
-      diffraction data contained in a data block other
-      than the current block. This will occur most frequently
-      when more than one set of diffraction data
-      is used for a structure determination. The data
-      block containing the diffraction data will contain
-      a _pd_block.id code matching the code in
-      _pd_block_diffractogram.id.
+    A block ID code (see _pd_block.id) that identifies
+    diffraction data contained in a data block other
+    than the current block. This will occur most frequently
+    when more than one set of diffraction data
+    is used for a structure determination. The data
+    block containing the diffraction data will contain
+    a _pd_block.id code matching the code in
+    _pd_block.diffractogram_id.
 ;
-    _name.category_id            pd_block_diffractogram
-    _name.object_id              id
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_block_diffractogram
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
 save_PD_CALC_OVERALL
 
-    _definition.id               PD_CALC_OVERALL
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2016-10-18
-    _description.text                   
+    _definition.id                PD_CALC_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      Items in this category record overall features of the computed
-      diffractogram.
-
+    Items in this category record overall features of the computed
+    diffractogram.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_CALC_OVERALL
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALC_OVERALL
 
 save_
 
-save__pd_calc.method
+save_pd_calc.method
 
-    _definition.id               '_pd_calc.method'
-    _definition.update           2016-10-18
-    loop_
-      _alias.definition_id
-          '_pd_calc_method' 
-    _description.text                   
+    _definition.id                '_pd_calc.method'
+    _alias.definition_id          '_pd_calc_method'
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      A description of the method used for the calculation of the
-      intensities in _pd_calc.intensity_*. If the pattern was
-      calculated from crystal structure data for a single phase, the
-      atom coordinates and other crystallographic information should
-      be included in the datablock using the core CIF _atom_site. and
-      _cell. data items.  If multiple phases were used, these should
-      be listed in the pd_phase category.
-
+    A description of the method used for the calculation of the
+    intensities in _pd_calc.intensity_*. If the pattern was
+    calculated from crystal structure data for a single phase, the
+    atom coordinates and other crystallographic information should
+    be included in the datablock using the core CIF _atom_site_ and
+    _cell_ data items.  If multiple phases were used, these should
+    be listed in the pd_phase category.
 ;
-
-    _name.category_id            pd_calc_overall
-    _name.object_id              method
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_calc_overall
+    _name.object_id               method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
-
-
-save_PD_CALC
-
-    _definition.id               PD_CALC
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-17
-    _description.text                   
-;
-
-      This section is used for storing a computed diffractogram trace.
-      This may be a simulated powder pattern for a material from a
-      program such as LAZY/PULVERIX or the computed intensities from a
-      Rietveld refinement.
-;
-    _name.category_id            PD_DATA
-    _name.object_id              PD_CALC
-    loop_
-    _category_key.name           '_pd_calc.point_id'
-
-save_
-
-
-save__pd_calc.intensity_net
-
-    _definition.id               '_pd_calc.intensity_net'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calc_intensity_net' 
-    _description.text                   
-;
-
-      Intensity values for a computed diffractogram at
-      each angle setting. Values should be computed at the
-      same locations as the processed diffractogram, and thus
-      the numbers of points will be defined by
-      _pd_proc.number_of_points and point positions may
-      be defined using _pd_proc.2theta_range_* or
-      _pd_proc.2theta_corrected.
- 
-      Use _pd_calc.intensity_net if the computed diffractogram
-      does not contain background or normalization corrections
-      and thus is specified on the same scale as the
-      _pd_proc_intensity_net values.
-      If an observed pattern is included, _pd_calc.intensity_*
-      should be looped with either _pd_proc.intensity_net,
-      _pd_meas.counts_* or _pd_meas.intensity_*.
-;
-    _name.category_id            pd_calc
-    _name.object_id              intensity_net
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-
-save_
-
-
-save__pd_calc.intensity_total
-
-    _definition.id               '_pd_calc.intensity_total'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calc_intensity_total' 
-    _description.text                   
-;
-
-      Intensity values for a computed diffractogram at
-      each angle setting. Values should be computed at the
-      same locations as the processed diffractogram, and thus
-      the numbers of points will be defined by
-      _pd_proc.number_of_points and point positions may
-      be defined using _pd_proc.2theta_range_* or
-      _pd_proc.2theta_corrected.
- 
-      Use _pd_calc.intensity_total if the computed diffraction
-      pattern includes background or normalization corrections
-      (or both) and thus is specified on the same scale as the
-      observed intensities (_pd_meas_counts_* or _pd_meas_intensity_*).
-      If an observed pattern is included, _pd_calc.intensity_*
-      should be looped with either _pd_proc.intensity_net,
-      _pd_meas.counts_* or _pd_meas.intensity_*.
-;
-    _name.category_id            pd_calc
-    _name.object_id              intensity_total
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-
-save_
-
-save__pd_calc.point_id
-
-    _definition.id               '_pd_calc.point_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calc_point_id' 
-    _description.text                   
-;
-
-      Arbitrary label identifying a calculated data point. Used to
-      identify a specific entry in a list of values forming the
-      calculated diffractogram. The role of this identifier may
-      be adopted by _pd_data.point_id if measured, processed and
-      calculated intensity values are combined in a single list.
-;
-    _name.category_id            pd_calc
-    _name.object_id              point_id
-    _name.linked_item_id         '_pd_data.point_id'
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
 
 save_PD_CALIB
 
-    _definition.id               PD_CALIB
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-17
-    _description.text                   
+    _definition.id                PD_CALIB
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-17
+    _description.text
 ;
-
-      This section defines the parameters used for the calibration
-      of the instrument that are used directly or indirectly in the
-      interpretation of this data set. The information in this
-      section of the CIF should generally be written when the
-      intensities are first measured, but from then on should remain
-      unchanged. Loops may be used for calibration information that
-      differs by detector channel. 
+    This section defines the parameters used for the calibration
+    of the instrument that are used directly or indirectly in the
+    interpretation of this data set. The information in this
+    section of the CIF should generally be written when the
+    intensities are first measured, but from then on should remain
+    unchanged. Loops may be used for calibration information that
+    differs by detector channel.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_CALIB
-    loop_
-    _category_key.name           '_pd_calib.detector_id'
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB
+    _category_key.name            '_pd_calib.detector_id'
 
 save_
 
+save_pd_calib.detector_id
 
-
-save__pd_calib.detector_id
-
-    _definition.id               '_pd_calib.detector_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_detector_id' 
-    _description.text                   
+    _definition.id                '_pd_calib.detector_id'
+    _alias.definition_id          '_pd_calib_detector_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      A code which identifies the detector or channel number in a
-      position-sensitive, energy-dispersive or other multiple-detector
-      instrument. Note that this code should match the code name used
-      for _pd_meas.detector_id.
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument. Note that this code should match the code name used
+    for _pd_meas_detector_id.
 ;
-    _name.category_id            pd_calib
-    _name.object_id              detector_id
-    _name.linked_object_id       '_pd_meas.detector_id'
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_calib
+    _name.object_id               detector_id
+    _name.linked_object_id        '_pd_meas.detector_id'
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
+save_pd_calib.detector_response
 
-save__pd_calib.detector_response
-
-    _definition.id               '_pd_calib.detector_response'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_detector_response' 
-    _description.text                   
+    _definition.id                '_pd_calib.detector_response'
+    _alias.definition_id          '_pd_calib_detector_response'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      A value that indicates the relative sensitivity of each
-      detector. This can compensate for differences in electronics,
-      size and collimation. Usually, one detector or the mean for
-      all detectors will be assigned the value of 1.
+    A value that indicates the relative sensitivity of each
+    detector. This can compensate for differences in electronics,
+    size and collimation. Usually, one detector or the mean for
+    all detectors will be assigned the value of 1.
 ;
-    _name.category_id            pd_calib
-    _name.object_id              detector_response
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_calib
+    _name.object_id               detector_response
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
-save__pd_calib.std_internal_mass_percent
+save_pd_calib.std_internal_mass_percent
 
-    _definition.id               '_pd_calib.std_internal_mass_percent'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_std_internal_mass_%' 
-    _description.text                   
+    _definition.id                '_pd_calib.std_internal_mass_percent'
+    _alias.definition_id          '_pd_calib_std_internal_mass_%'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Per cent presence of the internal standard specified by the
-      data item _pd_calib.std_internal_name expressed as 100 times
-      the ratio of the amount of standard added to the original
-      sample mass.
+    Per cent presence of the internal standard specified by the
+    data item _pd_calib.std_internal_name expressed as 100 times
+    the ratio of the amount of standard added to the original
+    sample mass.
 ;
-    _name.category_id            pd_calib
-    _name.object_id              std_internal_mass_percent
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:100.0
+    _name.category_id             pd_calib
+    _name.object_id               std_internal_mass_percent
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
 
 save_
 
+save_pd_calib.std_internal_name
 
-save__pd_calib.std_internal_name
-
-    _definition.id               '_pd_calib.std_internal_name'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_std_internal_name' 
-    _description.text                   
+    _definition.id                '_pd_calib.std_internal_name'
+    _alias.definition_id          '_pd_calib_std_internal_name'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Identity of material(s) used as an internal intensity standard.
+    Identity of material(s) used as an internal intensity standard.
 ;
-    _name.category_id            pd_calib
-    _name.object_id              std_internal_name
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_calib
+    _name.object_id               std_internal_name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
     loop_
-    _description_example.case
-            "NIST 640a Silicon standard"         
-            "Al2O3" 
+      _description_example.case
+         'NIST 640a Silicon standard'
+         'Al2O3'
 
 save_
 
 save_PD_CALIB_OFFSET
 
-    _definition.id               PD_CALIB_OFFSET
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-11-12
-    _description.text                   
+    _definition.id                PD_CALIB_OFFSET
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-11-12
+    _description.text
 ;
+    Datanames in this category define an offset angle (in degrees)
+    used to calibrate 2\\q (as defined in _pd_meas_2theta_).
+    Calibration is done by adding the offset:
 
-      Datanames in this category define an offset angle (in degrees)
-      used to calibrate 2\\q (as defined in _pd_meas.2theta_).
-      Calibration is done by adding the offset:
- 
-           2\\q~calibrated~ = 2\\q~measured~ + 2\\q~offset~
- 
-      For cases where the _pd_calib.2theta_offset value is
-      not a constant, but rather varies with 2\\q, a set
-      of offset values is supplied in a loop. In this case,
-      the value where the offset has been determined can be
-      specified as _pd_calib.2theta_off_point. Alternatively, a
-      range where the offset is applicable can be specified using
-      _pd_calib.2theta_off_min and _pd_calib.2theta_off_max.
+         2\\q~calibrated~ = 2\\q~measured~ + 2\\q~offset~
+
+    For cases where the _pd_calib.2theta_offset value is
+    not a constant, but rather varies with 2\\q, a set
+    of offset values is supplied in a loop. In this case,
+    the value where the offset has been determined can be
+    specified as _pd_calib.2theta_off_point. Alternatively, a
+    range where the offset is applicable can be specified using
+    _pd_calib.2theta_off_min and _pd_calib.2theta_off_max.
 ;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_OFFSET
 
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_CALIB_OFFSET
     loop_
-       _category_key.name
-       '_pd_calib_offset.id'
-       '_pd_calib_offset.detector_id'
-save_
-
-save__pd_calib.2theta_off_max
-
-    _definition.id               '_pd_calib.2theta_off_max'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_2theta_off_max' 
-    _description.text                   
-;
-
-     The maximum nominal 2\\q value to which the offset given by
-     _pd_calib.2theta_offset applies.
-;
-    _name.category_id            pd_calib_offset
-    _name.object_id              2theta_off_max
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
+      _category_key.name
+         '_pd_calib_offset.id'
+         '_pd_calib_offset.detector_id'
 
 save_
 
-save__pd_calib.2theta_off_min
+save_pd_calib.2theta_off_max
 
-    _definition.id               '_pd_calib.2theta_off_min'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_2theta_off_min' 
-    _description.text                   
+    _definition.id                '_pd_calib.2theta_off_max'
+    _alias.definition_id          '_pd_calib_2theta_off_max'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-     The minimum nominal 2\\q value to which the offset given by
-     _pd_calib.2theta_offset applies.
+    The maximum nominal 2\\q value to which the offset given by
+    _pd_calib.2theta_offset applies.
 ;
-    _name.category_id            pd_calib_offset
-    _name.object_id              2theta_off_min
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_off_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
 
 save_
 
-save__pd_calib.2theta_off_point
+save_pd_calib.2theta_off_min
 
-    _definition.id               '_pd_calib.2theta_off_point'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_2theta_off_point' 
-    _description.text                   
+    _definition.id                '_pd_calib.2theta_off_min'
+    _alias.definition_id          '_pd_calib_2theta_off_min'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-     The nominal 2\\q value to which the offset given in
-     _pd_calib.2theta_offset applies.
+    The minimum nominal 2\\q value to which the offset given by
+    _pd_calib.2theta_offset applies.
 ;
-    _name.category_id            pd_calib_offset
-    _name.object_id              2theta_off_point
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_off_min
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
 
 save_
 
-save__pd_calib.2theta_offset
+save_pd_calib.2theta_off_point
 
-    _definition.id               '_pd_calib.2theta_offset'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_calib_2theta_offset' 
-    _description.text                   
+    _definition.id                '_pd_calib.2theta_off_point'
+    _alias.definition_id          '_pd_calib_2theta_off_point'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    The nominal 2\\q value to which the offset given in
+    _pd_calib.2theta_offset applies.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_off_point
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
 
-      _pd_calib.2theta_offset defines an offset angle (in degrees)
-      used to calibrate 2\\q (as defined in _pd_meas_2theta_).
-      Calibration is done by adding the offset:
- 
-           2\\q~calibrated~ = 2\\q~measured~ + 2\\q~offset~
- 
+save_
+
+save_pd_calib.2theta_offset
+
+    _definition.id                '_pd_calib.2theta_offset'
+    _alias.definition_id          '_pd_calib_2theta_offset'
+    _definition.update            2014-06-20
+    _description.text
 ;
-    _name.category_id            pd_calib_offset
-    _name.object_id              2theta_offset
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
+    _pd_calib_2theta_offset defines an offset angle (in degrees)
+    used to calibrate 2\\q (as defined in _pd_meas_2theta_).
+    Calibration is done by adding the offset:
+
+         2\\q~calibrated~ = 2\\q~measured~ + 2\\q~offset~
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_offset
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
 
 save_
 
 save_pd_calib_offset.detector_id
 
-    _definition.id               '_pd_calib_offset.detector_id'
-    _definition.update           2016-11-12
-    _description.text                   
+    _definition.id                '_pd_calib_offset.detector_id'
+    _definition.update            2016-11-12
+    _description.text
 ;
-      The detector to which the offset values relate.
-      As a default value is defined, the detector id may be
-      omitted if only a single detector is present.
+    The detector to which the offset values relate.
+    As a default value is defined, the detector id may be
+    omitted if only a single detector is present.
 ;
-    _name.category_id            pd_calib_offset
-    _name.object_id              detector_id
-    _name.linked_item_id         '_pd_calib.detector_id'
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    _enumeration.default         '.'
-    
+    _name.category_id             pd_calib_offset
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_calib.detector_id'
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          '.'
+
 save_
 
 save_pd_calib_offset.id
 
-    _definition.id               '_pd_calib_offset.id'
-    _definition.update           2016-10-19
-    _description.text                   
+    _definition.id                '_pd_calib_offset.id'
+    _definition.update            2016-10-19
+    _description.text
 ;
-      An arbitrary code which identifies a particular 2\\q offset
-      description.  As a default value is defined, this may be
-      omitted if only a single offset is provided.
+    An arbitrary code which identifies a particular 2\\q offset
+    description.  As a default value is defined, this may be
+    omitted if only a single offset is provided.
 ;
-    _name.category_id            pd_calib_offset
-    _name.object_id              id
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    _enumeration.default         '.'
-    
+    _name.category_id             pd_calib_offset
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          '.'
+
 save_
 
 save_PD_CALIB_STD
 
-    _definition.id               PD_CALIB_STD
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-18
-    _description.text                   
+    _definition.id                PD_CALIB_STD
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      This category identifies the external standards used for the calibration
-      of the instrument that are used directly or indirectly in the
-      interpretation of this data set. The information in this
-      section of the CIF should generally be written when the
-      intensities are first measured, but from then on should remain
-      unchanged. Loops may be used for calibration information that
-      differs by detector channel or when multiple standards are
-      used (for example, separately for angular and gain calibration).
+    This category identifies the external standards used for the calibration
+    of the instrument that are used directly or indirectly in the
+    interpretation of this data set. The information in this
+    section of the CIF should generally be written when the
+    intensities are first measured, but from then on should remain
+    unchanged. Loops may be used for calibration information that
+    differs by detector channel or when multiple standards are
+    used (for example, separately for angular and gain calibration).
 ;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_STD
 
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_CALIB_STD
     loop_
-       _category_key.name
-       '_pd_calib_std.detector_id'
-       '_pd_calib_std.external_block_id'
+      _category_key.name
+         '_pd_calib_std.detector_id'
+         '_pd_calib_std.external_block_id'
 
 save_
 
-save__pd_calib_std.detector_id
+save_pd_calib_std.detector_id
 
-    _definition.id               '_pd_calib_std.detector_id'
-    _definition.update           2016-10-18
-    _description.text                   
+    _definition.id                '_pd_calib_std.detector_id'
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      A code which identifies the detector or channel number that the
-      calibration data applies to. Note that this code should match a
-      detector from _pd_meas.detector_id and may be omitted if only
-      one detector is used.
-      
+    A code which identifies the detector or channel number that the
+    calibration data applies to. Note that this code should match a
+    detector from _pd_meas.detector_id and may be omitted if only
+    one detector is used.
 ;
-    _name.category_id            pd_calib_std
-    _name.object_id              detector_id
-    _name.linked_object_id       '_pd_meas.detector_id'
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    _enumeration.default         "."
+    _name.category_id             pd_calib_std
+    _name.object_id               detector_id
+    _name.linked_object_id        '_pd_meas.detector_id'
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          '.'
 
 save_
 
-save__pd_calib_std.external_block_id
+save_pd_calib_std.external_block_id
 
-    _definition.id               '_pd_calib_std.external_block_id'
-    _definition.update           2016-10-18
-    loop_
-      _alias.definition_id
-          '_pd_calib_std_external_block_id' 
-    _description.text                   
+    _definition.id                '_pd_calib_std.external_block_id'
+    _alias.definition_id          '_pd_calib_std_external_block_id'
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      Identifies the _pd_block.id used as an external standard for the
-      diffraction angle or the intensity calibrations.
-
+    Identifies the _pd_block.id used as an external standard for the
+    diffraction angle or the intensity calibrations.
 ;
-
-    _name.category_id            pd_calib_std
-    _name.object_id              external_block_id
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_calib_std
+    _name.object_id               external_block_id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
-save__pd_calib_std.external_name
+save_pd_calib_std.external_name
 
-    _definition.id               '_pd_calib_std.external_name'
-    _definition.update           2016-10-18
-    loop_
-      _alias.definition_id
-          '_pd_calib_std_external_name' 
-    _description.text                   
+    _definition.id                '_pd_calib_std.external_name'
+    _alias.definition_id          '_pd_calib_std_external_name'
+    _definition.update            2016-10-18
+    _description.text
 ;
-
-      Identifies the name of the material used as an external standard for
-      the diffraction angle or the intensity calibrations.
-
+    Identifies the name of the material used as an external standard for
+    the diffraction angle or the intensity calibrations.
 ;
-    _name.category_id            pd_calib_std
-    _name.object_id              external_name
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_calib_std
+    _name.object_id               external_name
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
 save_PD_CALIBRATION
 
-    _definition.id               PD_CALIBRATION
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2016-10-17
-    _description.text                   
+    _definition.id                PD_CALIBRATION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-17
+    _description.text
 ;
-
-     This section contains calibration information that is
-     not looped
+    This section contains calibration information that is
+    not looped
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_CALIBRATION
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIBRATION
 
 save_
 
-save__pd_calibration.conversion_eqn
+save_pd_calibration.conversion_eqn
 
-    _definition.id               '_pd_calibration.conversion_eqn'
-    _definition.update           2016-10-17
-    loop_
-      _alias.definition_id
-          '_pd_calibration_conversion_eqn' 
-    _description.text                   
+    _definition.id                '_pd_calibration.conversion_eqn'
+    _alias.definition_id          '_pd_calibration_conversion_eqn'
+    _definition.update            2016-10-17
+    _description.text
 ;
-
-      The calibration function for converting a channel number
-      supplied in _pd_meas.detector_id for a position-sensitive
-      or energy-dispersive detector or the distance supplied in
-      _pd_meas_position to Q, energy, angle etc.
-      Use _pd_calib_std.external_* to define a pointer
-      to the file or data block containing the data used to
-      determine the parameter values in this function.
+    The calibration function for converting a channel number
+    supplied in _pd_meas.detector_id for a position-sensitive
+    or energy-dispersive detector or the distance supplied in
+    _pd_meas_position to Q, energy, angle etc.
+    Use _pd_calib_std.external_* to define a pointer
+    to the file or data block containing the data used to
+    determine the parameter values in this function.
 ;
-    _name.category_id            pd_calibration
-    _name.object_id              conversion_eqn
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
+    _name.category_id             pd_calibration
+    _name.object_id               conversion_eqn
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
     _description_example.case
-            
 ;
-     2\\q~actual~ = 2\\q~setting~ + arctan(
-      cos(P~1~) / {1/[P~0~ (CC - CH~0~ - P~2~ CC^2^)] - sin(P~1~)})
-; 
+    2\\q~actual~ = 2\\q~setting~ + arctan(
+     cos(P~1~) / {1/[P~0~ (CC - CH~0~ - P~2~ CC^2^)] - sin(P~1~)})
+;
 
 save_
 
-save__pd_calibration.special_details
+save_pd_calibration.special_details
 
-    _definition.id               '_pd_calibration.special_details'
-    _definition.update           2016-10-17
-    loop_
-      _alias.definition_id
-          '_pd_calibration_special_details' 
-    _description.text                   
+    _definition.id                '_pd_calibration.special_details'
+    _alias.definition_id          '_pd_calibration_special_details'
+    _definition.update            2016-10-17
+    _description.text
 ;
-
-      Description of how the instrument was
-      calibrated, particularly for instruments where
-      calibration information is used to make hardware
-      settings that would otherwise be invisible once data
-      collection is completed. Do not use this item to specify
-      information that can be specified using other _pd_calib.
-      items.
+    Description of how the instrument was
+    calibrated, particularly for instruments where
+    calibration information is used to make hardware
+    settings that would otherwise be invisible once data
+    collection is completed. Do not use this item to specify
+    information that can be specified using other _pd_calib_
+    items.
 ;
-    _name.category_id            pd_calibration
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_calibration
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
 save_PD_CHAR
 
-    _definition.id               PD_CHAR
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2014-06-20
-    _description.text                   
+    _definition.id                PD_CHAR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-     This section contains experimental (non-diffraction) information
-     relevant to the chemical and physical nature of the material.
+    This section contains experimental (non-diffraction) information
+    relevant to the chemical and physical nature of the material.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_CHAR
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CHAR
 
 save_
 
+save_pd_char.atten_coef_mu_calc
 
-save__pd_char.atten_coef_mu_calc
-
-    _definition.id               '_pd_char.atten_coef_mu_calc'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_char_atten_coef_mu_calc' 
-    _description.text                   
+    _definition.id                '_pd_char.atten_coef_mu_calc'
+    _alias.definition_id          '_pd_char_atten_coef_mu_calc'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      The calculated \\m will be obtained from the atomic content of
-      the cell, the average density (allowing for specimen packing)
-      and the radiation wavelength.
-      Note that _pd_char.atten_coef_mu_calc will differ from
-      _exptl_absorpt.coefficient_mu if the packing density is
-      not unity.
+    The calculated \\m will be obtained from the atomic content of
+    the cell, the average density (allowing for specimen packing)
+    and the radiation wavelength.
+    Note that _pd_char.atten_coef_mu_calc will differ from
+    _exptl_absorpt.coefficient_mu if the packing density is
+    not unity.
 ;
-    _name.category_id            pd_char
-    _name.object_id              atten_coef_mu_calc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-_units.code                             reciprocal_millimetres
+    _name.category_id             pd_char
+    _name.object_id               atten_coef_mu_calc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_millimetres
 
 save_
 
+save_pd_char.atten_coef_mu_obs
 
-save__pd_char.atten_coef_mu_obs
-
-    _definition.id               '_pd_char.atten_coef_mu_obs'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_char_atten_coef_mu_obs' 
-    _description.text                   
+    _definition.id                '_pd_char.atten_coef_mu_obs'
+    _alias.definition_id          '_pd_char_atten_coef_mu_obs'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    The observed linear attenuation coefficient,
+    \\m, in units of inverse millimetres. Note that this quantity
+    is sometimes referred to as the mass absorption coefficient;
+    however, this term accounts for other potentially significant
+    losses of incident radiation, for example incoherent
+    scattering of neutrons.
 
-      The observed linear attenuation coefficient,
-      \\m, in units of inverse millimetres. Note that this quantity
-      is sometimes referred to as the mass absorption coefficient;
-      however, this term accounts for other potentially significant
-      losses of incident radiation, for example incoherent
-      scattering of neutrons.
- 
-      The observed \\m will be determined by a transmission
-      measurement.
-
+    The observed \\m will be determined by a transmission
+    measurement.
 ;
-    _name.category_id            pd_char
-    _name.object_id              atten_coef_mu_obs
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             reciprocal_millimetres
+    _name.category_id             pd_char
+    _name.object_id               atten_coef_mu_obs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_millimetres
 
 save_
 
+save_pd_char.colour
 
-save__pd_char.colour
-
-    _definition.id               '_pd_char.colour'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_char_colour' 
-    _description.text                   
+    _definition.id                '_pd_char.colour'
+    _alias.definition_id          '_pd_char_colour'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    The colour of the material used for the measurement.
+    To facilitate more standardized use of names, the
+    following guidelines for colour naming developed by
+    Peter Bayliss for the International Centre for
+    Diffraction Data (ICDD) should be followed. Note that
+    combinations of descriptors are separated by an
+    underscore.
 
-      The colour of the material used for the measurement.
-      To facilitate more standardized use of names, the
-      following guidelines for colour naming developed by
-      Peter Bayliss for the International Centre for
-      Diffraction Data (ICDD) should be followed. Note that
-      combinations of descriptors are separated by an
-      underscore.
- 
-      Allowed colours are:
-        colourless, white, black, gray, brown, red, pink,
-        orange, yellow, green, blue, violet.
- 
-      Colours may be modified using prefixes of:
-        light, dark, whitish, blackish, grayish, brownish,
-        reddish, pinkish, orangish, yellowish, greenish, bluish.
- 
-      Intermediate hues may be indicated with two colours:
-      e.g. blue_green or bluish_green.
- 
-      For metallic materials, the term metallic may be added:
-      e.g. reddish_orange_metallic for copper.
- 
-      The ICDD standard allows commas to be used for minerals
-      that occur with ranges of colours; however this usage is
-      not appropriate for the description of a single sample.
+    Allowed colours are:
+      colourless, white, black, gray, brown, red, pink,
+      orange, yellow, green, blue, violet.
+
+    Colours may be modified using prefixes of:
+      light, dark, whitish, blackish, grayish, brownish,
+      reddish, pinkish, orangish, yellowish, greenish, bluish.
+
+    Intermediate hues may be indicated with two colours:
+    e.g. blue_green or bluish_green.
+
+    For metallic materials, the term metallic may be added:
+    e.g. reddish_orange_metallic for copper.
+
+    The ICDD standard allows commas to be used for minerals
+    that occur with ranges of colours; however this usage is
+    not appropriate for the description of a single sample.
 ;
-    _name.category_id            pd_char
-    _name.object_id              colour
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_char
+    _name.object_id               colour
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
     loop_
-    _description_example.case
-            "dark_green"     
-            "orange_red"     
-            "brownish_red"   
-            "yellow_metallic" 
+      _description_example.case
+         dark_green
+         orange_red
+         brownish_red
+         yellow_metallic
 
 save_
 
+save_pd_char.particle_morphology
 
-save__pd_char.particle_morphology
-
-    _definition.id               '_pd_char.particle_morphology'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_char_particle_morphology' 
-    _description.text                   
+    _definition.id                '_pd_char.particle_morphology'
+    _alias.definition_id          '_pd_char_particle_morphology'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      A description of the sample morphology and estimates for
-      particle sizes (before grinding/sieving, if noted by
-      _pd_spec.preparation). Include the method used for
-      these estimates (SEM, visual estimate etc.).
+    A description of the sample morphology and estimates for
+    particle sizes (before grinding/sieving, if noted by
+    _pd_spec_preparation). Include the method used for
+    these estimates (SEM, visual estimate etc.).
 ;
-    _name.category_id            pd_char
-    _name.object_id              particle_morphology
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_char
+    _name.object_id               particle_morphology
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
+save_pd_char.special_details
 
-save__pd_char.special_details
-
-    _definition.id               '_pd_char.special_details'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_char_special_details' 
-    _description.text                   
+    _definition.id                '_pd_char.special_details'
+    _alias.definition_id          '_pd_char_special_details'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Additional characterization information relevant to the sample
-      or documentation of non-routine processing steps used
-      for characterization.
+    Additional characterization information relevant to the sample
+    or documentation of non-routine processing steps used
+    for characterization.
 ;
-    _name.category_id            pd_char
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_char
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
-
 
 save_PD_DATA
 
-    _definition.id               PD_DATA
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2014-06-20
-    _description.text                   
-;
-
-      The PD_DATA category is a "container" category
-      that is defined in order to allow raw, processed and calculated
-      data points in a diffraction data set to be optionally
-      tabulated together. As PD_CALC, PD_MEAS and PD_PROC are
-      all subcategories of this category, the various
-      items belonging to those categories may be looped
-      together or separately, as desired. 
-;
-
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_DATA
-    loop_
-    _category_key.name           '_pd_data.point_id'
-
-save_
-
-save__pd_data.point_id
-
-    _definition.id               '_pd_data.point_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_data_point_id' 
-    _description.text                   
-;
-
-      Arbitrary label identifying an entry in the table of
-      diffractogram intensity values. This should be used in
-      preference to the pd_calc/pd_meas/pd_proc point_id datanames
-      whenever datanames from more than one of the pd_calc/
-      pd_proc/pd_meas categories are looped together.
-      
-;
-    _name.category_id            pd_data
-    _name.object_id              point_id
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
-save_PD_INSTR
-
-    _definition.id               PD_INSTR
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2014-06-20
-    _description.text                   
-;
-
-      This section contains information relevant to the instrument
-      used for the diffraction measurement. For most laboratories,
-      very little of this information will change, so a standard file
-      may be prepared and included with each data set.
- 
-      Note that several definitions in the core CIF dictionary
-      are relevant here. For example, use:
-        _diffrn_radiation_wavelength.value for the source wavelength,
-        _diffrn_radiation.type for the X-ray wavelength type,
-        _diffrn_source for the radiation source,
-        _diffrn_radiation.polarisn_ratio for the source polarization,
-        _diffrn_radiation.probe for the radiation type.
-      For data sets measured with partially monochromatized radiation,
-      for example, where both K\\a~1~ and K\\a~2~ are present, it is
-      important that all wavelengths present are included in a
-      loop_ using _diffrn_radiation_wavelength.value to define the
-      wavelength and _diffrn_radiation_wavelength.wt to define the
-      relative intensity of that wavelength. It is required that
-      _diffrn_radiation_wavelength.id also be present in the
-      wavelength loop. It may also be useful to
-      create a "dummy" ID to use for labelling
-      peaks/reflections where the K\\a~1~ and K\\a~2~ wavelengths are
-      not resolved. Set _diffrn_radiation_wavelength.wt to be 0 for
-      such a dummy ID.
- 
-      In the _pd_instr_ definitions, the term monochromator refers
-      to a primary beam (pre-specimen) monochromator and the term
-      analyser refers to post-diffraction (post-specimen)
-      monochromator.  The analyser may be fixed for specific
-      wavelength or may be capable of being scanned.
- 
-      It is strongly recommended that the core dictionary term
-      _diffrn_radiation.probe (specifying the nature of the radiation
-      used) is employed for all data sets.
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_INSTR
-
-save_
-
-save__pd_instr.2theta_monochr_pre
-
-    _definition.id               '_pd_instr.2theta_monochr_pre'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_2theta_monochr_pre' 
-    _description.text                   
-;
-
-      The 2\\q angle for a pre-specimen monochromator (see also
-      _pd_instr.monochr_pre_spec).
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              2theta_monochr_pre
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-_units.code                             degrees
-
-save_
-
-
-save__pd_instr.beam_size_ax
-
-    _definition.id               '_pd_instr.beam_size_ax'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_beam_size_ax' 
-    _description.text                   
-;
-
-      Axial dimension of the radiation beam
-      at the specimen position (in millimetres).
-      The perpendicular to the plane containing the incident
-      and scattered beam is the axial (*_ax) direction.
-;
-    _name.category_id            pd_instr
-    _name.object_id              size_ax
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.beam_size_eq
-
-    _definition.id               '_pd_instr.beam_size_eq'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_beam_size_eq' 
-    _description.text                   
-;
-
-      Equatorial dimensions of the radiation beam
-      at the specimen position (in millimetres).
-      The equatorial dimension is in the plane of scattering.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              size_eq
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.cons_illum_flag
-
-    _definition.id               '_pd_instr.cons_illum_flag'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_cons_illum_flag' 
-    _description.text                   
-;
-
-      Use 'yes' for instruments where the divergence slit is
-      \q-compensated to yield a constant illumination length
-      (also see _pd_instr.cons_illum_len).
- 
-      For other flat-plate instruments, where the illumination
-      length changes with 2\\q, specify 'no'. Note that
-      if the length is known, it may be specified using
-      _pd_instr.var_illum_len.
-;
-    _name.category_id            pd_instr
-    _name.object_id              cons_illum_flag
-    _type.purpose                State
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    loop_
-    _enumeration_set.state
-              yes  
-              no 
-
-save_
-
-
-save__pd_instr.cons_illum_len
-
-    _definition.id               '_pd_instr.cons_illum_len'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_cons_illum_len' 
-    _description.text                   
-;
-
-      Use _pd_instr_cons_illum_len for instruments where the length of
-      sample illuminated does not vary with 2\\q, usually achieved by
-      adjustment of the divergence slits (sometimes known as
-      \q-compensated slits).
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              cons_illum_len
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-
-
-save__pd_instr.dist_mono_spec
-
-    _definition.id               '_pd_instr.dist_mono_spec'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_dist_mono/spec' 
-    _description.text                   
-;
-
-      Specifies distances in millimetres from the monochromator to the specimen.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              dist_mono_spec
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.dist_src_mono
-
-    _definition.id               '_pd_instr.dist_src_mono'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_dist_src/mono' 
-    _description.text                   
-;
-
-      Specifies distance in millimetres from the radiation source to
-      the monochromator.  Note that *_src_spec is used in place of
-      *_src_mono and *_mono_spec if there is no monochromator in use.
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              dist_src_mono
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.dist_src_spec
-
-    _definition.id               '_pd_instr.dist_src_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_dist_src/spec' 
-    _description.text                   
-;
-
-      Specifies distances in millimetres from the radiation source to
-      the specimen.  Note that *_src_spec is used in place of
-      *_src_mono and *_mono_spec if there is no monochromator in use
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              dist_src_spec
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.divg_ax_mono_spec
-
-    _definition.id               '_pd_instr.divg_ax_mono_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_ax_mono/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction
-      (perpendicular to the plane containing the incident
-      and diffracted beams) between the monochromator and the specimen.
-      Values are the maximum divergence angles in
-      degrees, as limited by slits or beamline optics
-      other than Soller slits (see _pd_instr.soller_ax_):
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              divg_ax_mono_spec
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_ax_src_mono
-
-    _definition.id               '_pd_instr.divg_ax_src_mono'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_ax_src/mono' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) between
-      the radiation source and monochromator.  Values are the maximum
-      divergence angles in degrees, as limited by slits or beamline
-      optics other than Soller slits (see _pd_instr.soller_ax_).  Note
-      that *_src_spec is used in place of *_src_mono and *_mono_spec
-      if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              divg_ax_src_mono
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.divg_ax_src_spec
-
-    _definition.id               '_pd_instr.divg_ax_src_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_ax_src/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction
-      (perpendicular to the plane containing the incident
-      and diffracted beams)  between the radiation source and specimen.
-      Values are the maximum divergence angles in
-      degrees, as limited by slits or beamline optics
-      other than Soller slits (see _pd_instr.soller_ax_).
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              divg_ax_src_spec
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_eq_mono_spec
-
-    _definition.id               '_pd_instr.divg_eq_mono_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_eq_mono/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) between the monochromator and the specimen
-      Values are the maximum divergence angles in
-      degrees, as limited by slits or beamline optics
-      other than Soller slits (see _pd_instr.soller_eq_):
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              divg_eq_mono_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_eq_src_mono
-
-    _definition.id               '_pd_instr.divg_eq_src_mono'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_eq_src/mono' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) between the radiation source and monochromator
-      Values are the maximum divergence angles in
-      degrees, as limited by slits or beamline optics
-      other than Soller slits (see _pd_instr.soller_eq_).
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              divg_eq_src_mono
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.divg_eq_src_spec
-
-    _definition.id               '_pd_instr.divg_eq_src_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_eq_src/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) between the
-      radiation source and specimen.  Values are the maximum
-      divergence angles in degrees, as limited by slits or beamline
-      optics other than Soller slits (see _pd_instr_soller_eq_).  Note
-      that *_src_spec is used in place of *_src_mono and *_mono_spec
-      if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              divg_eq_src_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.geometry
-
-    _definition.id               '_pd_instr.geometry'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_geometry' 
-    _description.text                   
-;
-
-      A description of the diffractometer type or geometry.
-;
-    _name.category_id            pd_instr
-    _name.object_id              geometry
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "Bragg-Brentano"          
-            "Guinier"        
-            
-;         Parallel-beam non-focusing optics with channel-cut
-          monochromator and linear position-sensitive detector
-; 
-
-save_
-
-
-save__pd_instr.location
-
-    _definition.id               '_pd_instr.location'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_location' 
-    _description.text                   
-;
-
-      The name and location of the instrument where measurements
-      were made. This is used primarily to identify data sets
-      measured away from the author's home facility, at shared
-      resources such as a reactor or spallation source.
-;
-    _name.category_id            pd_instr
-    _name.object_id              location
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "SEPD diffractometer, IPNS, Argonne National Lab (USA)" 
-
-save_
-
-
-
-save__pd_instr.monochr_pre_spec
-
-    _definition.id               '_pd_instr.monochr_pre_spec'
-    _definition.update           2014-06-20
-    _alias.definition_id         '_pd_instr_monochr_pre_spec'
-    _description.text                   
-;
-
-      Indicates the method used to obtain monochromatic radiation.
-      Use _pd_instr_monochr_pre_spec to describe the primary beam
-      monochromator (pre-specimen monochromation). Use
-      _pd_instr.monochr_post_spec to specify the
-      post-diffraction analyser (post-specimen monochromation).
- 
-      When a monochromator crystal is used, the material and the
-      indices of the Bragg reflection are specified.
- 
-      Note that monochromators may have either 'parallel' or
-      'antiparallel' orientation. It is assumed that the
-      geometry is parallel unless specified otherwise.
-      In a parallel geometry, the position of the monochromator
-      allows the incident beam and the final post-specimen
-      and post-monochromator beam to be as close to parallel
-      as possible. In a parallel geometry, the diffracting
-      planes in the specimen and monochromator will be parallel
-      when 2\\q~monochromator~ is equal to 2\\q~specimen~.\
-      For further discussion see R. Jenkins & R. Snyder (1996).
-      Introduction to X-ray Powder Diffraction,
-      pp. 164-165. New York: Wiley.
-;
-    _name.category_id            pd_instr
-    _name.object_id              monochr_pre_spec
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "Zr filter"      
-            "Ge 220"         
-            "none"           
-            "equatorial mounted graphite (0001)"           
-            "Si (111), antiparallel" 
-
-save_
-
-
-save__pd_instr.slit_ax_mono_spec
-
-    _definition.id               '_pd_instr.slit_ax_mono_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_ax_mono/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction
-      (perpendicular to the plane containing the incident
-      and diffracted beams) for the instrument as a slit width
-      (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      collimation between the monochromator and the specimen.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-;
-    _name.category_id            pd_instr
-    _name.object_id              slit_ax_mono_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.slit_ax_src_mono
-
-    _definition.id               '_pd_instr.slit_ax_src_mono'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_ax_src/mono' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      Collimation between the radiation source and monochromator.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              slit_ax_src_mono
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.slit_ax_src_spec
-
-    _definition.id               '_pd_instr.slit_ax_src_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_ax_src/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      Collimation between the radiation source and the specimen.  Note
-      that *_src_spec is used in place of *_src_mono and *_mono_spec
-      if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              slit_ax_src_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.slit_eq_mono_spec
-
-    _definition.id               '_pd_instr.slit_eq_mono_spec'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_eq_mono/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      Ollimation between the monochromator and the specimen.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-;
-    _name.category_id            pd_instr
-    _name.object_id              slit_eq_mono_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.slit_eq_src_mono
-
-    _definition.id               '_pd_instr.slit_eq_src_mono'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_eq_src/mono' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      Collimation between the radiation source and monochromator.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              slit_eq_src_mono
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.slit_eq_src_spec
-
-    _definition.id               '_pd_instr.slit_eq_src_spec'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_eq_src/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      Ollimation between the radiation source and the specimen.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-;
-    _name.category_id            pd_instr
-    _name.object_id              slit_eq_src_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.soller_ax_mono_spec
-
-    _definition.id               '_pd_instr.soller_ax_mono_spec'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_ax_mono/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument.  Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located between the
-      monochromator and specimen.  Note that *_src_spec is used in
-      place of *_src_mono and *_mono_spec if there is no monochromator
-      in use.
-      
-;
-    _name.category_id            pd_instr
-    _name.object_id              soller_ax_mono_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-
-
-save__pd_instr.soller_ax_src_mono
-
-    _definition.id               '_pd_instr.soller_ax_src_mono'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_ax_src/mono' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction
-      (perpendicular to the plane containing the incident
-      and diffracted beams) for the instrument.
-      Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located thus:
-      Collimation between the radiation source and monochromator;
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use, and
-      *_spec_detc is used in place of *_spec_anal and
-      *_anal_detc if there is no analyser in use.
-;
-    _name.category_id            pd_instr
-    _name.object_id              soller_ax_src_mono
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.soller_ax_src_spec
-
-    _definition.id               '_pd_instr.soller_ax_src_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_ax_src/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument.  Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located between the
-      radiation source and specimen.  Note that *_src_spec is used in
-      place of *_src_mono and *_mono_spec if there is no monochromator
-      in use.
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              soller_ax_src_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.soller_eq_mono_spec
-
-    _definition.id               '_pd_instr.soller_eq_mono_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_eq_mono/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for
-      the instrument. Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located  between the monochromator and the specimen.
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use.
-;
-    _name.category_id            pd_instr
-    _name.object_id              soller_eq_mono_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-
-save__pd_instr.soller_eq_src_mono
-
-    _definition.id               '_pd_instr.soller_eq_src_mono'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_eq_src/mono' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for
-      the instrument. Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located thus:
-      Collimation between the radiation source and monochromator;
-      Note that *_src_spec is used in place of *_src_mono and
-      *_mono_spec if there is no monochromator in use, and
-      *_spec_detc is used in place of *_spec_anal and
-      *_anal_detc if there is no analyser in use.
-;
-    _name.category_id            pd_instr
-    _name.object_id              soller_eq_src_mono
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.soller_eq_src_spec
-
-    _definition.id               '_pd_instr.soller_eq_src_spec'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_eq_src/spec' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument. Values are the maximum divergence angles in degrees,
-      as limited by Soller slits located between the radiation source
-      and monochromator.  Note that *_src_spec is used in place of
-      *_src_mono and *_mono_spec if there is no monochromator in use.
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              soller_eq_src_spec
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.source_size_ax
-
-    _definition.id               '_pd_instr.source_size_ax'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_source_size_ax' 
-    _description.text                   
-;
-
-      Axial intrinsic dimension of the radiation source (in
-      millimetres).  The perpendicular to the plane containing the
-      incident and scattered beam is the axial (*_ax) direction.
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              source_size_ax
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.source_size_eq
-
-    _definition.id               '_pd_instr.source_size_eq'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_source_size_eq' 
-    _description.text                   
-;
-
-      Equatorial intrinsic dimension of the radiation source (in
-      millimetres).  The equatorial direction is in the plane
-      containing the incident and scattered beam.
-
-;
-    _name.category_id            pd_instr
-    _name.object_id              source_size_eq
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.special_details
-
-    _definition.id               '_pd_instr.special_details'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_special_details' 
-    _description.text                   
-;
-
-      A brief description of the instrument giving
-      details that cannot be given in other
-      _pd_instr. entries.
-;
-    _name.category_id            pd_instr
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-
-save__pd_instr.var_illum_len
-
-    _definition.id               '_pd_instr.var_illum_len'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_var_illum_len' 
-    _description.text                   
-;
-
-      Length of the specimen that is illuminated by the radiation
-      source (in millimetres) for instruments where
-      the illumination length varies with 2\\q (fixed
-      divergence slits). The _pd_instr.var_illum_len
-      values should be included in the same loop as the
-      intensity measurements (_pd_meas.).
- 
-      See _pd_instr.cons_illum_len for instruments where
-      the divergence slit is \q-compensated to yield a\
-      constant illumination length.
-
-;
-    _name.category_id            pd_meas
-    _name.object_id              var_illum_len
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save_PD_INSTR_DETECTOR
-
-    _definition.id               PD_INSTR_DETECTOR
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-20
-    _description.text                   
-;
-
-      This section contains information relevant to the detector
-      geometry used for the diffraction measurement. For most laboratories,
-      very little of this information will change, so a standard file
-      may be prepared and included with each data set.
- 
-      The term analyser refers to post-diffraction (post-specimen)
-      monochromator.  The analyser may be fixed for specific
-      wavelength or may be capable of being scanned.
- 
-      For multiple-detector instruments it may be necessary to loop the
-      *_anal_detc or *_spec_detc values (for  _pd_instr.dist_,
-      _pd_instr.divg_, _pd_instr.slit_ and  _pd_instr.soller_) with
-      the detector ID's (_pd_instr_detector.id).
- 
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_INSTR_DETECTOR
-    loop_
-    _category_key.name           '_pd_instr_detector.id'
-
-save_
-
-save__pd_instr.2theta_monochr_post
-
-    _definition.id               '_pd_instr.2theta_monochr_post'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_2theta_monochr_post' 
-    _description.text                   
-;
-
-      The 2\\q angle for a post-specimen
-      monochromator (also called an analyzer)
-      (see also _pd_instr.monochr_post_spec).
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              2theta_monochr_post
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-_units.code                             degrees
-
-save_
-
-save__pd_instr_detector.id
-
-    _definition.id               '_pd_instr_detector.id'
-    _definition.update           2016-10-20
-    _description.text                   
-;
-
-      A code which identifies the detector or channel number in a
-      position-sensitive, energy-dispersive or other multiple-detector
-      instrument for which individual instrument geometry is being
-      defined. Note that this code should match the code name used for
-      _pd_meas.detector_id.  Where a single detector is used, this
-      may be omitted.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              id
-    _name.linked_object_id       '_pd_meas.detector_id'
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
-save__pd_instr.dist_anal_detc
-
-    _definition.id               '_pd_instr.dist_anal_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_dist_anal/detc' 
-    _description.text                   
-;
-
-      Specifies the distance in millimetres from the analyser to the detector.
-      Note that *_spec_detc is used in place of *_anal_detc
-      if there is no analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              dist_anal_detc
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.dist_spec_anal
-
-    _definition.id               '_pd_instr.dist_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_dist_spec/anal' 
-    _description.text                   
-;
-
-      Specifies distances in millimetres from the specimen to the
-      analyser.  Note that *_spec_detc is used in place of *_spec_anal
-      if there is no analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              dist_spec_anal
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.dist_spec_detc
-
-    _definition.id               '_pd_instr.dist_spec_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_dist_spec/detc' 
-    _description.text                   
-;
-
-      Specifies distance in millimetres from the specimen to the
-      detector.  Note that *_spec_anal and *_anal_detc are used
-      instead of *_spec_detc if there is an analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              dist_spec_detc
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.divg_ax_anal_detc
-
-    _definition.id               '_pd_instr.divg_ax_anal_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_ax_anal/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) between
-      the analyser and the detector. Values are the maximum divergence
-      angles in degrees, as limited by slits or beamline optics other
-      than Soller slits (see _pd_instr.soller_ax_): Note that
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc if
-      there is no analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              divg_ax_anal_detc
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_ax_spec_anal
-
-    _definition.id               '_pd_instr.divg_ax_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_ax_spec/anal' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction
-      (perpendicular to the plane containing the incident
-      and diffracted beams) between the specimen and the analyser.
-      Values are the maximum divergence angles in
-      degrees, as limited by slits or beamline optics
-      other than Soller slits (see _pd_instr.soller_ax_).
-      Note that *_spec_detc is used in place of *_spec_anal 
-      and *_anal_detc if there is no analyser in use.
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              divg_ax_spec_anal
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_ax_spec_detc
-
-    _definition.id               '_pd_instr.divg_ax_spec_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_ax_spec/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction
-      (perpendicular to the plane containing the incident
-      and diffracted beams) between the specimen and the detector.
-      Values are the maximum divergence angles in
-      degrees, as limited by slits or beamline optics
-      other than Soller slits (see _pd_instr.soller_ax_).
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc
-      if there is no analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              divg_ax_spec_detc
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_eq_anal_detc
-
-    _definition.id               '_pd_instr.divg_eq_anal_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_eq_anal/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) between the
-      analyser and the detector.  Values are the maximum divergence
-      angles in degrees, as limited by slits or beamline optics other
-      than Soller slits (see _pd_instr.soller_eq_).  Note that
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc if
-      there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              divg_eq_anal_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_eq_spec_anal
-
-    _definition.id               '_pd_instr.divg_eq_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_eq_spec/anal' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) between the
-      specimen and the analyser. Values are the maximum divergence
-      angles in degrees, as limited by slits or beamline optics other
-      than Soller slits (see _pd_instr.soller_eq_). Note that
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc if
-      there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              divg_eq_spec_anal
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.divg_eq_spec_detc
-
-    _definition.id               '_pd_instr.divg_eq_spec_detc'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_divg_eq_spec/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) between the
-      specimen and the detector. Values are the maximum divergence
-      angles in degrees, as limited by slits or beamline optics other
-      than Soller slits (see _pd_instr.soller_eq_): *_spec_detc is
-      used in place of *_spec_anal and *_anal_detc if there is no
-      analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              divg_eq_spec_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.monochr_post_spec
-
-    _definition.id               '_pd_instr.monochr_post_spec'
-    _definition.update           2014-10-20
-    _alias.definition_id         '_pd_instr_monochr_post_spec'
-    _description.text                   
-;
-
-      Indicates the method used to obtain monochromatic radiation.
-      Use _pd_instr_monochr_pre_spec to describe the primary beam
-      monochromator (pre-specimen monochromation). Use
-      _pd_instr_monochr_post_spec to specify the
-      post-diffraction analyser (post-specimen monochromation).
- 
-      When a monochromator crystal is used, the material and the
-      indices of the Bragg reflection are specified.
- 
-      Note that monochromators may have either 'parallel' or
-      'antiparallel' orientation. It is assumed that the
-      geometry is parallel unless specified otherwise.
-      In a parallel geometry, the position of the monochromator
-      allows the incident beam and the final post-specimen
-      and post-monochromator beam to be as close to parallel
-      as possible. In a parallel geometry, the diffracting
-      planes in the specimen and monochromator will be parallel
-      when 2\\q~monochromator~ is equal to 2\\q~specimen~.\
-      For further discussion see R. Jenkins & R. Snyder (1996).
-      Introduction to X-ray Powder Diffraction,
-      pp. 164-165. New York: Wiley.
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              monochr_post_spec
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "Zr filter"      
-            "Ge 220"         
-            "none"           
-            "equatorial mounted graphite (0001)"           
-            "Si (111), antiparallel" 
-
-save_
-
-save__pd_instr.slit_ax_anal_detc
-
-    _definition.id               '_pd_instr.slit_ax_anal_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_ax_anal/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      collimation between the analyser and the detector.  Note that
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc if
-      there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              slit_ax_anal_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.slit_ax_spec_anal
-
-    _definition.id               '_pd_instr.slit_ax_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_ax_spec/anal' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      collimation between the specimen and the analyser.  Note that
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc if
-      there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              slit_ax_spec_anal
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.slit_ax_spec_detc
-
-    _definition.id               '_pd_instr.slit_ax_spec_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_ax_spec/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument as a slit width (as opposed to a divergence angle).
-      Values are the width of the slit (in millimetres) defining
-      Collimation between the specimen and the detector.  Note that
-      *_spec_detc is used in place of *_spec_anal and *_anal_detc if
-      there is no analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              slit_ax_spec_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-save__pd_instr.slit_eq_anal_detc
-
-    _definition.id               '_pd_instr.slit_eq_anal_detc'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_eq_anal/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the instrument
-      as a slit width (as opposed to a divergence angle).  Values are
-      the width of the slit (in millimetres) defining Ollimation
-      between the analyser and the detector.  Note that *_spec_detc is
-      used in place of *_spec_anal and *_anal_detc if there is no
-      analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              slit_eq_anal_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.slit_eq_spec_anal
-
-    _definition.id               '_pd_instr.slit_eq_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_eq_spec/anal' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the instrument
-      as a slit width (as opposed to a divergence angle).  Values are
-      the width of the slit (in millimetres) defining Collimation
-      between the specimen and the analyser.  Note that *_spec_detc is
-      used in place of *_spec_anal and *_anal_detc if there is no
-      analyser in use.
-      
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              slit_eq_spec_anal
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-
-save__pd_instr.slit_eq_spec_detc
-
-    _definition.id               '_pd_instr.slit_eq_spec_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_slit_eq_spec/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the instrument
-      as a slit width (as opposed to a divergence angle).  Values are
-      the width of the slit (in millimetres) defining Collimation
-      between the specimen and the detector.  Note that *_spec_detc is
-      used in place of *_spec_anal and *_anal_detc if there is no
-      analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              slit_eq_spec_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
-
-save_
-
-save__pd_instr.soller_ax_anal_detc
-
-    _definition.id               '_pd_instr.soller_ax_anal_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_ax_anal/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument.  Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located between the analyser
-      and the detector.  Note that *_spec_detc is used in place of
-      *_spec_anal and *_anal_detc if there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              soller_ax_anal_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.soller_ax_spec_anal
-
-    _definition.id               '_pd_instr.soller_ax_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_ax_spec/anal' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument.  Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located between the specimen
-      and the analyser; Note that *_spec_detc is used in place of
-      *_spec_anal and *_anal_detc if there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              soller_ax_spec_anal
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.soller_eq_anal_detc
-
-    _definition.id               '_pd_instr.soller_eq_anal_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_eq_anal/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument. Values are the maximum divergence angles in degrees,
-      as limited by Soller slits located between the analyser and the
-      detector; Note that *_spec_detc is used in place of *_spec_anal
-      and *_anal_detc if there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              soller_eq_anal_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.soller_ax_spec_detc
-
-    _definition.id               '_pd_instr.soller_ax_spec_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_ax_spec/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the axial direction (perpendicular to
-      the plane containing the incident and diffracted beams) for the
-      instrument.  Values are the maximum divergence angles in
-      degrees, as limited by Soller slits located between the specimen
-      and the detector.  Note that *_spec_detc is used in place of
-      *_spec_anal and *_anal_detc if there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              soller_ax_spec_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-save__pd_instr.soller_eq_spec_anal
-
-    _definition.id               '_pd_instr.soller_eq_spec_anal'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_eq_spec/anal' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument. Values are the maximum divergence angles in degrees,
-      as limited by Soller slits located between the specimen and the
-      analyser.  Note that *_spec_detc is used in place of *_spec_anal
-      and *_anal_detc if there is no analyser in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              soller_eq_spec_anal
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save__pd_instr.soller_eq_spec_detc
-
-    _definition.id               '_pd_instr.soller_eq_spec_detc'
-    _definition.update           2016-10-20
-    loop_
-      _alias.definition_id
-          '_pd_instr_soller_eq_spec/detc' 
-    _description.text                   
-;
-
-      Describes collimation in the equatorial plane (the plane
-      containing the incident and diffracted beams) for the
-      instrument. Values are the maximum divergence angles in degrees,
-      as limited by Soller slits located between the specimen and the
-      detectoomator in use, and *_spec_detc is used in place of
-      *_spec_anal and *_anal_detc if there is no analys er in use.
-
-;
-    _name.category_id            pd_instr_detector
-    _name.object_id              soller_eq_spec_detc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             degrees
-
-save_
-
-
-save_PD_MEAS_OVERALL
-
-    _definition.id               PD_MEAS_OVERALL
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2016-10-18
-    _description.text                   
-;
-
-      This section contains information about the conditions used for
-      the measurement of the diffraction data set, prior to processing
-      and application of correction terms. While additional
-      information may be added to the CIF as data are processed and
-      transported between laboratories (possibly with the addition of
-      a new _pd_block_id entry), the information in this section of
-      the CIF will rarely be changed once data collection is complete.
-
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_MEAS_OVERALL
-    
-save_
-
-save__pd_meas.2theta_fixed
-
-    _definition.id               '_pd_meas.2theta_fixed'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_2theta_fixed' 
-    _description.text                   
-;
-
-      The 2\\q diffraction angle in degrees for measurements\
-      in a white-beam fixed-angle experiment. For measurements
-      where 2\\q is scanned, see _pd_meas.2theta_scan or
-      _pd_meas.2theta_range_*.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              2theta_fixed
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-
-save_
-
-
-save__pd_meas.2theta_range_inc
-
-    _definition.id               '_pd_meas.2theta_range_inc'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_2theta_range_inc' 
-    _description.text                   
-;
-
-      2\\q diffraction angle increment in degrees used for the
-      measurement of intensities. These may be used in place of the
-      _pd_meas.2theta_scan values for data sets measured with a
-      constant step size.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              2theta_range_inc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_meas.2theta_range_max
-
-    _definition.id               '_pd_meas.2theta_range_max'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_2theta_range_max' 
-    _description.text                   
-;
-
-      Maximum 2\\q diffraction angle in degrees used for the
-      measurement of intensities. These may be used in place of the
-      _pd_meas.2theta_scan values for data sets measured with a
-      constant step size.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              2theta_range_max
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_meas.2theta_range_min
-
-    _definition.id               '_pd_meas.2theta_range_min'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_2theta_range_min' 
-    _description.text                   
-;
-
-      Minimum 2\\q diffraction angle in degrees used for the
-      measurement of intensities. These may be used in place of the
-      _pd_meas.2theta_scan values for data sets measured with a
-      constant step size.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              2theta_range_min
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-    _units.code                             degrees
-
-save_
-
-save__pd_meas.angle_chi
-
-    _definition.id               '_pd_meas.angle_chi'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_angle_chi' 
-    _description.text                   
-;
-
-      The diffractometer angle in degrees for an instrument with a
-      Euler circle. The definitions for these angles follow the
-      convention of International Tables for X-ray Crystallography
-      (1974), Vol. IV, p. 276.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              angle_chi
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-
-save_
-
-
-save__pd_meas.angle_omega
-
-    _definition.id               '_pd_meas.angle_omega'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_angle_omega' 
-    _description.text                   
-;
-
-      The diffractometer angle in degrees for an instrument with a
-      Euler circle. The definitions for these angles follow the
-      convention of International Tables for X-ray Crystallography
-      (1974), Vol. IV, p. 276.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              angle_omega
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-
-save_
-
-
-save__pd_meas.angle_phi
-
-    _definition.id               '_pd_meas.angle_phi'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_angle_phi' 
-    _description.text                   
-;
-
-      The diffractometer angle in degrees for an instrument with a
-      Euler circle. The definitions for these angles follow the
-      convention of International Tables for X-ray Crystallography
-      (1974), Vol. IV, p. 276.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              angle_phi
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-
-save_
-
-save__pd_meas.datetime_initiated
-
-    _definition.id               '_pd_meas.datetime_initiated'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_datetime_initiated' 
-    _description.text                   
-;
-
-      The date and time of the data-set measurement. 
-      Entries should follow the standard RFC 3339 ABNF format 
-      'yyyy-mm-ddThh:mm{:ss}{Z|[+-]zz:zz}'. Use of seconds and 
-      a time zone offset is optional, but use of hours and 
-      minutes is strongly encouraged. Where possible, give the 
-      time when the measurement was started, rather than when 
-      it was completed.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              datetime_initiated
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               DateTime
-    loop_
-    _description_example.case
-            "1990-07-13T14:40" 
-            "2042-12-13T02:37:23Z" 
-            "2005-03-03T12:02:09.17+09:30" 
-            "2015-10-30T22:45-02:00" 
-            "1912-02-03T11:47Z" 
-            "1979-09-01" 
-            
-save_
-
-save__pd_meas.number_of_points
-
-    _definition.id               '_pd_meas.number_of_points'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_meas_number_of_points' 
-    _description.text                   
-;
-
-     Total number of points in the measured diffractogram.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              number_of_points
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           1:
-
-save_
-
-
-
-save__pd_meas.rocking_angle
-
-    _definition.id               '_pd_meas.rocking_angle'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_rocking_angle' 
-    _description.text                   
-;
-
-      The angular range in degrees through which a sample
-      is rotated or oscillated during a measurement step
-      (see _pd_meas.rocking_axis).
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              rocking_angle
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0:360.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_meas.rocking_axis
-
-    _definition.id               '_pd_meas.rocking_axis'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_rocking_axis' 
-    _description.text                   
-;
-
-      The axis (or axes) used to rotate or rock the
-      specimen for better randomization of crystallites
-      (see _pd_meas.rocking_angle).
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              rocking_axis
-    _type.purpose                State
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    loop_
-    _enumeration_set.state
-              chi  
-              omega          
-              phi 
-
-save_
-
-
-save__pd_meas.scan_method
-
-    _definition.id               '_pd_meas.scan_method'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_scan_method' 
-    _description.text                   
-;
-
-      Code identifying the method for scanning reciprocal space.
-      The designation `fixed' should be used for measurements where
-      film, a stationary position-sensitive or area detector
-      or other non-moving detection mechanism is used to
-      measure diffraction intensities.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              scan_method
-    _type.purpose                State
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    loop_
-    _enumeration_set.state
-    _enumeration_set.detail
-              step          'step scan'          
-              cont          'continuous scan'    
-              tof           'time of flight'     
-              disp          'energy dispersive'  
-              fixed         'stationary detector' 
-
-save_
-
-
-save__pd_meas.special_details
-
-    _definition.id               '_pd_meas.special_details'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_special_details' 
-    _description.text                   
-;
-
-      Special details of the diffraction measurement process.
-      Include information about source instability, degradation etc.
-      However, this item should not be used to record information
-      that can be specified in other pd_meas entries.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-save__pd_meas.units_of_intensity
-
-    _definition.id               '_pd_meas.units_of_intensity'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_units_of_intensity' 
-    _description.text                   
-;
-
-      Units for intensity measurements when _pd_meas.intensity_*
-      is used. Note that use of 'counts' or 'counts per second'
-      here is strongly discouraged: convert the intensity
-      measurements to counts and use _pd_meas.counts_* and
-      _pd_meas.step_count_time instead of _pd_meas.intensity_*.
-;
-    _name.category_id            pd_meas_overall
-    _name.object_id              units_of_intensity
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "estimated from strip chart"         
-            "arbitrary, from film density"       
-            "counts, with automatic dead-time correction applied" 
+    _definition.id                PD_DATA
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2014-06-20
+    _description.text
+;
+    The PD_DATA category is a "container" category
+    that is defined in order to allow raw, processed and calculated
+    data points in a diffraction data set to be optionally
+    tabulated together. As PD_CALC, PD_MEAS and PD_PROC are
+    all subcategories of this category, the various
+    items belonging to those categories may be looped
+    together or separately, as desired.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_DATA
+    _category_key.name            '_pd_data.point_id'
+
+save_
+
+save_pd_data.point_id
+
+    _definition.id                '_pd_data.point_id'
+    _alias.definition_id          '_pd_data_point_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Arbitrary label identifying an entry in the table of
+    diffractogram intensity values. This should be used in
+    preference to the pd_calc/pd_meas/pd_proc point_id datanames
+    whenever datanames from more than one of the pd_calc/
+    pd_proc/pd_meas categories are looped together.
+;
+    _name.category_id             pd_data
+    _name.object_id               point_id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_CALC
+
+    _definition.id                PD_CALC
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-17
+    _description.text
+;
+    This section is used for storing a computed diffractogram trace.
+    This may be a simulated powder pattern for a material from a
+    program such as LAZY/PULVERIX or the computed intensities from a
+    Rietveld refinement.
+;
+    _name.category_id             PD_DATA
+    _name.object_id               PD_CALC
+    _category_key.name            '_pd_calc.point_id'
+
+save_
+
+save_pd_calc.intensity_net
+
+    _definition.id                '_pd_calc.intensity_net'
+    _alias.definition_id          '_pd_calc_intensity_net'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Intensity values for a computed diffractogram at
+    each angle setting. Values should be computed at the
+    same locations as the processed diffractogram, and thus
+    the numbers of points will be defined by
+    _pd_proc.number_of_points and point positions may
+    be defined using _pd_proc.2theta_range_* or
+    _pd_proc.2theta_corrected.
+
+    Use _pd_calc.intensity_net if the computed diffractogram
+    does not contain background or normalization corrections
+    and thus is specified on the same scale as the
+    _pd_proc_intensity_net values.
+    If an observed pattern is included, _pd_calc.intensity_*
+    should be looped with either _pd_proc.intensity_net,
+    _pd_meas.counts_* or _pd_meas.intensity_*.
+;
+    _name.category_id             pd_calc
+    _name.object_id               intensity_net
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_calc.intensity_total
+
+    _definition.id                '_pd_calc.intensity_total'
+    _alias.definition_id          '_pd_calc_intensity_total'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Intensity values for a computed diffractogram at
+    each angle setting. Values should be computed at the
+    same locations as the processed diffractogram, and thus
+    the numbers of points will be defined by
+    _pd_proc.number_of_points and point positions may
+    be defined using _pd_proc.2theta_range_* or
+    _pd_proc.2theta_corrected.
+
+    Use _pd_calc.intensity_total if the computed diffraction
+    pattern includes background or normalization corrections
+    (or both) and thus is specified on the same scale as the
+    observed intensities (_pd_meas_counts_* or _pd_meas_intensity_*).
+    If an observed pattern is included, _pd_calc.intensity_*
+    should be looped with either _pd_proc.intensity_net,
+    _pd_meas.counts_* or _pd_meas.intensity_*.
+;
+    _name.category_id             pd_calc
+    _name.object_id               intensity_total
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_calc.point_id
+
+    _definition.id                '_pd_calc.point_id'
+    _alias.definition_id          '_pd_calc_point_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Arbitrary label identifying a calculated data point. Used to
+    identify a specific entry in a list of values forming the
+    calculated diffractogram. The role of this identifier may
+    be adopted by _pd_data_point_id if measured, processed and
+    calculated intensity values are combined in a single list.
+;
+    _name.category_id             pd_calc
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
 save_PD_MEAS
 
-    _definition.id               PD_MEAS
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-17
-    _description.text                   
+    _definition.id                PD_MEAS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-17
+    _description.text
 ;
+    This section contains the measured diffractogram prior to
+    processing and application of correction terms. While additional
+    information may be added to the CIF as data are processed and
+    transported between laboratories (possibly with the addition of
+    a new _pd_block_id entry), the information in this section of
+    the CIF will rarely be changed once data collection is complete.
 
-      This section contains the measured diffractogram prior to
-      processing and application of correction terms. While additional
-      information may be added to the CIF as data are processed and
-      transported between laboratories (possibly with the addition of
-      a new _pd_block.id entry), the information in this section of
-      the CIF will rarely be changed once data collection is complete.
- 
-      Where possible, measurements in this section should have no
-      post-collection processing applied (normalizations, corrections,
-      smoothing, zero-offset corrections etc.). Such corrected
-      measurements should be recorded in the _pd_proc_ section.
- 
-      Data sets that are measured as counts, where a standard
-      uncertainty can be considered equivalent to the standard
-      deviation and where the standard deviation can be estimated
-      as the square root of the number of counts recorded, should
-      use the _pd_meas.counts_ fields. All other intensity values
-      should be recorded using _pd_meas.intensity_.
+    Where possible, measurements in this section should have no
+    post-collection processing applied (normalizations, corrections,
+    smoothing, zero-offset corrections etc.). Such corrected
+    measurements should be recorded in the _pd_proc_ section.
+
+    Data sets that are measured as counts, where a standard
+    uncertainty can be considered equivalent to the standard
+    deviation and where the standard deviation can be estimated
+    as the square root of the number of counts recorded, should
+    use the _pd_meas_counts_ fields. All other intensity values
+    should be recorded using _pd_meas_intensity_.
 ;
-    _name.category_id            PD_DATA
-    _name.object_id              PD_MEAS
-    loop_
-    _category_key.name           '_pd_meas.point_id'
+    _name.category_id             PD_DATA
+    _name.object_id               PD_MEAS
+    _category_key.name            '_pd_meas.point_id'
 
 save_
 
-save__pd_meas.2theta_scan
+save_pd_instr.var_illum_len
 
-    _definition.id               '_pd_meas.2theta_scan'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_2theta_scan'
-          '_pd_meas_angle_2theta'
-    _description.text                   
+    _definition.id                '_pd_instr.var_illum_len'
+    _alias.definition_id          '_pd_instr_var_illum_len'
+    _definition.update            2016-10-20
+    _description.text
 ;
+    Length of the specimen that is illuminated by the radiation
+    source (in millimetres) for instruments where
+    the illumination length varies with 2\\q (fixed
+    divergence slits). The _pd_instr.var_illum_len
+    values should be included in the same loop as the
+    intensity measurements (_pd_meas_).
 
-      2\\q diffraction angle (in degrees) for intensity
-      points measured in a scanning method. The scan method used
-      (e.g. continuous or step scan) should be specified in
-      the item _pd_meas.scan_method. For fixed 2\\q (white-beam)
-      experiments, use _pd_meas.2theta_fixed. In the case of
-      continuous-scan data sets, the 2\\q value should be the
-      value at the midpoint of the counting period. Associated
-      with each _pd_meas.2theta_scan value will be
-      _pd_meas.counts_* items. The 2\\q values should
-      not be corrected for nonlinearity,
-      zero offset etc. Corrected values may be specified
-      using _pd_proc.2theta_corrected.
- 
-      Note that for data sets collected with constant step size,
-      _pd_meas.2theta_range_ (*_min, *_max and *_inc) may be used
-      instead of _pd_meas.2theta_scan. _pd_meas_2theta_angle was
-      originally a distinct but cognate definition and should not be
-      used in new files.
-      
+    See _pd_instr.cons_illum_len for instruments where
+    the divergence slit is \q-compensated to yield a\
+    constant illumination length.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              2theta_scan
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:360.0
-    _units.code                             degrees
+    _name.category_id             pd_meas
+    _name.object_id               var_illum_len
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
-save__pd_meas.counts_background
+save_pd_meas.2theta_scan
 
-    _definition.id               '_pd_meas.counts_background'
-    _definition.update           2019-09-25
+    _definition.id                '_pd_meas.2theta_scan'
+
     loop_
       _alias.definition_id
-          '_pd_meas_counts_background' 
-    _description.text                   
+         '_pd_meas_2theta_scan'
+         '_pd_meas_angle_2theta'
+
+    _definition.update            2014-06-20
+    _description.text
 ;
+    2\\q diffraction angle (in degrees) for intensity
+    points measured in a scanning method. The scan method used
+    (e.g. continuous or step scan) should be specified in
+    the item _pd_meas.scan_method. For fixed 2\\q (white-beam)
+    experiments, use _pd_meas.2theta_fixed. In the case of
+    continuous-scan data sets, the 2\\q value should be the
+    value at the midpoint of the counting period. Associated
+    with each _pd_meas.2theta_scan value will be
+    _pd_meas.counts_* items. The 2\\q values should
+    not be corrected for nonlinearity,
+    zero offset etc. Corrected values may be specified
+    using _pd_proc.2theta_corrected.
 
-      Counts measured at the measurement point as a function of
-      angle, time, channel or some other variable (see
-      _pd_meas_2theta_ etc.).  Scattering measured without
-      a specimen, specimen mounting etc., often referred to
-      as the instrument background.
-      Corrections for background, detector dead time etc.
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      Note that counts-per-second values should be converted to
-      total counts. If the counting time varies for different
-      points, it may be included in the loop using
-      _pd_meas.step_count_time.
- 
-      Standard uncertainties should not be quoted for these values.
-      If the standard uncertainties differ from the square root of
-      the number of counts, _pd_meas.intensity_* should be used.
+    Note that for data sets collected with constant step size,
+    _pd_meas.2theta_range_ (*_min, *_max and *_inc) may be used
+    instead of _pd_meas.2theta_scan. _pd_meas_2theta_angle was
+    originally a distinct but cognate definition and should not be
+    used in new files.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              counts_background
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:
-
-save_
-
-
-save__pd_meas.counts_container
-
-    _definition.id               '_pd_meas.counts_container'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_meas_counts_container' 
-    _description.text                   
-;
-
-      Counts measured at the measurement point as a function of
-      angle, time, channel or some other variable (see
-      _pd_meas_2theta_ etc.). from specimen container or mounting
-      without a specimen, includes background.
-      Corrections for background, detector dead time etc.
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      Note that counts-per-second values should be converted to
-      total counts. If the counting time varies for different
-      points, it may be included in the loop using
-      _pd_meas.step_count_time.
- 
-      Standard uncertainties should not be quoted for these values.
-      If the standard uncertainties differ from the square root of
-      the number of counts, _pd_meas.intensity_* should be used.
-;
-    _name.category_id            pd_meas
-    _name.object_id              counts_container
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:
+    _name.category_id             pd_meas
+    _name.object_id               2theta_scan
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
 
 save_
 
+save_pd_meas.counts_background
 
-save__pd_meas.counts_monitor
-
-    _definition.id               '_pd_meas.counts_monitor'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_meas_counts_monitor' 
-    _description.text                   
+    _definition.id                '_pd_meas.counts_background'
+    _alias.definition_id          '_pd_meas_counts_background'
+    _definition.update            2019-09-25
+    _description.text
 ;
+    Counts measured at the measurement point as a function of
+    angle, time, channel or some other variable (see
+    _pd_meas_2theta_ etc.).  Scattering measured without
+    a specimen, specimen mounting etc., often referred to
+    as the instrument background.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
 
-      Counts measured at the measurement point as a function of
-      angle, time, channel or some other variable (see
-      _pd_meas.2theta_ etc.). Counts measured by an incident-
-      beam monitor to calibrate the flux on the specimen.
-      Corrections for background, detector dead time etc.
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      Note that counts-per-second values should be converted to
-      total counts. If the counting time varies for different
-      points, it may be included in the loop using
-      _pd_meas.step_count_time.
- 
-      Standard uncertainties should not be quoted for these values.
-      If the standard uncertainties differ from the square root of
-      the number of counts, _pd_meas.intensity_* should be used.
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              counts_monitor
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:
+    _name.category_id             pd_meas
+    _name.object_id               counts_background
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
 
 save_
 
+save_pd_meas.counts_container
 
-save__pd_meas.counts_total
-
-    _definition.id               '_pd_meas.counts_total'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_meas_counts_total' 
-    _description.text                   
+    _definition.id                '_pd_meas.counts_container'
+    _alias.definition_id          '_pd_meas_counts_container'
+    _definition.update            2019-09-25
+    _description.text
 ;
+    Counts measured at the measurement point as a function of
+    angle, time, channel or some other variable (see
+    _pd_meas_2theta_ etc.). from specimen container or mounting
+    without a specimen, includes background.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
 
-      Counts measured at the measurement point as a function of
-      angle, time, channel or some other variable (see
-      _pd_meas.2theta_ etc.). Total scattering from the specimen
-      with background, specimen mounting or container
-      scattering included.
-      Corrections for background, detector dead time etc.
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      Note that counts-per-second values should be converted to
-      total counts. If the counting time varies for different
-      points, it may be included in the loop using
-      _pd_meas.step_count_time.
- 
-      Standard uncertainties should not be quoted for these values.
-      If the standard uncertainties differ from the square root of
-      the number of counts, _pd_meas.intensity_* should be used.
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              counts_total
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:
+    _name.category_id             pd_meas
+    _name.object_id               counts_container
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
 
 save_
 
-save__pd_meas.detector_id
+save_pd_meas.counts_monitor
 
-    _definition.id               '_pd_meas.detector_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_detector_id' 
-    _description.text                   
+    _definition.id                '_pd_meas.counts_monitor'
+    _alias.definition_id          '_pd_meas_counts_monitor'
+    _definition.update            2019-09-25
+    _description.text
 ;
+    Counts measured at the measurement point as a function of
+    angle, time, channel or some other variable (see
+    _pd_meas_2theta_ etc.). Counts measured by an incident-
+    beam monitor to calibrate the flux on the specimen.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
 
-      A code or number which identifies the measuring detector or
-      channel number in a position-sensitive, energy-dispersive
-      or other multiple-detector instrument.
- 
-      Calibration information, such as angle offsets or
-      a calibration function to convert channel numbers
-      to Q, energy, wavelength, angle etc. should
-      be described with _pd_calib. values. If
-      _pd_calibration.conversion_eqn is used, the detector ID's
-      should be the number to be used in the equation.
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              detector_id
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
-save__pd_meas.intensity_background
-
-    _definition.id               '_pd_meas.intensity_background'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_intensity_background' 
-    _description.text                   
-;
-
-      Intensity measurements at the measurement point (see
-      the definition of _pd_meas.2theta_*). Scattering measured
-      without a specimen, specimen mounting etc., often
-      referred to as the instrument background.
-      Use these entries for measurements where intensity
-      values are not counts (use _pd_meas.counts_* for event-counting
-      measurements where the standard uncertainty is
-      estimated as the square root of the number of counts).
- 
-      Corrections for background, detector dead time etc.,
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      _pd_meas.units_of_intensity should be used to specify
-      the units of the intensity measurements.
-;
-    _name.category_id            pd_meas
-    _name.object_id              intensity_background
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
+    _name.category_id             pd_meas
+    _name.object_id               counts_monitor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
 
 save_
 
+save_pd_meas.counts_total
 
-save__pd_meas.intensity_container
-
-    _definition.id               '_pd_meas.intensity_container'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_intensity_container' 
-    _description.text                   
+    _definition.id                '_pd_meas.counts_total'
+    _alias.definition_id          '_pd_meas_counts_total'
+    _definition.update            2019-09-25
+    _description.text
 ;
+    Counts measured at the measurement point as a function of
+    angle, time, channel or some other variable (see
+    _pd_meas.2theta_ etc.). Total scattering from the specimen
+    with background, specimen mounting or container
+    scattering included.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
 
-      Intensity measurements at the measurement point (see
-      the definition of _pd_meas.2theta_*). The specimen container
-      or mounting without a specimen, includes background.
-      Use these entries for measurements where intensity
-      values are not counts (use _pd_meas.counts_* for event-counting
-      measurements where the standard uncertainty is
-      estimated as the square root of the number of counts).
- 
-      Corrections for background, detector dead time etc.,
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      _pd_meas.units_of_intensity should be used to specify
-      the units of the intensity measurements.
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              intensity_container
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-
-save_
-
-
-save__pd_meas.intensity_monitor
-
-    _definition.id               '_pd_meas.intensity_monitor'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_intensity_monitor' 
-    _description.text                   
-;
-
-      Intensity measurements at the measurement point (see
-      the definition of _pd_meas.2theta_*). Intensity measured by an
-      incident-beam monitor to calibrate the flux on the specimen.
-      Use these entries for measurements where intensity
-      values are not counts (use _pd_meas.counts_* for event-counting
-      measurements where the standard uncertainty is
-      estimated as the square root of the number of counts).
- 
-      Corrections for background, detector dead time etc.,
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      _pd_meas.units_of_intensity should be used to specify
-      the units of the intensity measurements.
-;
-    _name.category_id            pd_meas
-    _name.object_id              intensity_monitor
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
+    _name.category_id             pd_meas
+    _name.object_id               counts_total
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
 
 save_
 
+save_pd_meas.detector_id
 
-save__pd_meas.intensity_total
-
-    _definition.id               '_pd_meas.intensity_total'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_intensity_total' 
-    _description.text                   
+    _definition.id                '_pd_meas.detector_id'
+    _alias.definition_id          '_pd_meas_detector_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    A code or number which identifies the measuring detector or
+    channel number in a position-sensitive, energy-dispersive
+    or other multiple-detector instrument.
 
-      Intensity measurements at the measurement point (see
-      the definition of _pd_meas.2theta_*). Scattering from
-      the specimen (with background, specimen mounting or container
-      scattering included).
-      Use these entries for measurements where intensity
-      values are not counts (use _pd_meas.counts_* for event-counting
-      measurements where the standard uncertainty is
-      estimated as the square root of the number of counts).
- 
-      Corrections for background, detector dead time etc.,
-      should not have been made to these values. Instead use
-      _pd_proc.intensity_* for corrected diffractograms.
- 
-      _pd_meas.units_of_intensity should be used to specify
-      the units of the intensity measurements.
+    Calibration information, such as angle offsets or
+    a calibration function to convert channel numbers
+    to Q, energy, wavelength, angle etc. should
+    be described with _pd_calib_ values. If
+    _pd_calibration_conversion_eqn is used, the detector ID's
+    should be the number to be used in the equation.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              intensity_total
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
+    _name.category_id             pd_meas
+    _name.object_id               detector_id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
-save__pd_meas.point_id
+save_pd_meas.intensity_background
 
-    _definition.id               '_pd_meas.point_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_point_id' 
-    _description.text                   
+    _definition.id                '_pd_meas.intensity_background'
+    _alias.definition_id          '_pd_meas_intensity_background'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Intensity measurements at the measurement point (see
+    the definition of _pd_meas.2theta_*). Scattering measured
+    without a specimen, specimen mounting etc., often
+    referred to as the instrument background.
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
 
-      Arbitrary label identifying a measured data point. Used to
-      identify a specific entry in a list of measured intensities.
-      The role of this identifier may be adopted by
-      _pd_data.point_id if measured, processed and calculated
-      intensity values are combined in a single list.
+    Corrections for background, detector dead time etc.,
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              point_id
-    _name.linked_item_id         '_pd_data.point_id'
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
-
-save__pd_meas.position
-
-    _definition.id               '_pd_meas.position'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_position' 
-    _description.text                   
-;
-
-      A linear distance in millimetres corresponding to the
-      location where an intensity measurement is made.
-      Used for detectors where a distance measurement is made
-      as a direct observable, such as from a microdensitometer
-      trace from film or a strip chart recorder. This is an
-      alternative to _pd_meas_2theta_scan, which should only be
-      used for instruments that record intensities directly
-      against 2\\q. For instruments where the position scale\
-      is nonlinear, the data item _pd_meas.detector_id should
-      be used to record positions.
- 
-      Calibration information, such as angle offsets or a
-      function to convert this distance to a 2\\q angle\
-      or d-space, should be supplied with the _pd_calib_ values.
- 
-      Do not confuse this with the instrument geometry
-      descriptions given by _pd_instr.dist_.
-;
-    _name.category_id            pd_meas
-    _name.object_id              position
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                             millimetres
+    _name.category_id             pd_meas
+    _name.object_id               intensity_background
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
-save__pd_meas.step_count_time
+save_pd_meas.intensity_container
 
-    _definition.id               '_pd_meas.step_count_time'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_meas_step_count_time' 
-    _description.text                   
+    _definition.id                '_pd_meas.intensity_container'
+    _alias.definition_id          '_pd_meas_intensity_container'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Intensity measurements at the measurement point (see
+    the definition of _pd_meas.2theta_*). The specimen container
+    or mounting without a specimen, includes background.
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
 
-      The count time in seconds for each intensity measurement.
+    Corrections for background, detector dead time etc.,
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
 
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
 ;
-    _name.category_id            pd_meas
-    _name.object_id              step_count_time
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:
-    _units.code                             seconds
-
-save_
-
-save__pd_meas.time_of_flight
-
-    _definition.id               '_pd_meas.time_of_flight'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_meas_time_of_flight' 
-    _description.text                   
-;
-
-      Measured time in microseconds for time-of-flight neutron
-      measurements. Note that the flight distance may be
-      specified using _pd_instr.dist_ values.
-;
-    _name.category_id            pd_meas
-    _name.object_id              time_of_flight
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:
-    _units.code                             microseconds
+    _name.category_id             pd_meas
+    _name.object_id               intensity_container
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
+save_pd_meas.intensity_monitor
 
-save_PD_MEAS_INFO_AUTHOR
-
-    _definition.id               PD_MEAS_INFO_AUTHOR
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-18
-    _description.text                   
+    _definition.id                '_pd_meas.intensity_monitor'
+    _alias.definition_id          '_pd_meas_intensity_monitor'
+    _definition.update            2014-06-20
+    _description.text
 ;
-      This section contains information about the person(s)
-      who conducted the measurement.
+    Intensity measurements at the measurement point (see
+    the definition of _pd_meas.2theta_*). Intensity measured by an
+    incident-beam monitor to calibrate the flux on the specimen.
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
+
+    Corrections for background, detector dead time etc.,
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_MEAS_INFO_AUTHOR
-    loop_
-    _category_key.name           '_pd_meas_info_author.name'
-
-save_
-
-save__pd_meas_info_author.address
-
-    _definition.id               '_pd_meas_info_author.address'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_info_author_address' 
-    _description.text                   
-;
-
-      The address of the person who measured the data set. If there
-      is more than one person, this will be looped with
-      _pd_meas_info_author.name.
-;
-    _name.category_id            pd_meas_info_author
-    _name.object_id              address
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_meas
+    _name.object_id               intensity_monitor
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
+save_pd_meas.intensity_total
 
-save__pd_meas_info_author.email
-
-    _definition.id               '_pd_meas_info_author.email'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_info_author_email' 
-    _description.text                   
+    _definition.id                '_pd_meas.intensity_total'
+    _alias.definition_id          '_pd_meas_intensity_total'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Intensity measurements at the measurement point (see
+    the definition of _pd_meas.2theta_*). Scattering from
+    the specimen (with background, specimen mounting or container
+    scattering included.
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
 
-      The e-mail address of the person who measured the data set. If
-      there is more than one person, this will be looped with
-      _pd_meas_info_author.name.
+    Corrections for background, detector dead time etc.,
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
 ;
-    _name.category_id            pd_meas_info_author
-    _name.object_id              email
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_meas
+    _name.object_id               intensity_total
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
+save_pd_meas.point_id
 
-save__pd_meas_info_author.fax
-
-    _definition.id               '_pd_meas_info_author.fax'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_info_author_fax' 
-    _description.text                   
+    _definition.id                '_pd_meas.point_id'
+    _alias.definition_id          '_pd_meas_point_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      The fax number of the person who measured the data set. If
-      there is more than one person, this will be looped with
-      _pd_meas_info_author.name. The recommended style is
-      the international dialing prefix, followed by the area code in
-      parentheses, followed by the local number with no spaces.
+    Arbitrary label identifying a measured data point. Used to
+    identify a specific entry in a list of measured intensities.
+    The role of this identifier may be adopted by
+    _pd_data_point_id if measured, processed and calculated
+    intensity values are combined in a single list.
 ;
-    _name.category_id            pd_meas_info_author
-    _name.object_id              fax
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_meas
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
+save_pd_meas.position
 
-save__pd_meas_info_author.name
-
-    _definition.id               '_pd_meas_info_author.name'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_info_author_name' 
-    _description.text                   
+    _definition.id                '_pd_meas.position'
+    _alias.definition_id          '_pd_meas_position'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    A linear distance in millimetres corresponding to the
+    location where an intensity measurement is made.
+    Used for detectors where a distance measurement is made
+    as a direct observable, such as from a microdensitometer
+    trace from film or a strip chart recorder. This is an
+    alternative to _pd_meas_2theta_scan, which should only be
+    used for instruments that record intensities directly
+    against 2\\q. For instruments where the position scale\
+    is nonlinear, the data item _pd_meas_detector_id should
+    be used to record positions.
 
-      The name of the person who measured the data set. The family
-      name(s), followed by a comma and including any dynastic
-      components, precedes the first name(s) or initial(s).
-      For more than one person use a loop to specify multiple values.
+    Calibration information, such as angle offsets or a
+    function to convert this distance to a 2\\q angle\
+    or d-space, should be supplied with the _pd_calib_ values.
+
+    Do not confuse this with the instrument geometry
+    descriptions given by _pd_instr_dist_.
 ;
-    _name.category_id            pd_meas_info_author
-    _name.object_id              name
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_meas
+    _name.object_id               position
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
 
 save_
 
+save_pd_meas.step_count_time
 
-save__pd_meas_info_author.phone
-
-    _definition.id               '_pd_meas_info_author.phone'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_meas_info_author_phone' 
-    _description.text                   
+    _definition.id                '_pd_meas.step_count_time'
+    _alias.definition_id          '_pd_meas_step_count_time'
+    _definition.update            2019-09-25
+    _description.text
 ;
-
-      The telephone number of the person who measured the data set.
-      If there is more than one person, this will be looped with
-      _pd_meas_info_author.name. The recommended style is
-      the international dialing prefix, followed by the area code in
-      parentheses, followed by the local number with no spaces.
+    The count time in seconds for each intensity measurement.
 ;
-    _name.category_id            pd_meas_info_author
-    _name.object_id              phone
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_meas
+    _name.object_id               step_count_time
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   seconds
 
 save_
 
-save_PD_PEAK_OVERALL
+save_pd_meas.time_of_flight
 
-    _definition.id               PD_PEAK_OVERALL
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2016-10-18
-    _description.text                   
+    _definition.id                '_pd_meas.time_of_flight'
+    _alias.definition_id          '_pd_meas_time_of_flight'
+    _definition.update            2019-09-25
+    _description.text
 ;
-
-      This category describes general aspects of the peak extraction
-      process. 
+    Measured time in microseconds for time-of-flight neutron
+    measurements. Note that the flight distance may be
+    specified using _pd_instr_dist_ values.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PEAK_OVERALL
-
-save_
-
-save__pd_peak.special_details
-
-    _definition.id               '_pd_peak.special_details'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_special_details' 
-    _description.text                   
-;
-
-      Detailed description of any non-routine processing steps
-      used for peak determination or other comments
-      related to the peak table that cannot be given elsewhere.
-;
-    _name.category_id            pd_peak_overall
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-
-save_PD_PEAK
-
-    _definition.id               PD_PEAK
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2014-06-20
-    _description.text                   
-;
-
-      This section contains peak information extracted from the
-      measured or, if present, the processed diffractogram. Each
-      peak in this table will have a unique label (see _pd_peak.id).
-      The reflections and phases associated with each peak will be
-      specified in other sections (see the _pd_refln. and
-      _pd_phase. sections).
- 
-      Note that peak positions are customarily determined from the
-      processed diffractogram and thus corrections for position
-      and intensity will have been previously applied.
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PEAK
-    loop_
-    _category_key.name           '_pd_peak.id'
-
-save_
-
-
-save__pd_peak.2theta_centroid
-
-    _definition.id               '_pd_peak.2theta_centroid'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_2theta_centroid' 
-    _description.text                   
-;
-
-      Position of the centroid of a peak as a 2\\q angle.
-;
-    _name.category_id            pd_peak
-    _name.object_id              2theta_centroid
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:180.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_peak.2theta_maximum
-
-    _definition.id               '_pd_peak.2theta_maximum'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_2theta_maximum' 
-    _description.text                   
-;
-
-      Position of the maximum of a peak as a 2\\q angle.
-;
-    _name.category_id            pd_peak
-    _name.object_id              2theta_maximum
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:180.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_peak.d_spacing
-
-    _definition.id               '_pd_peak.d_spacing'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_d_spacing' 
-    _description.text                   
-;
-
-      Peak position as a d-spacing in angstroms.
-;
-    _name.category_id            pd_peak
-    _name.object_id              d_spacing
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             angstroms
-
-save_
-
-
-save__pd_peak.id
-
-    _definition.id               '_pd_peak.id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_id' 
-    _description.text                   
-;
-
-      An arbitrary code is assigned to each peak. Used to link with
-      _pd_refln.peak_id so that multiple hkl and/or phase
-      identifications can be assigned to a single peak.
-      Each peak will have a unique code. In cases
-      where two peaks are severely overlapped, it may be
-      desirable to list them as a single peak.
- 
-      A peak ID must be included for every peak.
-;
-    _name.category_id            pd_peak
-    _name.object_id              id
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
-
-save__pd_peak.intensity
-
-    _definition.id               '_pd_peak.intensity'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_intensity' 
-    _description.text                   
-;
-
-      Integrated area for the peak, with the same scaling as
-      the _pd_proc.intensity_ values. It is good practice to
-      include s.u.'s for these values.
-;
-    _name.category_id            pd_peak
-    _name.object_id              intensity
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-
-save_
-
-
-save__pd_peak.pk_height
-
-    _definition.id               '_pd_peak.pk_height'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_pk_height' 
-    _description.text                   
-;
-
-      The maximum intensity of the peak, either extrapolated
-      or the highest observed intensity value. The same
-      scaling is used for the _pd_proc.intensity_ values.
-      It is good practice to include s.u.'s for these values.
-;
-    _name.category_id            pd_peak
-    _name.object_id              pk_height
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-
-save_
-
-save__pd_peak.wavelength_id
-
-    _definition.id               '_pd_peak.wavelength_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_wavelength_id' 
-    _description.text                   
-;
-
-      Code identifying the wavelength appropriate for this peak
-      from the wavelengths in the _diffrn_radiation_ list.
-      (See _diffrn_radiation_wavelength.id.) Most commonly used
-      to distinguish K\\a~1~ peaks from K\\a~2~ or to designate
-      where K\\a~1~ and K\\a~2~ peaks cannot be resolved. For
-      complex peak tables with multiple superimposed peaks,
-      specify wavelengths in the reflection table using
-      _pd_refln.wavelength_id rather than identifying peaks by
-      wavelength.
-;
-    _name.category_id            pd_peak
-    _name.object_id              wavelength_id
-    _name.linked_item_id         '_diffrn_radiation_wavelength.id'
-    _type.purpose                Link
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-
-save_
-
-
-save__pd_peak.width_2theta
-
-    _definition.id               '_pd_peak.width_2theta'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_width_2theta' 
-    _description.text                   
-;
-
-      Peak width as full-width at half-maximum expressed as
-      a 2\\q value in degrees.
-;
-    _name.category_id            pd_peak
-    _name.object_id              width_2theta
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:180.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_peak.width_d_spacing
-
-    _definition.id               '_pd_peak.width_d_spacing'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_peak_width_d_spacing' 
-    _description.text                   
-;
-
-      Peak width as full-width at half-maximum expressed as
-      a d-spacing in angstroms.
-;
-    _name.category_id            pd_peak
-    _name.object_id              width_d_spacing
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             angstroms
-
-save_
-
-
-
-
-save_PD_PREP
-
-    _definition.id               PD_PREP
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2014-06-20
-    _description.text                   
-;
-
-      This section contains descriptive information about how the
-      sample was prepared.
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PREP
-
-save_
-
-
-save__pd_prep.conditions
-
-    _definition.id               '_pd_prep.conditions'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_prep_conditions' 
-    _description.text                   
-;
-
-      A description of how the material was prepared
-      (reaction conditions etc.)
-;
-    _name.category_id            pd_prep
-    _name.object_id              conditions
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-
-save__pd_prep.cool_rate
-
-    _definition.id               '_pd_prep.cool_rate'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_prep_cool_rate' 
-    _description.text                   
-;
-
-      Cooling rate in kelvins per minute for samples prepared
-      at high temperatures. If the cooling rate is not linear
-      or is unknown (e.g. quenched samples), it should be
-      described in _pd_prep_conditions instead.
-;
-    _name.category_id            pd_prep
-    _name.object_id              cool_rate
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             kelvins_per_minute
-
-save_
-
-
-save__pd_prep.pressure
-
-    _definition.id               '_pd_prep.pressure'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_prep_pressure' 
-    _description.text                   
-;
-
-      Preparation pressure of the sample in kilopascals. This
-      is particularly important for materials which are metastable
-      at the measurement pressure, _diffrn.ambient_pressure.
-;
-    _name.category_id            pd_prep
-    _name.object_id              pressure
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             kilopascals
-
-save_
-
-
-save__pd_prep.temperature
-
-    _definition.id               '_pd_prep.temperature'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_prep_temperature' 
-    _description.text                   
-;
-
-      Preparation temperature of the sample in kelvins. This is
-      particularly important for materials which are metastable
-      at the measurement temperature, _diffrn.ambient_temperature.
-;
-    _name.category_id            pd_prep
-    _name.object_id              temperature
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             kelvins
-
-save_
-
-save_PD_PROC_OVERALL
-
-    _definition.id               PD_PROC_OVERALL
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2016-10-18
-    _description.text                   
-;
-
-      This section contains overall information about the diffraction
-      data set after processing and application of correction
-      terms. If the data set is reprocessed, this section may be
-      replaced (with the addition of a new _pd_block.id entry).
-
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PROC_OVERALL
-
-save_
-
-save__pd_proc.2theta_range_inc
-
-    _definition.id               '_pd_proc.2theta_range_inc'
-    _definition.update           2021-11-12
-    loop_
-      _alias.definition_id
-          '_pd_proc_2theta_range_inc' 
-    _description.text                   
-;
-
-      The increment in 2\\q diffraction angles in degrees for the
-      measurement of intensities. These may be used in place of the
-      _pd_proc.2theta_corrected values, or in the case of white-beam
-      experiments it will define the fixed 2\\q value.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              2theta_range_inc
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_proc.2theta_range_max
-
-    _definition.id               '_pd_proc.2theta_range_max'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_2theta_range_max' 
-    _description.text                   
-;
-
-      The maximum 2\\q diffraction angle in degrees for the
-      measurement of intensities. This may be used in place of the
-      _pd_proc_2theta_corrected values, or in the case of white-beam
-      experiments it will define the fixed 2\\q value together with
-      _pd_proc.2theta_range_min.
-      
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              2theta_range_max
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
-
-save_
-
-
-save__pd_proc.2theta_range_min
-
-    _definition.id               '_pd_proc.2theta_range_min'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_2theta_range_min' 
-    _description.text                   
-;
-
-      The minimum 2\\q diffraction angle in degrees for the
-      measurement of intensities. This may be used in place of the
-      _pd_proc_2theta_corrected values, or in the case of white-beam
-      experiments they will define the fixed 2\\q value together with
-      _pd_proc.2theta_range_max.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              2theta_range_min
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
-
-save_
-
-save__pd_proc.info_data_reduction
-
-    _definition.id               '_pd_proc.info_data_reduction'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_data_reduction' 
-    _description.text                   
-;
-
-      Description of the processing steps applied in the data-reduction
-      process (background subtraction, \a-2 stripping, smoothing\
-      etc.). Include details of the program(s) used etc.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              info_data_reduction
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-
-save__pd_proc.info_datetime
-
-    _definition.id               '_pd_proc.info_datetime'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_datetime' 
-    _description.text                    
-;
-
-      Date(s) and time(s) when the data set was processed.
-      May be looped if multiple processing steps were used.
- 
-      Entries should follow the standard RFC 3339 ABNF format 
-      'yyyy-mm-ddThh:mm{:ss}{Z|[+-]zz:zz}'. Use of seconds and 
-      a time zone offset is optional, but use of hours and 
-      minutes is strongly encouraged.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              info_datetime
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               DateTime
-    loop_
-    _description_example.case
-            "1990-07-13T14:40" 
-            "2042-12-13T02:37:23Z" 
-            "2005-03-03T12:02:09.17+09:30" 
-            "2015-10-30T22:45-02:00" 
-            "1912-02-03T11:47Z" 
-            "1979-09-01" 
-
-save_
-
-
-save__pd_proc.info_excluded_regions
-
-    _definition.id               '_pd_proc.info_excluded_regions'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_excluded_regions' 
-    _description.text                   
-;
-
-      Description of regions in the diffractogram excluded
-      from processing along with a justification of why the
-      data points were not used.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              info_excluded_regions
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "20 to 21 degrees unreliable due to beam dump" 
-
-save_
-
-
-save__pd_proc.info_special_details
-
-    _definition.id               '_pd_proc.info_special_details'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_special_details' 
-    _description.text                   
-;
-
-      Detailed description of any non-routine processing steps
-      applied due to any irregularities in this particular data set.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              info_special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-save__pd_proc.number_of_points
-
-    _definition.id               '_pd_proc.number_of_points'
-    _definition.update           2019-09-25
-    loop_
-      _alias.definition_id
-          '_pd_proc_number_of_points' 
-    _description.text                   
-;
-
-      The total number of data points in the processed diffractogram.
-;
-    _name.category_id            pd_proc_overall
-    _name.object_id              number_of_points
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           1:
+    _name.category_id             pd_meas
+    _name.object_id               time_of_flight
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   microseconds
 
 save_
 
 save_PD_PROC
 
-    _definition.id               PD_PROC
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2014-06-20
-    _description.text                   
+    _definition.id                PD_PROC
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      This section contains the diffraction data set after processing
-      and application of correction terms. If the data set is
-      reprocessed, this section may be replaced (with the addition of
-      a new _pd_block.id entry).
+    This section contains the diffraction data set after processing
+    and application of correction terms. If the data set is
+    reprocessed, this section may be replaced (with the addition of
+    a new _pd_block.id entry).
 ;
-    _name.category_id            PD_DATA
-    _name.object_id              PD_PROC
-    loop_
-    _category_key.name          '_pd_proc.point_id'
+    _name.category_id             PD_DATA
+    _name.object_id               PD_PROC
+    _category_key.name            '_pd_proc.point_id'
 
 save_
 
+save_pd_proc.2theta_corrected
 
-save__pd_proc.2theta_corrected
-
-    _definition.id               '_pd_proc.2theta_corrected'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_2theta_corrected' 
-    _description.text                   
+    _definition.id                '_pd_proc.2theta_corrected'
+    _alias.definition_id          '_pd_proc_2theta_corrected'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      The 2\\q diffraction angle in degrees of an intensity
-      measurement where 2\\q is not constant. Used if
-      corrections such as for nonlinearity, zero offset etc.
-      have been applied to the _pd_meas.2theta_ values or if
-      2\\q values are computed. If the 2\\q values
-      are evenly spaced, _pd_proc.2theta_range_min,
-      _pd_proc.2theta_range_max and _pd_proc.2theta_range_inc
-      may be used to specify the 2\\q values.
+    The 2\\q diffraction angle in degrees of an intensity
+    measurement where 2\\q is not constant. Used if
+    corrections such as for nonlinearity, zero offset etc.
+    have been applied to the _pd_meas.2theta_ values or if
+    2\\q values are computed. If the 2\\q values
+    are evenly spaced, _pd_proc.2theta_range_min,
+    _pd_proc.2theta_range_max and _pd_proc.2theta_range_inc
+    may be used to specify the 2\\q values.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              2theta_corrected
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.0:180.0
-    _units.code                             degrees
+    _name.category_id             pd_proc
+    _name.object_id               2theta_corrected
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
 
 save_
 
-save__pd_proc.d_spacing
+save_pd_proc.d_spacing
 
-    _definition.id               '_pd_proc.d_spacing'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_d_spacing' 
-    _description.text                   
+    _definition.id                '_pd_proc.d_spacing'
+    _alias.definition_id          '_pd_proc_d_spacing'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      d-spacing corresponding to an intensity point
-      from Bragg's law, d = \l/(2 sin\\q), in units of angstroms.
+    d-spacing corresponding to an intensity point
+    from Bragg's law, d = \l/(2 sin\\q), in units of angstroms.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              d_spacing
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             angstroms
+    _name.category_id             pd_proc
+    _name.object_id               d_spacing
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
 
 save_
 
-save__pd_proc.energy_detection
+save_pd_proc.energy_detection
 
-    _definition.id               '_pd_proc.energy_detection'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_energy_detection' 
-    _description.text                   
+    _definition.id                '_pd_proc.energy_detection'
+    _alias.definition_id          '_pd_proc_energy_detection'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Detection energy in electronvolts selected by the analyser,
-      if not the same as the incident energy (triple-axis or
-      energy-dispersive data). This may be a single value or may
-      vary for each data point (triple-axis and time-of-flight data).
+    Detection energy in electronvolts selected by the analyser,
+    if not the same as the incident energy (triple-axis or
+    energy-dispersive data). This may be a single value or may
+    vary for each data point (triple-axis and time-of-flight data).
 ;
-    _name.category_id            pd_proc
-    _name.object_id              energy_detection
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             electron_volts
+    _name.category_id             pd_proc
+    _name.object_id               energy_detection
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   electron_volts
 
 save_
 
+save_pd_proc.energy_incident
 
-save__pd_proc.energy_incident
-
-    _definition.id               '_pd_proc.energy_incident'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_energy_incident' 
-    _description.text                   
+    _definition.id                '_pd_proc.energy_incident'
+    _alias.definition_id          '_pd_proc_energy_incident'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Incident energy in electronvolts of the source computed
-      from secondary calibration information (time-of-flight
-      and synchrotron data).
+    Incident energy in electronvolts of the source computed
+    from secondary calibration information (time-of-flight
+    and synchrotron data).
 ;
-    _name.category_id            pd_proc
-    _name.object_id              energy_incident
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             electron_volts
+    _name.category_id             pd_proc
+    _name.object_id               energy_incident
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   electron_volts
 
 save_
 
-save__pd_proc.intensity_bkg_calc
+save_pd_proc.intensity_bkg_calc
 
-    _definition.id               '_pd_proc.intensity_bkg_calc'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_intensity_bkg_calc' 
-    _description.text                   
+    _definition.id                '_pd_proc.intensity_bkg_calc'
+    _alias.definition_id          '_pd_proc_intensity_bkg_calc'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Inclusion of s.u.'s for these values is strongly recommended.
 
-      Inclusion of s.u.'s for these values is strongly recommended.
-      
-      _pd_proc_intensity_bkg_calc is intended to contain the
-      background intensity for every data point where the
-      background function has been fitted or estimated (for example, in
-      all Rietveld and profile fits).
+    _pd_proc_intensity_bkg_calc is intended to contain the
+    background intensity for every data point where the
+    background function has been fitted or estimated (for example, in
+    all Rietveld and profile fits).
 ;
-    _name.category_id            pd_proc
-    _name.object_id              intensity_bkg_calc
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_proc
+    _name.object_id               intensity_bkg_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
+save_pd_proc.intensity_bkg_fix
 
-save__pd_proc.intensity_bkg_fix
-
-    _definition.id               '_pd_proc.intensity_bkg_fix'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_intensity_bkg_fix' 
-    _description.text                   
+    _definition.id                '_pd_proc.intensity_bkg_fix'
+    _alias.definition_id          '_pd_proc_intensity_bkg_fix'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Inclusion of s.u.'s for these values is strongly recommended.
 
-      Inclusion of s.u.'s for these values is strongly recommended.
+    If the background is estimated for a limited number of points
+    and the calculated background is then extrapolated from
+    these fixed points, indicate the background values for
+    these points with _pd_proc_intensity_bkg_fix. Use a value
+    of '.' for data points where a fixed background has not
+    been defined. The extrapolated background at every point
+    may be specified using _pd_proc_intensity_bkg_calc.
 
-      If the background is estimated for a limited number of points
-      and the calculated background is then extrapolated from
-      these fixed points, indicate the background values for
-      these points with _pd_proc.intensity_bkg_fix. Use a value
-      of '.' for data points where a fixed background has not
-      been defined. The extrapolated background at every point
-      may be specified using _pd_proc.intensity_bkg_calc.
- 
-      Background values should be on the same scale as the
-      _pd_proc.intensity_net values. Thus normalization and
-      correction factors should be applied before
-      background subtraction (or should be applied to the
-      background values equally).
- 
-      The other normalization factors applied to the data set (for
-      example, Lp corrections, compensation for variation in
-      counting time) may be specified in _pd_proc.intensity_norm.
-      The function should be specified as the one used to divide the
-      measured intensities.
+    Background values should be on the same scale as the
+    _pd_proc_intensity_net values. Thus normalization and
+    correction factors should be applied before
+    background subtraction (or should be applied to the
+    background values equally).
+
+    The other normalization factors applied to the data set (for
+    example, Lp corrections, compensation for variation in
+    counting time) may be specified in _pd_proc_intensity_norm.
+    The function should be specified as the one used to divide the
+    measured intensities.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              intensity_bkg_fix
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_proc
+    _name.object_id               intensity_bkg_fix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
+save_pd_proc.intensity_incident
 
-save__pd_proc.intensity_incident
-
-    _definition.id               '_pd_proc.intensity_incident'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_intensity_incident' 
-    _description.text                   
+    _definition.id                '_pd_proc.intensity_incident'
+    _alias.definition_id          '_pd_proc_intensity_incident'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Inclusion of s.u.'s for these values is strongly recommended.
-      If the intensities have been corrected for a variation of the
-      incident intensity as a function of a data-collection
-      variable (examples: source fluctuations in synchrotrons,
-      \q-compensated slits in conventional diffractometers,
-      spectral corrections for white-beam experiments), the
-      correction function should be specified as
-      _pd_proc_intensity_incident. The normalization should be
-      specified in _pd_proc.intensity_incident as a value to be
-      used to divide the measured intensities to obtained the
-      normalized diffractogram. Thus, the
-      _pd_proc.intensity_incident values should increase as the
-      incident flux is increased.
+    Inclusion of s.u.'s for these values is strongly recommended.
+    If the intensities have been corrected for a variation of the
+    incident intensity as a function of a data-collection
+    variable (examples: source fluctuations in synchrotrons,
+    \q-compensated slits in conventional diffractometers,
+    spectral corrections for white-beam experiments), the
+    correction function should be specified as
+    _pd_proc_intensity_incident. The normalization should be
+    specified in _pd_proc_intensity_incident as a value to be
+    used to divide the measured intensities to obtained the
+    normalized diffractogram. Thus, the
+    _pd_proc_intensity_incident values should increase as the
+    incident flux is increased.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              intensity_incident
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_proc
+    _name.object_id               intensity_incident
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
+save_pd_proc.intensity_net
 
-save__pd_proc.intensity_net
-
-    _definition.id               '_pd_proc.intensity_net'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_intensity_net' 
-    _description.text                   
+    _definition.id                '_pd_proc.intensity_net'
+    _alias.definition_id          '_pd_proc_intensity_net'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      _pd_proc.intensity_net contains intensity values for the
-      processed diffractogram for each data point (see
-      _pd_proc.2theta_, _pd_proc.wavelength etc.) after
-      correction and normalization factors have been applied
-      (in contrast to _pd_meas.counts_ values, which are
-      uncorrected).
+    _pd_proc.intensity_net contains intensity values for the
+    processed diffractogram for each data point (see
+    _pd_proc_2theta_, _pd_proc_wavelength etc.) after
+    correction and normalization factors have been applied
+    (in contrast to _pd_meas_counts_ values, which are
+    uncorrected).
 ;
-    _name.category_id            pd_proc
-    _name.object_id              intensity_net
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_proc
+    _name.object_id               intensity_net
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
+save_pd_proc.intensity_norm
 
-save__pd_proc.intensity_norm
-
-    _definition.id               '_pd_proc.intensity_norm'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_intensity_norm' 
-    _description.text                   
+    _definition.id                '_pd_proc.intensity_norm'
+    _alias.definition_id          '_pd_proc_intensity_norm'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Inclusion of s.u.'s for these values is strongly recommended.
 
-      Inclusion of s.u.'s for these values is strongly recommended.
+    Background values should be on the same scale as the
+    _pd_proc_intensity_net values. Thus normalization and correction
+    factors should be applied before background subtraction (or
+    should be applied to the background values equally).
 
-      Background values should be on the same scale as the
-      _pd_proc.intensity_net values. Thus normalization and correction
-      factors should be applied before background subtraction (or
-      should be applied to the background values equally).
- 
-      Normalization factors applied to the data set (for
-      example, Lp corrections, compensation for variation in
-      counting time) may be specified in _pd_proc.intensity_norm.
-      The function should be specified as the one used to divide the
-      measured intensities.
+    Normalization factors applied to the data set (for
+    example, Lp corrections, compensation for variation in
+    counting time) may be specified in _pd_proc_intensity_norm.
+    The function should be specified as the one used to divide the
+    measured intensities.
 
-      Note that if the intensities have been corrected for a variation
-      of the incident intensity as a function of a data-collection
-      variable, the correction function should be specified separately
-      as _pd_proc.intensity_incident.
-
+    Note that if the intensities have been corrected for a variation
+    of the incident intensity as a function of a data-collection
+    variable, the correction function should be specified separately
+    as _pd_proc_intensity_incident.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              intensity_norm
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_proc
+    _name.object_id               intensity_norm
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
+save_pd_proc.intensity_total
 
-save__pd_proc.intensity_total
-
-    _definition.id               '_pd_proc.intensity_total'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_intensity_total' 
-    _description.text                   
+    _definition.id                '_pd_proc.intensity_total'
+    _alias.definition_id          '_pd_proc_intensity_total'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    _pd_proc_intensity_total contains intensity values for the
+    processed diffractogram for each data point where
+    background, normalization and other corrections have not
+    been applied.
 
-      _pd_proc.intensity_total contains intensity values for the
-      processed diffractogram for each data point where
-      background, normalization and other corrections have not
-      been applied.
- 
-      Inclusion of s.u.'s for these values is strongly recommended.
+    Inclusion of s.u.'s for these values is strongly recommended.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              intensity_total
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_proc
+    _name.object_id               intensity_total
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
 
 save_
 
-save__pd_proc.point_id
+save_pd_proc.point_id
 
-    _definition.id               '_pd_proc.point_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_point_id' 
-    _description.text                   
+    _definition.id                '_pd_proc.point_id'
+    _alias.definition_id          '_pd_proc_point_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Arbitrary label identifying a processed data point. Used to
-      identify a specific entry in a list of processed intensities.
-      The role of this identifier may be adopted by
-      _pd_data.point_id if measured, processed and calculated
-      intensity values are combined in a single list, or by
-      _pd_meas.point_id if measured and processed lists are
-      combined.
+    Arbitrary label identifying a processed data point. Used to
+    identify a specific entry in a list of processed intensities.
+    The role of this identifier may be adopted by
+    _pd_data_point_id if measured, processed and calculated
+    intensity values are combined in a single list, or by
+    _pd_meas_point_id if measured and processed lists are
+    combined.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              point_id
-    _name.linked_item_id         '_pd_data.point_id'
-    _type.purpose                Key
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_proc
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
+save_pd_proc.recip_len_q
 
-save__pd_proc.recip_len_Q
-
-    _definition.id               '_pd_proc.recip_len_Q'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_recip_len_Q' 
-    _description.text                   
+    _definition.id                '_pd_proc.recip_len_Q'
+    _alias.definition_id          '_pd_proc_recip_len_Q'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Length in reciprocal space (|Q|= 2\\p/d) corresponding to
-      an intensity point. Units are inverse angstroms.
+    Length in reciprocal space (|Q|= 2\\p/d) corresponding to
+    an intensity point. Units are inverse angstroms.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              recip_len_Q
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             reciprocal_angstroms
+    _name.category_id             pd_proc
+    _name.object_id               recip_len_Q
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
 
 save_
 
+save_pd_proc.wavelength
 
-save__pd_proc.wavelength
-
-    _definition.id               '_pd_proc.wavelength'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_wavelength' 
-    _description.text                   
+    _definition.id                '_pd_proc.wavelength'
+    _alias.definition_id          '_pd_proc_wavelength'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      Wavelength in angstroms for the incident radiation as
-      computed from secondary calibration information. This will
-      be most appropriate for time-of-flight and synchrotron
-      measurements. This will be a single value for
-      continuous-wavelength methods or may vary for each data point
-      and be looped with the intensity values for energy-dispersive
-      measurements.
+    Wavelength in angstroms for the incident radiation as
+    computed from secondary calibration information. This will
+    be most appropriate for time-of-flight and synchrotron
+    measurements. This will be a single value for
+    continuous-wavelength methods or may vary for each data point
+    and be looped with the intensity values for energy-dispersive
+    measurements.
 ;
-    _name.category_id            pd_proc
-    _name.object_id              wavelength
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             angstroms
+    _name.category_id             pd_proc
+    _name.object_id               wavelength
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
 
 save_
 
+save_PD_INSTR
 
-save_PD_PROC_INFO_AUTHOR
+    _definition.id                PD_INSTR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2014-06-20
+    _description.text
+;
+    This section contains information relevant to the instrument
+    used for the diffraction measurement. For most laboratories,
+    very little of this information will change, so a standard file
+    may be prepared and included with each data set.
 
-    _definition.id               PD_PROC_INFO_AUTHOR
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-10-18
-    _description.text                   
+    Note that several definitions in the core CIF dictionary
+    are relevant here. For example, use:
+      _diffrn_radiation_wavelength for the source wavelength,
+      _diffrn_radiation_type for the X-ray wavelength type,
+      _diffrn_source for the radiation source,
+      _diffrn_radiation_polarisn_ratio for the source polarization,
+      _diffrn_radiation_probe for the radiation type.
+    For data sets measured with partially monochromatized radiation,
+    for example, where both K\\a~1~ and K\\a~2~ are present, it is
+    important that all wavelengths present are included in a
+    loop_ using _diffrn_radiation_wavelength to define the
+    wavelength and _diffrn_radiation_wavelength_wt to define the
+    relative intensity of that wavelength. It is required that
+    _diffrn_radiation_wavelength_id also be present in the
+    wavelength loop. It may also be useful to
+    create a "dummy" ID to use for labelling
+    peaks/reflections where the K\\a~1~ and K\\a~2~ wavelengths are
+    not resolved. Set _diffrn_radiation_wavelength_wt to be 0 for
+    such a dummy ID.
+
+    In the _pd_instr_ definitions, the term monochromator refers
+    to a primary beam (pre-specimen) monochromator and the term
+    analyser refers to post-diffraction (post-specimen)
+    monochromator.  The analyser may be fixed for specific
+    wavelength or may be capable of being scanned.
+
+    It is strongly recommended that the core dictionary term
+    _diffrn_radiation_probe (specifying the nature of the radiation
+    used) is employed for all data sets.
 ;
-      This section contains information about the person(s)
-      who processed the data.
-;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PROC_INFO_AUTHOR
-    loop_
-    _category_key.name           '_pd_proc_info_author.name'
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_INSTR
 
 save_
 
-save__pd_proc_info_author.address
+save_pd_instr.2theta_monochr_pre
 
-    _definition.id               '_pd_proc_info_author.address'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_author_address' 
-    _description.text                   
+    _definition.id                '_pd_instr.2theta_monochr_pre'
+    _alias.definition_id          '_pd_instr_2theta_monochr_pre'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-       The address of the person who processed the data.
-       If there is more than one person, this will be looped with
-       _pd_proc_info_author_name.
+    The 2\\q angle for a pre-specimen monochromator (see also
+    _pd_instr.monochr_pre_spec).
 ;
-    _name.category_id            pd_proc_info_author
-    _name.object_id              address
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               2theta_monochr_pre
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.beam_size_ax
 
-save__pd_proc_info_author.email
-
-    _definition.id               '_pd_proc_info_author.email'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_author_email' 
-    _description.text                   
+    _definition.id                '_pd_instr.beam_size_ax'
+    _alias.definition_id          '_pd_instr_beam_size_ax'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-       The e-mail address of the person who processed the
-       data.  If there is more than one person, this will be looped
-       with _pd_proc_info_author.name.
+    Axial dimension of the radiation beam
+    at the specimen position (in millimetres).
+    The perpendicular to the plane containing the incident
+    and scattered beam is the axial (*_ax) direction.
 ;
-    _name.category_id            pd_proc_info_author
-    _name.object_id              email
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               size_ax
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
+save_pd_instr.beam_size_eq
 
-save__pd_proc_info_author.fax
-
-    _definition.id               '_pd_proc_info_author.fax'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_author_fax' 
-    _description.text                   
+    _definition.id                '_pd_instr.beam_size_eq'
+    _alias.definition_id          '_pd_instr_beam_size_eq'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-       The fax number of the person who processed the data.
-       If there is more than one person, this will be looped with
-       _pd_proc_info_author.name. The recommended style is
-       the international dialing prefix, followed by the area code in
-       parentheses, followed by the local number with no spaces.
+    Equatorial dimensions of the radiation beam
+    at the specimen position (in millimetres).
+    The equatorial dimension is in the plane of scattering.
 ;
-    _name.category_id            pd_proc_info_author
-    _name.object_id              fax
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               size_eq
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
+save_pd_instr.cons_illum_flag
 
-save__pd_proc_info_author.name
+    _definition.id                '_pd_instr.cons_illum_flag'
+    _alias.definition_id          '_pd_instr_cons_illum_flag'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Use 'yes' for instruments where the divergence slit is
+    \q-compensated to yield a constant illumination length
+    (also see _pd_instr.cons_illum_len).
 
-    _definition.id               '_pd_proc_info_author.name'
-    _definition.update           2014-06-20
+    For other flat-plate instruments, where the illumination
+    length changes with 2\\q, specify 'no'. Note that
+    if the length is known, it may be specified using
+    _pd_instr.var_illum_len.
+;
+    _name.category_id             pd_instr
+    _name.object_id               cons_illum_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
     loop_
-      _alias.definition_id
-          '_pd_proc_info_author_name' 
-    _description.text                   
-;
-
-       The name of the person who processed the data, if different
-       from the person(s) who measured the data set. The family
-       name(s), followed by a comma and including any dynastic
-       components, precedes the first name(s) or initial(s). For
-       more than one person use a loop to specify multiple values.
-;
-    _name.category_id            pd_proc_info_author
-    _name.object_id              name
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+      _enumeration_set.state
+         yes
+         no
 
 save_
 
-save__pd_proc_info_author.phone
+save_pd_instr.cons_illum_len
 
-    _definition.id               '_pd_proc_info_author.phone'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_info_author_phone' 
-    _description.text                   
+    _definition.id                '_pd_instr.cons_illum_len'
+    _alias.definition_id          '_pd_instr_cons_illum_len'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-       The telephone number of the person who processed the data.
-       If there is more than one person, this will be looped
-       with _pd_proc_info_author.name. The recommended style is
-       the international dialing prefix, followed by the area code in
-       parentheses, followed by the local number with no spaces.
+    Use _pd_instr_cons_illum_len for instruments where the length of
+    sample illuminated does not vary with 2\\q, usually achieved by
+    adjustment of the divergence slits (sometimes known as
+    \q-compensated slits).
 ;
-    _name.category_id            pd_proc_info_author
-    _name.object_id              phone
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               cons_illum_len
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
-save_PD_PROC_LS
+save_pd_instr.dist_mono_spec
 
-    _definition.id               PD_PROC_LS
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2014-06-20
-    _description.text                   
+    _definition.id                '_pd_instr.dist_mono_spec'
+    _alias.definition_id          '_pd_instr_dist_mono/spec'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      This section is used to define parameters relevant to a
-      least-squares fit to a powder diffractogram, using a Rietveld
-      or other full-profile (e.g. Pawley or Le Bail methods) fit.
- 
-      Note that values in this section refer to full-pattern fitting.
-      Use the appropriate items for single-crystal analyses from the
-      core CIF dictionary for structure refinements using diffraction
-      intensities estimated from a powder diffractogram by
-      pattern-decomposition methods. Also note that many entries in
-      the core _refine_ls_ entries may also be useful (for example
-      _refine_ls_shift/su_*).
+    Specifies distances in millimetres from the monochromator to the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PROC_LS
+    _name.category_id             pd_instr
+    _name.object_id               dist_mono_spec
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
-save__pd_proc_ls.background_function
+save_pd_instr.dist_src_mono
 
-    _definition.id               '_pd_proc_ls.background_function'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_background_function' 
-    _description.text                   
+    _definition.id                '_pd_instr.dist_src_mono'
+    _alias.definition_id          '_pd_instr_dist_src/mono'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      Description of the background treatment mechanism used to
-      fit the data set.
- 
-      For refinements where the background is computed as a
-      function that is fitted to minimize the difference between
-      the observed and calculated patterns, it is
-      recommended that in addition to a description of the
-      function (e.g. Chebychev polynomial), the actual equation(s)
-      used are included in TeX, or a programming language such
-      as Fortran or C. Include also the values used for the
-      coefficients used in the background function with their
-      s.u.'s. The background values for each data point
-      computed from the function should be specified in
-      _pd_proc.intensity_bkg_calc.
- 
-      If background correction is performed using extrapolation
-      from a set of points at fixed locations, these points
-      should be defined using _pd_proc_intensity_bkg_fix, and
-      _pd_proc_ls.background_function should indicate the
-      extrapolation method (linear extrapolation, spline etc.).
-      _pd_proc_ls.background_function should also indicate how the
-      points were determined (automatically, by visual estimation
-      etc.) and whether the values were refined to improve the
-      agreement. The extrapolated background intensity value for
-      each data point should be specified in
-      _pd_proc.intensity_bkg_calc.
+    Specifies distance in millimetres from the radiation source to
+    the monochromator.  Note that *_src_spec is used in place of
+    *_src_mono and *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              background_function
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               dist_src_mono
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
+save_pd_instr.dist_src_spec
 
-save__pd_proc_ls.peak_cutoff
-
-    _definition.id               '_pd_proc_ls.peak_cutoff'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_peak_cutoff' 
-    _description.text                   
+    _definition.id                '_pd_instr.dist_src_spec'
+    _alias.definition_id          '_pd_instr_dist_src/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      Describes where peak-intensity computation is
-      discontinued as a fraction of the intensity of the
-      peak at maximum. Thus for a value of 0.005, the
-      tails of a diffraction peak are neglected
-      after the intensity has dropped below 0.5% of the
-      diffraction intensity at the maximum.
+    Specifies distances in millimetres from the radiation source to
+    the specimen.  Note that *_src_spec is used in place of
+    *_src_mono and *_mono_spec if there is no monochromator in use
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              peak_cutoff
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               dist_src_spec
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
+save_pd_instr.divg_ax_mono_spec
 
-save__pd_proc_ls.pref_orient_corr
-
-    _definition.id               '_pd_proc_ls.pref_orient_corr'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_pref_orient_corr' 
-    _description.text                   
+    _definition.id                '_pd_instr.divg_ax_mono_spec'
+    _alias.definition_id          '_pd_instr_divg_ax_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      Description of the preferred-orientation correction if
-      such a correction is used. Omitting this entry
-      implies that no preferred-orientation correction
-      has been used. If a function form is used, it is
-      recommended that the actual equation in TeX, or a
-      programming language, is used to specify the function as
-      well as a giving a description. Include the value(s) used
-      for the correction with s.u.'s.
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) between the monochromator and the specimen.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_):
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              pref_orient_corr
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               divg_ax_mono_spec
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.divg_ax_src_mono
 
-save__pd_proc_ls.prof_R_factor
-
-    _definition.id               '_pd_proc_ls.prof_R_factor'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_prof_R_factor' 
-    _description.text                   
+    _definition.id                '_pd_instr.divg_ax_src_mono'
+    _alias.definition_id          '_pd_instr_divg_ax_src/mono'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-     _pd_proc_ls.prof_R_factor, often called R~p~, is an
-       unweighted fitness metric for the agreement between the
-       observed and computed diffraction patterns.
-          R~p~ = sum~i~ | I~obs~(i) - I~calc~(i) |
-                 / sum~i~ ( I~obs~(i) )
-       Note that in the above equations,
-          w(i) is the weight for the ith data point (see
-               _pd_proc_ls_weight).
-          I~obs~(i) is the observed intensity for the ith data
-               point, sometimes referred to as y~i~(obs) or
-               y~oi~. (See _pd_meas_counts_total,
-               _pd_meas_intensity_total or _pd_proc_intensity_total.)
-          I~calc~(i) is the computed intensity for the ith data
-               point with background and other corrections
-               applied to match the scale of the observed data set,
-               sometimes referred to as y~i~(calc) or
-               y~ci~. (See _pd_calc_intensity_total.)
-          n is the total number of data points (see
-               _pd_proc_number_of_points) less the number of
-               data points excluded from the refinement.
-          p is the total number of refined parameters.
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) between
+    the radiation source and monochromator.  Values are the maximum
+    divergence angles in degrees, as limited by slits or beamline
+    optics other than Soller slits (see _pd_instr.soller_ax_).  Note
+    that *_src_spec is used in place of *_src_mono and *_mono_spec
+    if there is no monochromator in use.
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              pd_proc_ls_prof_R_factor
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_instr
+    _name.object_id               divg_ax_src_mono
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.divg_ax_src_spec
 
-save__pd_proc_ls.prof_wR_expected
-
-    _definition.id               '_pd_proc_ls.prof_wR_expected'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_prof_wR_expected' 
-    _description.text                   
+    _definition.id                '_pd_instr.divg_ax_src_spec'
+    _alias.definition_id          '_pd_instr_divg_ax_src/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
- 
-     _pd_proc_ls.prof_wR_expected, sometimes called the
-       theoretical R~wp~ or R~exp~, is a weighted fitness metric for
-       the statistical precision of the data set. For an idealized fit,
-       where all deviations between the observed intensities and
-       those computed from the model are due to statistical
-       fluctuations, the observed R~wp~ should match the expected
-       R factor. In reality, R~wp~ will always be higher than
-       R~exp~.
-         R~exp~ = SQRT { (n - p)  / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }
- 
-       Note that in the above equations,
-          w(i) is the weight for the ith data point (see
-               _pd_proc_ls_weight).
-          I~obs~(i) is the observed intensity for the ith data
-               point, sometimes referred to as y~i~(obs) or
-               y~oi~. (See _pd_meas_counts_total,
-               _pd_meas_intensity_total or _pd_proc_intensity_total.)
-          I~calc~(i) is the computed intensity for the ith data
-               point with background and other corrections
-               applied to match the scale of the observed data set,
-               sometimes referred to as y~i~(calc) or
-               y~ci~. (See _pd_calc_intensity_total.)
-          n is the total number of data points (see
-               _pd_proc_number_of_points) less the number of
-               data points excluded from the refinement.
-          p is the total number of refined parameters.
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams)  between the radiation source and specimen.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_).
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              pd_proc_ls_prof_wR_expected
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_instr
+    _name.object_id               divg_ax_src_spec
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.divg_eq_mono_spec
 
-save__pd_proc_ls.prof_wR_factor
-
-    _definition.id               '_pd_proc_ls.prof_wR_factor'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_prof_wR_factor' 
-    _description.text                   
+    _definition.id                '_pd_instr.divg_eq_mono_spec'
+    _alias.definition_id          '_pd_instr_divg_eq_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
- 
-     _pd_proc_ls.prof_wR_factor, often called R~wp~, is a
-       weighted fitness metric for the agreement between the
-       observed and computed diffraction patterns.
-         R~wp~ = SQRT {\
-                  sum~i~ ( w(i) [ I~obs~(i) - I~calc~(i) ]^2^ )
-                  / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }\
- 
-       Note that in the above equations,
-          w(i) is the weight for the ith data point (see
-               _pd_proc_ls_weight).
-          I~obs~(i) is the observed intensity for the ith data
-               point, sometimes referred to as y~i~(obs) or
-               y~oi~. (See _pd_meas_counts_total,
-               _pd_meas_intensity_total or _pd_proc_intensity_total.)
-          I~calc~(i) is the computed intensity for the ith data
-               point with background and other corrections
-               applied to match the scale of the observed data set,
-               sometimes referred to as y~i~(calc) or
-               y~ci~. (See _pd_calc_intensity_total.)
-          n is the total number of data points (see
-               _pd_proc_number_of_points) less the number of
-               data points excluded from the refinement.
-          p is the total number of refined parameters.
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the monochromator and
+    the specimen Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_eq_):
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              pd_proc_ls_prof_wR_factor
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
+    _name.category_id             pd_instr
+    _name.object_id               divg_eq_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.divg_eq_src_mono
 
-save__pd_proc_ls.profile_function
-
-    _definition.id               '_pd_proc_ls.profile_function'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_profile_function' 
-    _description.text                   
+    _definition.id                '_pd_instr.divg_eq_src_mono'
+    _alias.definition_id          '_pd_instr_divg_eq_src/mono'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      Description of the profile function used to
-      fit the data set. If a function form is used, it is
-      recommended that the actual equation in TeX, or a
-      programming language, is used to specify the function as
-      well as giving a description. Include the values used
-      for the profile-function coefficients and their s.u.'s.
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the radiation source
+    and monochromator Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_eq_).
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              profile_function
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               divg_eq_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.divg_eq_src_spec
 
-save__pd_proc_ls.special_details
-
-    _definition.id               '_pd_proc_ls.special_details'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_proc_ls_special_details' 
-    _description.text                   
+    _definition.id                '_pd_instr.divg_eq_src_spec'
+    _alias.definition_id          '_pd_instr_divg_eq_src/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      Additional characterization information relevant to
-      non-routine steps used for refinement of a structural model
-      that cannot be specified elsewhere.
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    radiation source and specimen.  Values are the maximum
+    divergence angles in degrees, as limited by slits or beamline
+    optics other than Soller slits (see _pd_instr_soller_eq_).  Note
+    that *_src_spec is used in place of *_src_mono and *_mono_spec
+    if there is no monochromator in use.
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    _name.category_id             pd_instr
+    _name.object_id               divg_eq_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
 
 save_
 
+save_pd_instr.geometry
 
-save__pd_proc_ls.weight
+    _definition.id                '_pd_instr.geometry'
+    _alias.definition_id          '_pd_instr_geometry'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the diffractometer type or geometry.
+;
+    _name.category_id             pd_instr
+    _name.object_id               geometry
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
-    _definition.id               '_pd_proc_ls.weight'
-    _definition.update           2014-06-20
     loop_
-      _alias.definition_id
-          '_pd_proc_ls_weight' 
-    _description.text                   
+      _description_example.case
 ;
-
-      Weight applied to each profile point. These values
-      may be omitted if the weights are 1/u^2^, where
-      u is the s.u. for the _pd_proc.intensity_net values.
- 
-      A weight value of zero is used to indicate a data
-      point not used for refinement (see
-      _pd_proc.info_excluded_regions).
+       Bragg-Brentano
 ;
-    _name.category_id            pd_proc_ls
-    _name.object_id              weight
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0:
+;
+       Guinier
+;
+;
+       Parallel-beam non-focusing optics with channel-cut
+        monochromator and linear position-sensitive detector
+;
 
 save_
 
+save_pd_instr.location
 
-save_PD_SPEC
-
-    _definition.id               PD_SPEC
-    _definition.scope            Category
-    _definition.class            Set
-    _definition.update           2014-06-20
-    _description.text                   
+    _definition.id                '_pd_instr.location'
+    _alias.definition_id          '_pd_instr_location'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      This section contains information about the specimen used
-      for measurement of the diffraction data set. Note that
-      information about the sample (the batch of material from which
-      the specimen was obtained) is specified in _pd_prep_.
+    The name and location of the instrument where measurements
+    were made. This is used primarily to identify data sets
+    measured away from the author's home facility, at shared
+    resources such as a reactor or spallation source.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_SPEC
-
-save_
-
-
-save__pd_spec.description
-
-    _definition.id               '_pd_spec.description'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_spec_description' 
-    _description.text                   
-;
-
-       A description of the specimen, such as the source of the
-       specimen, identification of standards, mixtures etc.
-;
-    _name.category_id            pd_spec
-    _name.object_id              description
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-
-save_
-
-
-save__pd_spec.mount_mode
-
-    _definition.id               '_pd_spec.mount_mode'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_spec_mount_mode' 
-    _description.text                   
-;
-
-      A code describing the beam path through the specimen.
-;
-    _name.category_id            pd_spec
-    _name.object_id              mount_mode
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    loop_
-    _enumeration_set.state
-              reflection     
-              transmission 
-
-save_
-
-
-save__pd_spec.mounting
-
-    _definition.id               '_pd_spec.mounting'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_spec_mounting' 
-    _description.text                   
-;
-
-      A description of how the specimen is mounted.
-;
-    _name.category_id            pd_spec
-    _name.object_id              mounting
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
+    _name.category_id             pd_instr
+    _name.object_id               location
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
     _description_example.case
-            "vanadium can with He exchange gas"  
-            "quartz capillary"         
-            "packed powder pellet"     
-            "drifted powder on off-cut Si"       
-            "drifted powder on Kapton film" 
+        'SEPD diffractometer, IPNS, Argonne National Lab (USA)'
 
 save_
 
+save_pd_instr.monochr_pre_spec
 
-save__pd_spec.orientation
-
-    _definition.id               '_pd_spec.orientation'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_spec_orientation' 
-    _description.text                   
+    _definition.id                '_pd_instr.monochr_pre_spec'
+    _alias.definition_id          '_pd_instr_monochr_pre_spec'
+    _definition.update            2014-06-20
+    _description.text
 ;
+    Indicates the method used to obtain monochromatic radiation.
+    Use _pd_instr_monochr_pre_spec to describe the primary beam
+    monochromator (pre-specimen monochromation). Use
+    _pd_instr_monochr_post_spec to specify the
+    post-diffraction analyser (post-specimen monochromation).
 
-      The orientation of the \\w (\\q) and 2\\q axis.\
-      Note that this axis is parallel to the specimen axial axis
-      and perpendicular to the plane containing the incident and
-      scattered beams.
- 
-      Thus for a horizontal orientation, scattering
-      measurements are made in a plane perpendicular to the
-      ground (the 2\\q axis is parallel to the ground);\
-      for vertical orientation, scattering measurements are
-      made in a plane parallel with the ground (the 2\\q axis\
-      is perpendicular to the ground). `Both' is appropriate for
-      experiments where measurements are made in both planes,
-      for example using two-dimensional detectors.
+    When a monochromator crystal is used, the material and the
+    indices of the Bragg reflection are specified.
+
+    Note that monochromators may have either 'parallel' or
+    'antiparallel' orientation. It is assumed that the
+    geometry is parallel unless specified otherwise.
+    In a parallel geometry, the position of the monochromator
+    allows the incident beam and the final post-specimen
+    and post-monochromator beam to be as close to parallel
+    as possible. In a parallel geometry, the diffracting
+    planes in the specimen and monochromator will be parallel
+    when 2\\q~monochromator~ is equal to 2\\q~specimen~.\
+    For further discussion see R. Jenkins & R. Snyder (1996).
+    Introduction to X-ray Powder Diffraction,
+    pp. 164-165. New York: Wiley.
 ;
-    _name.category_id            pd_spec
-    _name.object_id              orientation
-    _type.purpose                State
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_instr
+    _name.object_id               monochr_pre_spec
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
     loop_
-    _enumeration_set.state
-              horizontal     
-              vertical       
-              both 
+      _description_example.case
+         'Zr filter'
+         'Ge 220'
+         'none'
+         'equatorial mounted graphite (0001)'
+         'Si (111), antiparallel'
 
 save_
 
+save_pd_instr.slit_ax_mono_spec
 
-save__pd_spec.preparation
-
-    _definition.id               '_pd_spec.preparation'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_spec_preparation' 
-    _description.text                   
+    _definition.id                '_pd_instr.slit_ax_mono_spec'
+    _alias.definition_id          '_pd_instr_slit_ax_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      A description of the preparation steps for producing the
-      diffraction specimen from the sample. Include any procedures
-      related to grinding, sieving, spray drying etc. For
-      information relevant to how the sample is synthesized, use
-      the _pd_prep_ entries.
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) for the instrument as a slit width
+    (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the monochromator and the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_spec
-    _name.object_id              preparation
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
-    loop_
-    _description_example.case
-            "wet grinding in acetone"  
-            "sieved through a 44 micron (325 mesh/inch) sieve"       
-            "spray dried in water with 1% clay" 
+    _name.category_id             pd_instr
+    _name.object_id               slit_ax_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
+save_pd_instr.slit_ax_src_mono
 
-save__pd_spec.shape
-
-    _definition.id               '_pd_spec.shape'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_spec_shape' 
-    _description.text                   
+    _definition.id                '_pd_instr.slit_ax_src_mono'
+    _alias.definition_id          '_pd_instr_slit_ax_src/mono'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      A code describing the specimen shape.
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    Collimation between the radiation source and monochromator.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_spec
-    _name.object_id              shape
-    _type.purpose                State
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    loop_
-    _enumeration_set.state
-              cylinder       
-              flat_sheet     
-              irregular 
+    _name.category_id             pd_instr
+    _name.object_id               slit_ax_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
+save_pd_instr.slit_ax_src_spec
 
-save__pd_spec.size_axial
-
-    _definition.id               '_pd_spec.size_axial'
-    _definition.update           2017-10-18
-    loop_
-      _alias.definition_id
-          '_pd_spec_size_axial' 
-    _description.text                   
+    _definition.id                '_pd_instr.slit_ax_src_spec'
+    _alias.definition_id          '_pd_instr_slit_ax_src/spec'
+    _definition.update            2016-10-20
+    _description.text
 ;
-
-      The size of the specimen in three mutually perpendicular
-      directions in millimetres.
-      The perpendicular to the plane containing the incident
-      and scattered beam is the *_axial direction.
-      In transmission geometry, the scattering vector is parallel
-      to *_equat and in reflection geometry the scattering vector is
-      parallel to *_thick.
- 
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    Collimation between the radiation source and the specimen.  Note
+    that *_src_spec is used in place of *_src_mono and *_mono_spec
+    if there is no monochromator in use.
 ;
-    _name.category_id            pd_spec
-    _name.object_id              size_axial
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
+    _name.category_id             pd_instr
+    _name.object_id               slit_ax_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
-save__pd_spec.size_equat
+save_pd_instr.slit_eq_mono_spec
 
-    _definition.id               '_pd_spec.size_equat'
-    _definition.update           2017-10-18
-    loop_
-      _alias.definition_id
-          '_pd_spec_size_equat' 
-    _description.text                   
+    _definition.id                '_pd_instr.slit_eq_mono_spec'
+    _alias.definition_id          '_pd_instr_slit_eq_mono/spec'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      The size of the specimen in three mutually perpendicular
-      directions in millimetres.
-      The perpendicular to the plane containing the incident
-      and scattered beam is the *_axial direction.
-      In transmission geometry, the scattering vector is parallel
-      to *_equat and in reflection geometry the scattering vector is
-      parallel to *_thick.
- 
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    Ollimation between the monochromator and the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_spec
-    _name.object_id              size_equat
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
+    _name.category_id             pd_instr
+    _name.object_id               slit_eq_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
-save__pd_spec.size_thick
+save_pd_instr.slit_eq_src_mono
 
-    _definition.id               '_pd_spec.size_thick'
-    _definition.update           2017-10-18
-    loop_
-      _alias.definition_id
-          '_pd_spec_size_thick' 
-    _description.text                   
+    _definition.id                '_pd_instr.slit_eq_src_mono'
+    _alias.definition_id          '_pd_instr_slit_eq_src/mono'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      The size of the specimen in three mutually perpendicular
-      directions in millimetres.
-      The perpendicular to the plane containing the incident
-      and scattered beam is the *_axial direction.
-      In transmission geometry, the scattering vector is parallel
-      to *_equat and in reflection geometry the scattering vector is
-      parallel to *_thick.
- 
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    Collimation between the radiation source and monochromator.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
 ;
-    _name.category_id            pd_spec
-    _name.object_id              size_thick
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:
-    _units.code                             millimetres
+    _name.category_id             pd_instr
+    _name.object_id               slit_eq_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 
-save__pd_spec.special_details
+save_pd_instr.slit_eq_src_spec
 
-    _definition.id               '_pd_spec.special_details'
-    _definition.update           2014-06-20
+    _definition.id                '_pd_instr.slit_eq_src_spec'
+    _alias.definition_id          '_pd_instr_slit_eq_src/spec'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    Ollimation between the radiation source and the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_eq_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.soller_ax_mono_spec
+
+    _definition.id                '_pd_instr.soller_ax_mono_spec'
+    _alias.definition_id          '_pd_instr_soller_ax_mono/spec'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument.  Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the
+    monochromator and specimen.  Note that *_src_spec is used in
+    place of *_src_mono and *_mono_spec if there is no monochromator
+    in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_ax_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_src_mono
+
+    _definition.id                '_pd_instr.soller_ax_src_mono'
+    _alias.definition_id          '_pd_instr_soller_ax_src/mono'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) for the instrument.
+    Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located thus:
+    Collimation between the radiation source and monochromator;
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use, and
+    *_spec_detc is used in place of *_spec_anal and
+    *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_ax_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_src_spec
+
+    _definition.id                '_pd_instr.soller_ax_src_spec'
+    _alias.definition_id          '_pd_instr_soller_ax_src/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument.  Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the
+    radiation source and specimen.  Note that *_src_spec is used in
+    place of *_src_mono and *_mono_spec if there is no monochromator
+    in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_ax_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_mono_spec
+
+    _definition.id                '_pd_instr.soller_eq_mono_spec'
+    _alias.definition_id          '_pd_instr_soller_eq_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for
+    the instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located  between the monochromator and
+    the specimen. Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_eq_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_src_mono
+
+    _definition.id                '_pd_instr.soller_eq_src_mono'
+    _alias.definition_id          '_pd_instr_soller_eq_src/mono'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for
+    the instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located thus:
+    Collimation between the radiation source and monochromator;
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use, and
+    *_spec_detc is used in place of *_spec_anal and
+    *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_eq_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_src_spec
+
+    _definition.id                '_pd_instr.soller_eq_src_spec'
+    _alias.definition_id          '_pd_instr_soller_eq_src/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the radiation source
+    and monochromator.  Note that *_src_spec is used in place of
+    *_src_mono and *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_eq_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.source_size_ax
+
+    _definition.id                '_pd_instr.source_size_ax'
+    _alias.definition_id          '_pd_instr_source_size_ax'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Axial intrinsic dimension of the radiation source (in
+    millimetres).  The perpendicular to the plane containing the
+    incident and scattered beam is the axial (*_ax) direction.
+;
+    _name.category_id             pd_instr
+    _name.object_id               source_size_ax
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.source_size_eq
+
+    _definition.id                '_pd_instr.source_size_eq'
+    _alias.definition_id          '_pd_instr_source_size_eq'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Equatorial intrinsic dimension of the radiation source (in
+    millimetres).  The equatorial direction is in the plane
+    containing the incident and scattered beam.
+;
+    _name.category_id             pd_instr
+    _name.object_id               source_size_eq
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.special_details
+
+    _definition.id                '_pd_instr.special_details'
+    _alias.definition_id          '_pd_instr_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A brief description of the instrument giving
+    details that cannot be given in other
+    _pd_instr. entries.
+;
+    _name.category_id             pd_instr
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_INSTR_DETECTOR
+
+    _definition.id                PD_INSTR_DETECTOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-20
+    _description.text
+;
+    This section contains information relevant to the detector
+    geometry used for the diffraction measurement. For most laboratories,
+    very little of this information will change, so a standard file
+    may be prepared and included with each data set.
+
+    The term analyser refers to post-diffraction (post-specimen)
+    monochromator.  The analyser may be fixed for specific
+    wavelength or may be capable of being scanned.
+
+    For multiple-detector instruments it may be necessary to loop the
+    *_anal_detc or *_spec_detc values (for  _pd_instr.dist_,
+    _pd_instr.divg_, _pd_instr.slit_ and  _pd_instr.soller_) with
+    the detector ID's (_pd_instr_detector.id).
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_INSTR_DETECTOR
+    _category_key.name            '_pd_instr_detector.id'
+
+save_
+
+save_pd_instr.2theta_monochr_post
+
+    _definition.id                '_pd_instr.2theta_monochr_post'
+    _alias.definition_id          '_pd_instr_2theta_monochr_post'
+    _definition.update            2016-10-20
+    _description.text
+;
+    The 2\\q angle for a post-specimen
+    monochromator (also called an analyzer)
+    (see also _pd_instr.monochr_post_spec).
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               2theta_monochr_post
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.dist_anal_detc
+
+    _definition.id                '_pd_instr.dist_anal_detc'
+    _alias.definition_id          '_pd_instr_dist_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Specifies the distance in millimetres from the analyser to the detector.
+    Note that *_spec_detc is used in place of *_anal_detc
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               dist_anal_detc
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_spec_anal
+
+    _definition.id                '_pd_instr.dist_spec_anal'
+    _alias.definition_id          '_pd_instr_dist_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Specifies distances in millimetres from the specimen to the
+    analyser.  Note that *_spec_detc is used in place of *_spec_anal
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               dist_spec_anal
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_spec_detc
+
+    _definition.id                '_pd_instr.dist_spec_detc'
+    _alias.definition_id          '_pd_instr_dist_spec/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Specifies distance in millimetres from the specimen to the
+    detector.  Note that *_spec_anal and *_anal_detc are used
+    instead of *_spec_detc if there is an analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               dist_spec_detc
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.divg_ax_anal_detc
+
+    _definition.id                '_pd_instr.divg_ax_anal_detc'
+    _alias.definition_id          '_pd_instr_divg_ax_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) between
+    the analyser and the detector. Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr.soller_ax_): Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_ax_anal_detc
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_ax_spec_anal
+
+    _definition.id                '_pd_instr.divg_ax_spec_anal'
+    _alias.definition_id          '_pd_instr_divg_ax_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) between the specimen and the analyser.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_).
+    Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_ax_spec_anal
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_ax_spec_detc
+
+    _definition.id                '_pd_instr.divg_ax_spec_detc'
+    _alias.definition_id          '_pd_instr_divg_ax_spec/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) between the specimen and the detector.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_).
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_ax_spec_detc
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_anal_detc
+
+    _definition.id                '_pd_instr.divg_eq_anal_detc'
+    _alias.definition_id          '_pd_instr_divg_eq_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    analyser and the detector.  Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr.soller_eq_).  Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_eq_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_spec_anal
+
+    _definition.id                '_pd_instr.divg_eq_spec_anal'
+    _alias.definition_id          '_pd_instr_divg_eq_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    specimen and the analyser.  Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr_soller_eq_). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_eq_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_spec_detc
+
+    _definition.id                '_pd_instr.divg_eq_spec_detc'
+    _alias.definition_id          '_pd_instr_divg_eq_spec/detc'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    specimen and the detector. Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr_soller_eq_): *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_eq_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.monochr_post_spec
+
+    _definition.id                '_pd_instr.monochr_post_spec'
+    _alias.definition_id          '_pd_instr_monochr_post_spec'
+    _definition.update            2014-10-20
+    _description.text
+;
+    Indicates the method used to obtain monochromatic radiation.
+    Use _pd_instr_monochr_pre_spec to describe the primary beam
+    monochromator (pre-specimen monochromation). Use
+    _pd_instr_monochr_post_spec to specify the
+    post-diffraction analyser (post-specimen monochromation).
+
+    When a monochromator crystal is used, the material and the
+    indices of the Bragg reflection are specified.
+
+    Note that monochromators may have either 'parallel' or
+    'antiparallel' orientation. It is assumed that the
+    geometry is parallel unless specified otherwise.
+    In a parallel geometry, the position of the monochromator
+    allows the incident beam and the final post-specimen
+    and post-monochromator beam to be as close to parallel
+    as possible. In a parallel geometry, the diffracting
+    planes in the specimen and monochromator will be parallel
+    when 2\\q~monochromator~ is equal to 2\\q~specimen~.\
+    For further discussion see R. Jenkins & R. Snyder (1996).
+    Introduction to X-ray Powder Diffraction,
+    pp. 164-165. New York: Wiley.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               monochr_post_spec
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
     loop_
-      _alias.definition_id
-          '_pd_spec_special_details' 
-    _description.text                   
-;
+      _description_example.case
+         'Zr filter'
+         'Ge 220'
+         'none'
+         'equatorial mounted graphite (0001)'
+         'Si (111), antiparallel'
 
-      Descriptive information about the specimen that cannot be
-      included in other data items.
+save_
+
+save_pd_instr.slit_ax_anal_detc
+
+    _definition.id                '_pd_instr.slit_ax_anal_detc'
+    _alias.definition_id          '_pd_instr_slit_ax_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
 ;
-    _name.category_id            pd_spec
-    _name.object_id              special_details
-    _type.purpose                Describe
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Text
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the analyser and the detector.  Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_ax_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_ax_spec_anal
+
+    _definition.id                '_pd_instr.slit_ax_spec_anal'
+    _alias.definition_id          '_pd_instr_slit_ax_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the specimen and the analyser.  Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_ax_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_ax_spec_detc
+
+    _definition.id                '_pd_instr.slit_ax_spec_detc'
+    _alias.definition_id          '_pd_instr_slit_ax_spec/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    Collimation between the specimen and the detector.  Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_ax_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_anal_detc
+
+    _definition.id                '_pd_instr.slit_eq_anal_detc'
+    _alias.definition_id          '_pd_instr_slit_eq_anal/detc'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the instrument
+    as a slit width (as opposed to a divergence angle).  Values are
+    the width of the slit (in millimetres) defining Ollimation
+    between the analyser and the detector.  Note that *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_eq_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_spec_anal
+
+    _definition.id                '_pd_instr.slit_eq_spec_anal'
+    _alias.definition_id          '_pd_instr_slit_eq_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the instrument
+    as a slit width (as opposed to a divergence angle).  Values are
+    the width of the slit (in millimetres) defining Collimation
+    between the specimen and the analyser.  Note that *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_eq_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_spec_detc
+
+    _definition.id                '_pd_instr.slit_eq_spec_detc'
+    _alias.definition_id          '_pd_instr_slit_eq_spec/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the instrument
+    as a slit width (as opposed to a divergence angle).  Values are
+    the width of the slit (in millimetres) defining Collimation
+    between the specimen and the detector.  Note that *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_eq_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.soller_ax_anal_detc
+
+    _definition.id                '_pd_instr.soller_ax_anal_detc'
+    _alias.definition_id          '_pd_instr_soller_ax_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument.  Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the analyser
+    and the detector.  Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_ax_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_spec_anal
+
+    _definition.id                '_pd_instr.soller_ax_spec_anal'
+    _alias.definition_id          '_pd_instr_soller_ax_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument.  Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the specimen
+    and the analyser; Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_ax_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_spec_detc
+
+    _definition.id                '_pd_instr.soller_ax_spec_detc'
+    _alias.definition_id          '_pd_instr_soller_ax_spec/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument.  Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the specimen
+    and the detector.  Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_ax_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_anal_detc
+
+    _definition.id                '_pd_instr.soller_eq_anal_detc'
+    _alias.definition_id          '_pd_instr_soller_eq_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the analyser and the
+    detector; Note that *_spec_detc is used in place of *_spec_anal
+    and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_eq_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_spec_anal
+
+    _definition.id                '_pd_instr.soller_eq_spec_anal'
+    _alias.definition_id          '_pd_instr_soller_eq_spec/anal'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the specimen and the
+    analyser.  Note that *_spec_detc is used in place of *_spec_anal
+    and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_eq_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_spec_detc
+
+    _definition.id                '_pd_instr.soller_eq_spec_detc'
+    _alias.definition_id          '_pd_instr_soller_eq_spec/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the specimen and the
+    detectoomator in use, and *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analys er in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_eq_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr_detector.id
+
+    _definition.id                '_pd_instr_detector.id'
+    _definition.update            2016-10-20
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which individual instrument geometry is being
+    defined. Note that this code should match the code name used for
+    _pd_meas.detector_id.  Where a single detector is used, this
+    may be omitted.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               id
+    _name.linked_object_id        '_pd_meas.detector_id'
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_MEAS_INFO_AUTHOR
+
+    _definition.id                PD_MEAS_INFO_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-18
+    _description.text
+;
+    This section contains information about the person(s)
+    who conducted the measurement.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_MEAS_INFO_AUTHOR
+    _category_key.name            '_pd_meas_info_author.name'
+
+save_
+
+save_pd_meas_info_author.address
+
+    _definition.id                '_pd_meas_info_author.address'
+    _alias.definition_id          '_pd_meas_info_author_address'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The address of the person who measured the data set. If there
+    is more than one person, this will be looped with
+    _pd_meas_info.author_name.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.email
+
+    _definition.id                '_pd_meas_info_author.email'
+    _alias.definition_id          '_pd_meas_info_author_email'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The e-mail address of the person who measured the data set. If
+    there is more than one person, this will be looped with
+    _pd_meas_info_author_name.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               email
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.fax
+
+    _definition.id                '_pd_meas_info_author.fax'
+    _alias.definition_id          '_pd_meas_info_author_fax'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The fax number of the person who measured the data set. If
+    there is more than one person, this will be looped with
+    _pd_meas_info_author_name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               fax
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.name
+
+    _definition.id                '_pd_meas_info_author.name'
+    _alias.definition_id          '_pd_meas_info_author_name'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The name of the person who measured the data set. The family
+    name(s), followed by a comma and including any dynastic
+    components, precedes the first name(s) or initial(s).
+    For more than one person use a loop to specify multiple values.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.phone
+
+    _definition.id                '_pd_meas_info_author.phone'
+    _alias.definition_id          '_pd_meas_info_author_phone'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The telephone number of the person who measured the data set.
+    If there is more than one person, this will be looped with
+    _pd_meas_info_author.name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               phone
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_MEAS_OVERALL
+
+    _definition.id                PD_MEAS_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-18
+    _description.text
+;
+    This section contains information about the conditions used for
+    the measurement of the diffraction data set, prior to processing
+    and application of correction terms. While additional
+    information may be added to the CIF as data are processed and
+    transported between laboratories (possibly with the addition of
+    a new _pd_block_id entry), the information in this section of
+    the CIF will rarely be changed once data collection is complete.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_MEAS_OVERALL
+
+save_
+
+save_pd_meas.2theta_fixed
+
+    _definition.id                '_pd_meas.2theta_fixed'
+    _alias.definition_id          '_pd_meas_2theta_fixed'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The 2\\q diffraction angle in degrees for measurements\
+    in a white-beam fixed-angle experiment. For measurements
+    where 2\\q is scanned, see _pd_meas.2theta_scan or
+    _pd_meas.2theta_range_*.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_fixed
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+
+save_
+
+save_pd_meas.2theta_range_inc
+
+    _definition.id                '_pd_meas.2theta_range_inc'
+    _alias.definition_id          '_pd_meas_2theta_range_inc'
+    _definition.update            2014-06-20
+    _description.text
+;
+    2\\q diffraction angle increment in degrees used for the
+    measurement of intensities. These may be used in place of the
+    _pd_meas.2theta_scan values for data sets measured with a
+    constant step size.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_range_inc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.2theta_range_max
+
+    _definition.id                '_pd_meas.2theta_range_max'
+    _alias.definition_id          '_pd_meas_2theta_range_max'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Maximum 2\\q diffraction angle in degrees used for the
+    measurement of intensities. These may be used in place of the
+    _pd_meas.2theta_scan values for data sets measured with a
+    constant step size.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_range_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.2theta_range_min
+
+    _definition.id                '_pd_meas.2theta_range_min'
+    _alias.definition_id          '_pd_meas_2theta_range_min'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Minimum 2\\q diffraction angle in degrees used for the
+    measurement of intensities. These may be used in place of the
+    _pd_meas.2theta_scan values for data sets measured with a
+    constant step size.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_range_min
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.angle_chi
+
+    _definition.id                '_pd_meas.angle_chi'
+    _alias.definition_id          '_pd_meas_angle_chi'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The diffractometer angle in degrees for an instrument with a
+    Euler circle. The definitions for these angles follow the
+    convention of International Tables for X-ray Crystallography
+    (1974), Vol. IV, p. 276.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_chi
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+
+save_
+
+save_pd_meas.angle_omega
+
+    _definition.id                '_pd_meas.angle_omega'
+    _alias.definition_id          '_pd_meas_angle_omega'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The diffractometer angle in degrees for an instrument with a
+    Euler circle. The definitions for these angles follow the
+    convention of International Tables for X-ray Crystallography
+    (1974), Vol. IV, p. 276.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_omega
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+
+save_
+
+save_pd_meas.angle_phi
+
+    _definition.id                '_pd_meas.angle_phi'
+    _alias.definition_id          '_pd_meas_angle_phi'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The diffractometer angle in degrees for an instrument with a
+    Euler circle. The definitions for these angles follow the
+    convention of International Tables for X-ray Crystallography
+    (1974), Vol. IV, p. 276.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_phi
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+
+save_
+
+save_pd_meas.datetime_initiated
+
+    _definition.id                '_pd_meas.datetime_initiated'
+    _alias.definition_id          '_pd_meas_datetime_initiated'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The date and time of the data-set measurement.
+    Entries should follow the standard RFC 3339 ABNF format
+    'yyyy-mm-ddThh:mm{:ss}{Z|[+-]zz:zz}'. Use of seconds and
+    a time zone offset is optional, but use of hours and
+    minutes is strongly encouraged. Where possible, give the
+    time when the measurement was started, rather than when
+    it was completed.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               datetime_initiated
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                DateTime
+
+    loop_
+      _description_example.case
+         1990-07-13T14:40
+         2042-12-13T02:37:23Z
+         2005-03-03T12:02:09.17+09:30
+         2015-10-30T22:45-02:00
+         1912-02-03T11:47Z
+         1979-09-01
+
+save_
+
+save_pd_meas.number_of_points
+
+    _definition.id                '_pd_meas.number_of_points'
+    _alias.definition_id          '_pd_meas_number_of_points'
+    _definition.update            2019-09-25
+    _description.text
+;
+    Total number of points in the measured diffractogram.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               number_of_points
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+
+save_
+
+save_pd_meas.rocking_angle
+
+    _definition.id                '_pd_meas.rocking_angle'
+    _alias.definition_id          '_pd_meas_rocking_angle'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The angular range in degrees through which a sample
+    is rotated or oscillated during a measurement step
+    (see _pd_meas.rocking_axis).
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               rocking_angle
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.rocking_axis
+
+    _definition.id                '_pd_meas.rocking_axis'
+    _alias.definition_id          '_pd_meas_rocking_axis'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The axis (or axes) used to rotate or rock the
+    specimen for better randomization of crystallites
+    (see _pd_meas.rocking_angle).
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               rocking_axis
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         chi
+         omega
+         phi
+
+save_
+
+save_pd_meas.scan_method
+
+    _definition.id                '_pd_meas.scan_method'
+    _alias.definition_id          '_pd_meas_scan_method'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Code identifying the method for scanning reciprocal space.
+    The designation `fixed' should be used for measurements where
+    film, a stationary position-sensitive or area detector
+    or other non-moving detection mechanism is used to
+    measure diffraction intensities.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               scan_method
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         step                     'step scan'
+         cont                     'continuous scan'
+         tof                      'time of flight'
+         disp                     'energy dispersive'
+         fixed                    'stationary detector'
+
+save_
+
+save_pd_meas.special_details
+
+    _definition.id                '_pd_meas.special_details'
+    _alias.definition_id          '_pd_meas_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Special details of the diffraction measurement process.
+    Include information about source instability, degradation etc.
+    However, this item should not be used to record information
+    that can be specified in other pd_meas entries.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas.units_of_intensity
+
+    _definition.id                '_pd_meas.units_of_intensity'
+    _alias.definition_id          '_pd_meas_units_of_intensity'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Units for intensity measurements when _pd_meas.intensity_*
+    is used. Note that use of 'counts' or 'counts per second'
+    here is strongly discouraged: convert the intensity
+    measurements to counts and use _pd_meas.counts_* and
+    _pd_meas.step_count_time instead of _pd_meas.intensity_*.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               units_of_intensity
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'estimated from strip chart'
+         'arbitrary, from film density'
+         'counts, with automatic dead-time correction applied'
+
+save_
+
+save_PD_PEAK
+
+    _definition.id                PD_PEAK
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2014-06-20
+    _description.text
+;
+    This section contains peak information extracted from the
+    measured or, if present, the processed diffractogram. Each
+    peak in this table will have a unique label (see _pd_peak_id).
+    The reflections and phases associated with each peak will be
+    specified in other sections (see the _pd_refln_ and
+    _pd_phase_ sections).
+
+    Note that peak positions are customarily determined from the
+    processed diffractogram and thus corrections for position
+    and intensity will have been previously applied.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PEAK
+    _category_key.name            '_pd_peak.id'
+
+save_
+
+save_pd_peak.2theta_centroid
+
+    _definition.id                '_pd_peak.2theta_centroid'
+    _alias.definition_id          '_pd_peak_2theta_centroid'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Position of the centroid of a peak as a 2\\q angle.
+;
+    _name.category_id             pd_peak
+    _name.object_id               2theta_centroid
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_peak.2theta_maximum
+
+    _definition.id                '_pd_peak.2theta_maximum'
+    _alias.definition_id          '_pd_peak_2theta_maximum'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Position of the maximum of a peak as a 2\\q angle.
+;
+    _name.category_id             pd_peak
+    _name.object_id               2theta_maximum
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_peak.d_spacing
+
+    _definition.id                '_pd_peak.d_spacing'
+    _alias.definition_id          '_pd_peak_d_spacing'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Peak position as a d-spacing in angstroms.
+;
+    _name.category_id             pd_peak
+    _name.object_id               d_spacing
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_pd_peak.id
+
+    _definition.id                '_pd_peak.id'
+    _alias.definition_id          '_pd_peak_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    An arbitrary code is assigned to each peak. Used to link with
+    _pd_refln_peak_id so that multiple hkl and/or phase
+    identifications can be assigned to a single peak.
+    Each peak will have a unique code. In cases
+    where two peaks are severely overlapped, it may be
+    desirable to list them as a single peak.
+
+    A peak ID must be included for every peak.
+;
+    _name.category_id             pd_peak
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_peak.intensity
+
+    _definition.id                '_pd_peak.intensity'
+    _alias.definition_id          '_pd_peak_intensity'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Integrated area for the peak, with the same scaling as
+    the _pd_proc_intensity_ values. It is good practice to
+    include s.u.'s for these values.
+;
+    _name.category_id             pd_peak
+    _name.object_id               intensity
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_peak.pk_height
+
+    _definition.id                '_pd_peak.pk_height'
+    _alias.definition_id          '_pd_peak_pk_height'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The maximum intensity of the peak, either extrapolated
+    or the highest observed intensity value. The same
+    scaling is used for the _pd_proc_intensity_ values.
+    It is good practice to include s.u.'s for these values.
+;
+    _name.category_id             pd_peak
+    _name.object_id               pk_height
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_peak.wavelength_id
+
+    _definition.id                '_pd_peak.wavelength_id'
+    _alias.definition_id          '_pd_peak_wavelength_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Code identifying the wavelength appropriate for this peak
+    from the wavelengths in the _diffrn_radiation_ list.
+    (See _diffrn_radiation_wavelength_id.) Most commonly used
+    to distinguish K\\a~1~ peaks from K\\a~2~ or to designate
+    where K\\a~1~ and K\\a~2~ peaks cannot be resolved. For
+    complex peak tables with multiple superimposed peaks,
+    specify wavelengths in the reflection table using
+    _pd_refln_wavelength_id rather than identifying peaks by
+    wavelength.
+;
+    _name.category_id             pd_peak
+    _name.object_id               wavelength_id
+    _name.linked_item_id          '_diffrn_radiation_wavelength.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_peak.width_2theta
+
+    _definition.id                '_pd_peak.width_2theta'
+    _alias.definition_id          '_pd_peak_width_2theta'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Peak width as full-width at half-maximum expressed as
+    a 2\\q value in degrees.
+;
+    _name.category_id             pd_peak
+    _name.object_id               width_2theta
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_peak.width_d_spacing
+
+    _definition.id                '_pd_peak.width_d_spacing'
+    _alias.definition_id          '_pd_peak_width_d_spacing'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Peak width as full-width at half-maximum expressed as
+    a d-spacing in angstroms.
+;
+    _name.category_id             pd_peak
+    _name.object_id               width_d_spacing
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_PD_PEAK_OVERALL
+
+    _definition.id                PD_PEAK_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-18
+    _description.text
+;
+    This category describes general aspects of the peak extraction
+    process.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PEAK_OVERALL
+
+save_
+
+save_pd_peak.special_details
+
+    _definition.id                '_pd_peak.special_details'
+    _alias.definition_id          '_pd_peak_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Detailed description of any non-routine processing steps
+    used for peak determination or other comments
+    related to the peak table that cannot be given elsewhere.
+;
+    _name.category_id             pd_peak_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
 save_PD_PHASE
 
-    _definition.id               PD_PHASE
-    _definition.scope            Category
-    _definition.class            Loop
-    _definition.update           2016-11-09
-    _description.text                   
+    _definition.id                PD_PHASE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-11-09
+    _description.text
 ;
+    This section contains a description of the crystalline phases
+    contributing to the powder diffraction data set. Note that if
+    multiple-phase Rietveld or other structural analysis is
+    performed, the structural results will be placed in different
+    data blocks, using CIF entries from the core CIF dictionary.
 
-      This section contains a description of the crystalline phases
-      contributing to the powder diffraction data set. Note that if
-      multiple-phase Rietveld or other structural analysis is
-      performed, the structural results will be placed in different
-      data blocks, using CIF entries from the core CIF dictionary.
- 
-      The _pd_phase.block_id entry points to the CIF block with
-      structural parameters for each crystalline phase. The
-      _pd_phase_id serves to link to _pd_refln.phase_id, which is
-      used to label peaks by phase.
+    The _pd_phase.block_id entry points to the CIF block with
+    structural parameters for each crystalline phase. The
+    _pd_phase_id serves to link to _pd_refln.phase_id, which is
+    used to label peaks by phase.
 ;
-    _name.category_id            PD_GROUP
-    _name.object_id              PD_PHASE
-    loop_
-    _category_key.name           '_pd_phase.id'
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE
+    _category_key.name            '_pd_phase.id'
 
 save_
 
+save_pd_phase.block_id
 
-save__pd_phase.block_id
-
-    _definition.id               '_pd_phase.block_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_phase_block_id' 
-    _description.text                   
+    _definition.id                '_pd_phase.block_id'
+    _alias.definition_id          '_pd_phase_block_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      A block ID code identifying the phase contributing to
-      the diffraction peak. The data block containing the
-      crystallographic information for this phase will be
-      identified with a _pd_block.id code matching the
-      code in _pd_phase.block_id.
+    A block ID code identifying the phase contributing to
+    the diffraction peak. The data block containing the
+    crystallographic information for this phase will be
+    identified with a _pd_block.id code matching the
+    code in _pd_phase.block_id.
 ;
-    _name.category_id            pd_phase
-    _name.object_id              block_id
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             pd_phase
+    _name.object_id               block_id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
-save__pd_phase.id
+save_pd_phase.id
 
-    _definition.id               '_pd_phase.id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_phase_id' 
-    _description.text                   
+    _definition.id                '_pd_phase.id'
+    _alias.definition_id          '_pd_phase_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
-
-      A code for each crystal phase used to link with
-      _pd_refln.phase_id.
+    A code for each crystal phase used to link with
+    _pd_refln.phase_id.
 ;
-    _name.category_id            pd_phase
-    _name.object_id              id
-    _name.linked_item_id         '_pd_refln.phase_id'
-    _type.purpose                Link
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
-    _enumeration.default         '.'
+    _name.category_id             pd_phase
+    _name.object_id               id
+    _name.linked_item_id          '_pd_refln.phase_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          '.'
 
 save_
 
-save__pd_phase.mass_percent
+save_pd_phase.mass_percent
 
-    _definition.id               '_pd_phase.mass_percent'
-    _definition.update           2014-06-20
+    _definition.id                '_pd_phase.mass_percent'
+
     loop_
       _alias.definition_id
-          '_pd_phase_mass_percent'     
-          '_pd_phase_mass_%' 
-    _description.text                   
-;
+         '_pd_phase_mass_percent'
+         '_pd_phase_mass_%'
 
-      Per cent composition of the specified crystal phase
-      expressed as the total mass of the component
-      with respect to the total mass of the specimen.
+    _definition.update            2014-06-20
+    _description.text
 ;
-    _name.category_id            pd_phase
-    _name.object_id              mass_percent
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:100.0
+    Per cent composition of the specified crystal phase
+    expressed as the total mass of the component
+    with respect to the total mass of the specimen.
+;
+    _name.category_id             pd_phase
+    _name.object_id               mass_percent
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
 
 save_
 
-save__pd_phase.name
+save_pd_phase.name
 
-    _definition.id               '_pd_phase.name'
-    _definition.update           2014-06-20
+    _definition.id                '_pd_phase.name'
+    _alias.definition_id          '_pd_phase_name'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The name of the crystal phase.
+    It may be designated as unknown or by a structure type etc.
+;
+    _name.category_id             pd_phase
+    _name.object_id               name
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_PREP
+
+    _definition.id                PD_PREP
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2014-06-20
+    _description.text
+;
+    This section contains descriptive information about how the
+    sample was prepared.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PREP
+
+save_
+
+save_pd_prep.conditions
+
+    _definition.id                '_pd_prep.conditions'
+    _alias.definition_id          '_pd_prep_conditions'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of how the material was prepared
+    (reaction conditions etc.)
+;
+    _name.category_id             pd_prep
+    _name.object_id               conditions
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_prep.cool_rate
+
+    _definition.id                '_pd_prep.cool_rate'
+    _alias.definition_id          '_pd_prep_cool_rate'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Cooling rate in kelvins per minute for samples prepared
+    at high temperatures. If the cooling rate is not linear
+    or is unknown (e.g. quenched samples), it should be
+    described in _pd_prep_conditions instead.
+;
+    _name.category_id             pd_prep
+    _name.object_id               cool_rate
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins_per_minute
+
+save_
+
+save_pd_prep.pressure
+
+    _definition.id                '_pd_prep.pressure'
+    _alias.definition_id          '_pd_prep_pressure'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Preparation pressure of the sample in kilopascals. This
+    is particularly important for materials which are metastable
+    at the measurement pressure, _diffrn_ambient_pressure.
+;
+    _name.category_id             pd_prep
+    _name.object_id               pressure
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_pd_prep.temperature
+
+    _definition.id                '_pd_prep.temperature'
+    _alias.definition_id          '_pd_prep_temperature'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Preparation temperature of the sample in kelvins. This is
+    particularly important for materials which are metastable
+    at the measurement temperature, _diffrn.ambient_temperature.
+;
+    _name.category_id             pd_prep
+    _name.object_id               temperature
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_PD_PROC_INFO_AUTHOR
+
+    _definition.id                PD_PROC_INFO_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-10-18
+    _description.text
+;
+    This section contains information about the person(s)
+    who processed the data.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PROC_INFO_AUTHOR
+    _category_key.name            '_pd_proc_info_author.name'
+
+save_
+
+save_pd_proc_info_author.address
+
+    _definition.id                '_pd_proc_info_author.address'
+    _alias.definition_id          '_pd_proc_info_author_address'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The address of the person who processed the data.
+    If there is more than one person, this will be looped with
+    _pd_proc_info_author_name.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.email
+
+    _definition.id                '_pd_proc_info_author.email'
+    _alias.definition_id          '_pd_proc_info_author_email'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The e-mail address of the person who processed the
+    data.  If there is more than one person, this will be looped
+    with _pd_proc_info_author_name.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               email
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.fax
+
+    _definition.id                '_pd_proc_info_author.fax'
+    _alias.definition_id          '_pd_proc_info_author_fax'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The fax number of the person who processed the data.
+    If there is more than one person, this will be looped with
+    _pd_proc_info_author_name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               fax
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.name
+
+    _definition.id                '_pd_proc_info_author.name'
+    _alias.definition_id          '_pd_proc_info_author_name'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The name of the person who processed the data, if different
+    from the person(s) who measured the data set. The family
+    name(s), followed by a comma and including any dynastic
+    components, precedes the first name(s) or initial(s). For
+    more than one person use a loop to specify multiple values.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.phone
+
+    _definition.id                '_pd_proc_info_author.phone'
+    _alias.definition_id          '_pd_proc_info_author_phone'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The telephone number of the person who processed the data.
+    If there is more than one person, this will be looped
+    with _pd_proc_info_author_name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               phone
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PROC_LS
+
+    _definition.id                PD_PROC_LS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2014-06-20
+    _description.text
+;
+    This section is used to define parameters relevant to a
+    least-squares fit to a powder diffractogram, using a Rietveld
+    or other full-profile (e.g. Pawley or Le Bail methods) fit.
+
+    Note that values in this section refer to full-pattern fitting.
+    Use the appropriate items for single-crystal analyses from the
+    core CIF dictionary for structure refinements using diffraction
+    intensities estimated from a powder diffractogram by
+    pattern-decomposition methods. Also note that many entries in
+    the core _refine_ls_ entries may also be useful (for example
+    _refine_ls_shift/su_*).
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PROC_LS
+
+save_
+
+save_pd_proc_ls.background_function
+
+    _definition.id                '_pd_proc_ls.background_function'
+    _alias.definition_id          '_pd_proc_ls_background_function'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the background treatment mechanism used to
+    fit the data set.
+
+    For refinements where the background is computed as a
+    function that is fitted to minimize the difference between
+    the observed and calculated patterns, it is
+    recommended that in addition to a description of the
+    function (e.g. Chebychev polynomial), the actual equation(s)
+    used are included in TeX, or a programming language such
+    as Fortran or C. Include also the values used for the
+    coefficients used in the background function with their
+    s.u.'s. The background values for each data point
+    computed from the function should be specified in
+    _pd_proc_intensity_bkg_calc.
+
+    If background correction is performed using extrapolation
+    from a set of points at fixed locations, these points
+    should be defined using _pd_proc_intensity_bkg_fix, and
+    _pd_proc_ls_background_function should indicate the
+    extrapolation method (linear extrapolation, spline etc.).
+    _pd_proc_ls_background_function should also indicate how the
+    points were determined (automatically, by visual estimation
+    etc.) and whether the values were refined to improve the
+    agreement. The extrapolated background intensity value for
+    each data point should be specified in
+    _pd_proc_intensity_bkg_calc.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               background_function
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.peak_cutoff
+
+    _definition.id                '_pd_proc_ls.peak_cutoff'
+    _alias.definition_id          '_pd_proc_ls_peak_cutoff'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes where peak-intensity computation is
+    discontinued as a fraction of the intensity of the
+    peak at maximum. Thus for a value of 0.005, the
+    tails of a diffraction peak are neglected
+    after the intensity has dropped below 0.5% of the
+    diffraction intensity at the maximum.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               peak_cutoff
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.pref_orient_corr
+
+    _definition.id                '_pd_proc_ls.pref_orient_corr'
+    _alias.definition_id          '_pd_proc_ls_pref_orient_corr'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the preferred-orientation correction if
+    such a correction is used. Omitting this entry
+    implies that no preferred-orientation correction
+    has been used. If a function form is used, it is
+    recommended that the actual equation in TeX, or a
+    programming language, is used to specify the function as
+    well as a giving a description. Include the value(s) used
+    for the correction with s.u.'s.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pref_orient_corr
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.prof_r_factor
+
+    _definition.id                '_pd_proc_ls.prof_R_factor'
+    _alias.definition_id          '_pd_proc_ls_prof_R_factor'
+    _definition.update            2014-06-20
+    _description.text
+;
+    _pd_proc_ls.prof_R_factor, often called R~p~, is an
+      unweighted fitness metric for the agreement between the
+      observed and computed diffraction patterns.
+         R~p~ = sum~i~ | I~obs~(i) - I~calc~(i) |
+                / sum~i~ ( I~obs~(i) )
+      Note that in the above equations,
+         w(i) is the weight for the ith data point (see
+              _pd_proc_ls_weight).
+         I~obs~(i) is the observed intensity for the ith data
+              point, sometimes referred to as y~i~(obs) or
+              y~oi~. (See _pd_meas_counts_total,
+              _pd_meas_intensity_total or _pd_proc_intensity_total.)
+         I~calc~(i) is the computed intensity for the ith data
+              point with background and other corrections
+              applied to match the scale of the observed data set,
+              sometimes referred to as y~i~(calc) or
+              y~ci~. (See _pd_calc_intensity_total.)
+         n is the total number of data points (see
+              _pd_proc_number_of_points) less the number of
+              data points excluded from the refinement.
+         p is the total number of refined parameters.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pd_proc_ls_prof_R_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_proc_ls.prof_wr_expected
+
+    _definition.id                '_pd_proc_ls.prof_wR_expected'
+    _alias.definition_id          '_pd_proc_ls_prof_wR_expected'
+    _definition.update            2014-06-20
+    _description.text
+;
+    _pd_proc_ls.prof_wR_expected, sometimes called the
+      theoretical R~wp~ or R~exp~, is a weighted fitness metric for
+      the statistical precision of the data set. For an idealized fit,
+      where all deviations between the observed intensities and
+      those computed from the model are due to statistical
+      fluctuations, the observed R~wp~ should match the expected
+      R factor. In reality, R~wp~ will always be higher than
+      R~exp~.
+        R~exp~ = SQRT { (n - p)  / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }
+
+      Note that in the above equations,
+         w(i) is the weight for the ith data point (see
+              _pd_proc_ls_weight).
+         I~obs~(i) is the observed intensity for the ith data
+              point, sometimes referred to as y~i~(obs) or
+              y~oi~. (See _pd_meas_counts_total,
+              _pd_meas_intensity_total or _pd_proc_intensity_total.)
+         I~calc~(i) is the computed intensity for the ith data
+              point with background and other corrections
+              applied to match the scale of the observed data set,
+              sometimes referred to as y~i~(calc) or
+              y~ci~. (See _pd_calc_intensity_total.)
+         n is the total number of data points (see
+              _pd_proc_number_of_points) less the number of
+              data points excluded from the refinement.
+         p is the total number of refined parameters.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pd_proc_ls_prof_wR_expected
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_proc_ls.prof_wr_factor
+
+    _definition.id                '_pd_proc_ls.prof_wR_factor'
+    _alias.definition_id          '_pd_proc_ls_prof_wR_factor'
+    _definition.update            2014-06-20
+    _description.text
+;
+    _pd_proc_ls.prof_wR_factor, often called R~wp~, is a
+      weighted fitness metric for the agreement between the
+      observed and computed diffraction patterns.
+        R~wp~ = SQRT {\
+                 sum~i~ ( w(i) [ I~obs~(i) - I~calc~(i) ]^2^ )
+                 / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }\
+
+      Note that in the above equations,
+         w(i) is the weight for the ith data point (see
+              _pd_proc_ls_weight).
+         I~obs~(i) is the observed intensity for the ith data
+              point, sometimes referred to as y~i~(obs) or
+              y~oi~. (See _pd_meas_counts_total,
+              _pd_meas_intensity_total or _pd_proc_intensity_total.)
+         I~calc~(i) is the computed intensity for the ith data
+              point with background and other corrections
+              applied to match the scale of the observed data set,
+              sometimes referred to as y~i~(calc) or
+              y~ci~. (See _pd_calc_intensity_total.)
+         n is the total number of data points (see
+              _pd_proc_number_of_points) less the number of
+              data points excluded from the refinement.
+         p is the total number of refined parameters.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pd_proc_ls_prof_wR_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+
+save_
+
+save_pd_proc_ls.profile_function
+
+    _definition.id                '_pd_proc_ls.profile_function'
+    _alias.definition_id          '_pd_proc_ls_profile_function'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the profile function used to
+    fit the data set. If a function form is used, it is
+    recommended that the actual equation in TeX, or a
+    programming language, is used to specify the function as
+    well as giving a description. Include the values used
+    for the profile-function coefficients and their s.u.'s.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               profile_function
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.special_details
+
+    _definition.id                '_pd_proc_ls.special_details'
+    _alias.definition_id          '_pd_proc_ls_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Additional characterization information relevant to
+    non-routine steps used for refinement of a structural model
+    that cannot be specified elsewhere.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.weight
+
+    _definition.id                '_pd_proc_ls.weight'
+    _alias.definition_id          '_pd_proc_ls_weight'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Weight applied to each profile point. These values
+    may be omitted if the weights are 1/u^2^, where
+    u is the s.u. for the _pd_proc_intensity_net values.
+
+    A weight value of zero is used to indicate a data
+    point not used for refinement (see
+    _pd_proc_info_excluded_regions).
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               weight
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0:
+
+save_
+
+save_PD_PROC_OVERALL
+
+    _definition.id                PD_PROC_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-18
+    _description.text
+;
+    This section contains overall information about the diffraction
+    data set after processing and application of correction
+    terms. If the data set is reprocessed, this section may be
+    replaced (with the addition of a new _pd_block.id entry).
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PROC_OVERALL
+
+save_
+
+save_pd_proc.2theta_range_inc
+
+    _definition.id                '_pd_proc.2theta_range_inc'
+    _alias.definition_id          '_pd_proc_2theta_range_inc'
+    _definition.update            2021-11-12
+    _description.text
+;
+    The increment in 2\\q diffraction angles in degrees for the
+    measurement of intensities. These may be used in place of the
+    _pd_proc_2theta_corrected values, or in the case of white-beam
+    experiments it will define the fixed 2\\q value.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               2theta_range_inc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.2theta_range_max
+
+    _definition.id                '_pd_proc.2theta_range_max'
+    _alias.definition_id          '_pd_proc_2theta_range_max'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The maximum 2\\q diffraction angle in degrees for the
+    measurement of intensities. This may be used in place of the
+    _pd_proc_2theta_corrected values, or in the case of white-beam
+    experiments it will define the fixed 2\\q value together with
+    _pd_proc.2theta_range_min.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               2theta_range_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.2theta_range_min
+
+    _definition.id                '_pd_proc.2theta_range_min'
+    _alias.definition_id          '_pd_proc_2theta_range_min'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The minimum 2\\q diffraction angle in degrees for the
+    measurement of intensities. This may be used in place of the
+    _pd_proc_2theta_corrected values, or in the case of white-beam
+    experiments they will define the fixed 2\\q value together with
+    _pd_proc.2theta_range_max.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               2theta_range_min
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.info_data_reduction
+
+    _definition.id                '_pd_proc.info_data_reduction'
+    _alias.definition_id          '_pd_proc_info_data_reduction'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the processing steps applied in the data-reduction
+    process (background subtraction, \a-2 stripping, smoothing\
+    etc.). Include details of the program(s) used etc.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_data_reduction
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc.info_datetime
+
+    _definition.id                '_pd_proc.info_datetime'
+    _alias.definition_id          '_pd_proc_info_datetime'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Date(s) and time(s) when the data set was processed.
+    May be looped if multiple processing steps were used.
+
+    Entries should follow the standard RFC 3339 ABNF format
+    'yyyy-mm-ddThh:mm{:ss}{Z|[+-]zz:zz}'. Use of seconds and
+    a time zone offset is optional, but use of hours and
+    minutes is strongly encouraged.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_datetime
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                DateTime
+
     loop_
-      _alias.definition_id
-          '_pd_phase_name' 
-    _description.text                   
-;
+      _description_example.case
+         1990-07-13T14:40
+         2042-12-13T02:37:23Z
+         2005-03-03T12:02:09.17+09:30
+         2015-10-30T22:45-02:00
+         1912-02-03T11:47Z
+         1979-09-01
 
-      The name of the crystal phase.
-      It may be designated as unknown or by a structure type etc.
+save_
+
+save_pd_proc.info_excluded_regions
+
+    _definition.id                '_pd_proc.info_excluded_regions'
+    _alias.definition_id          '_pd_proc_info_excluded_regions'
+    _definition.update            2014-06-20
+    _description.text
 ;
-    _name.category_id            pd_phase
-    _name.object_id              name
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    Description of regions in the diffractogram excluded
+    from processing along with a justification of why the
+    data points were not used.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_excluded_regions
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     '20 to 21 degrees unreliable due to beam dump'
+
+save_
+
+save_pd_proc.info_special_details
+
+    _definition.id                '_pd_proc.info_special_details'
+    _alias.definition_id          '_pd_proc_info_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Detailed description of any non-routine processing steps
+    applied due to any irregularities in this particular data set.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc.number_of_points
+
+    _definition.id                '_pd_proc.number_of_points'
+    _alias.definition_id          '_pd_proc_number_of_points'
+    _definition.update            2019-09-25
+    _description.text
+;
+    The total number of data points in the processed diffractogram.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               number_of_points
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+
+save_
+
+save_PD_SPEC
+
+    _definition.id                PD_SPEC
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2014-06-20
+    _description.text
+;
+    This section contains information about the specimen used
+    for measurement of the diffraction data set. Note that
+    information about the sample (the batch of material from which
+    the specimen was obtained) is specified in _pd_prep_.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_SPEC
+
+save_
+
+save_pd_spec.description
+
+    _definition.id                '_pd_spec.description'
+    _alias.definition_id          '_pd_spec_description'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the specimen, such as the source of the
+    specimen, identification of standards, mixtures etc.
+;
+    _name.category_id             pd_spec
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_spec.mount_mode
+
+    _definition.id                '_pd_spec.mount_mode'
+    _alias.definition_id          '_pd_spec_mount_mode'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A code describing the beam path through the specimen.
+;
+    _name.category_id             pd_spec
+    _name.object_id               mount_mode
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         reflection
+         transmission
+
+save_
+
+save_pd_spec.mounting
+
+    _definition.id                '_pd_spec.mounting'
+    _alias.definition_id          '_pd_spec_mounting'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of how the specimen is mounted.
+;
+    _name.category_id             pd_spec
+    _name.object_id               mounting
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'vanadium can with He exchange gas'
+         'quartz capillary'
+         'packed powder pellet'
+         'drifted powder on off-cut Si'
+         'drifted powder on Kapton film'
+
+save_
+
+save_pd_spec.orientation
+
+    _definition.id                '_pd_spec.orientation'
+    _alias.definition_id          '_pd_spec_orientation'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The orientation of the \\w (\\q) and 2\\q axis.\
+    Note that this axis is parallel to the specimen axial axis
+    and perpendicular to the plane containing the incident and
+    scattered beams.
+
+    Thus for a horizontal orientation, scattering
+    measurements are made in a plane perpendicular to the
+    ground (the 2\\q axis is parallel to the ground);\
+    for vertical orientation, scattering measurements are
+    made in a plane parallel with the ground (the 2\\q axis\
+    is perpendicular to the ground). `Both' is appropriate for
+    experiments where measurements are made in both planes,
+    for example using two-dimensional detectors.
+;
+    _name.category_id             pd_spec
+    _name.object_id               orientation
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         horizontal
+         vertical
+         both
+
+save_
+
+save_pd_spec.preparation
+
+    _definition.id                '_pd_spec.preparation'
+    _alias.definition_id          '_pd_spec_preparation'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the preparation steps for producing the
+    diffraction specimen from the sample. Include any procedures
+    related to grinding, sieving, spray drying etc. For
+    information relevant to how the sample is synthesized, use
+    the _pd_prep_ entries.
+;
+    _name.category_id             pd_spec
+    _name.object_id               preparation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'wet grinding in acetone'
+         'sieved through a 44 micron (325 mesh/inch) sieve'
+         'spray dried in water with 1% clay'
+
+save_
+
+save_pd_spec.shape
+
+    _definition.id                '_pd_spec.shape'
+    _alias.definition_id          '_pd_spec_shape'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A code describing the specimen shape.
+;
+    _name.category_id             pd_spec
+    _name.object_id               shape
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         cylinder
+         flat_sheet
+         irregular
+
+save_
+
+save_pd_spec.size_axial
+
+    _definition.id                '_pd_spec.size_axial'
+    _alias.definition_id          '_pd_spec_size_axial'
+    _definition.update            2017-10-18
+    _description.text
+;
+    The size of the specimen in three mutually perpendicular
+    directions in millimetres.
+    The perpendicular to the plane containing the incident
+    and scattered beam is the *_axial direction.
+    In transmission geometry, the scattering vector is parallel
+    to *_equat and in reflection geometry the scattering vector is
+    parallel to *_thick.
+;
+    _name.category_id             pd_spec
+    _name.object_id               size_axial
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_spec.size_equat
+
+    _definition.id                '_pd_spec.size_equat'
+    _alias.definition_id          '_pd_spec_size_equat'
+    _definition.update            2017-10-18
+    _description.text
+;
+    The size of the specimen in three mutually perpendicular
+    directions in millimetres.
+    The perpendicular to the plane containing the incident
+    and scattered beam is the *_axial direction.
+    In transmission geometry, the scattering vector is parallel
+    to *_equat and in reflection geometry the scattering vector is
+    parallel to *_thick.
+;
+    _name.category_id             pd_spec
+    _name.object_id               size_equat
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_spec.size_thick
+
+    _definition.id                '_pd_spec.size_thick'
+    _alias.definition_id          '_pd_spec_size_thick'
+    _definition.update            2017-10-18
+    _description.text
+;
+    The size of the specimen in three mutually perpendicular
+    directions in millimetres.
+    The perpendicular to the plane containing the incident
+    and scattered beam is the *_axial direction.
+    In transmission geometry, the scattering vector is parallel
+    to *_equat and in reflection geometry the scattering vector is
+    parallel to *_thick.
+;
+    _name.category_id             pd_spec
+    _name.object_id               size_thick
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_spec.special_details
+
+    _definition.id                '_pd_spec.special_details'
+    _alias.definition_id          '_pd_spec_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Descriptive information about the specimen that cannot be
+    included in other data items.
+;
+    _name.category_id             pd_spec
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
 save_REFLN
 
-_definition.id                          REFLN
-_definition.scope                       Category
-_definition.class                       Loop
-_definition.update                      2016-11-09
-_description.text                       
+    _definition.id                REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-11-09
+    _description.text
 ;
-     The CATEGORY of data items used to describe the reflection data
-     used in the refinement of one or more crystallographic phases.
+    The CATEGORY of data items used to describe the reflection data
+    used in the refinement of one or more crystallographic phases.
 ;
-_name.category_id                       DIFFRACTION
-_name.object_id                         REFLN
-loop_
-  _category_key.name
-         '_refln.index_h'    
-         '_refln.index_k'    
+    _name.category_id             DIFFRACTION
+    _name.object_id               REFLN
+
+    loop_
+      _category_key.name
+         '_refln.index_h'
+         '_refln.index_k'
          '_refln.index_l'
          '_pd_refln.phase_id'
-save_
-
-save_refln.F_complex
-
-_definition.id                          '_refln.F_complex'
-loop_
-  _alias.definition_id
-         '_refln_F_complex' 
-_definition.update                      2017-03-07
-_description.text                       
-;
-     The structure factor vector for the reflection calculated from
-     the atom site data for the phase given by phase_id.
-;
-_name.category_id                       refln
-_name.object_id                         F_complex
-_type.purpose                           Measurand
-_type.source                            Derived
-_type.container                         Single
-_type.contents                          Complex
-_enumeration.default                    0.
-loop_
-  _method.purpose
-  _method.expression
-         Definition          
-;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
-;        
 
 save_
 
-save_refln.F_squared_meas
+save_pd_refln.peak_id
 
-_definition.id                          '_refln.F_squared_meas'
-loop_
-  _alias.definition_id  
-         '_refln_F_squared_meas' 
-_definition.update                      2017-03-22
-_description.text                       
+    _definition.id                '_pd_refln.peak_id'
+    _alias.definition_id          '_pd_refln_peak_id'
+    _definition.update            2014-06-20
+    _description.text
 ;
-     The structure factor amplitude for the reflection derived by partitioning
-     the background-subtracted observed intensity _pd_proc.intensity_net between
-     reflections in the same proportion as those reflections contribute to
-     the corresponding background-free calculated point in _pd_calc.intensity_net 
-
+    Code which identifies the powder diffraction peak that
+    contains the current reflection. This code must match a
+    _pd_peak.id code.
 ;
-_name.category_id                       refln
-_name.object_id                         F_squared_meas
-_type.purpose                           Measurand
-_type.source                            Derived
-_type.container                         Single
-_type.contents                          Real
-_enumeration.default                    0.
-loop_
-  _method.purpose
-  _method.expression
-         Definition          
-;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometre_squared"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volt_squared"
-    Else                                            _units.code =  "electron_squared"
-; 
+    _name.category_id             refln
+    _name.object_id               peak_id
+    _name.linked_item_id          '_pd_peak.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
 save_pd_refln.phase_id
 
-    _definition.id               '_pd_refln.phase_id'
-    _definition.update           2016-11-09
-    loop_
-      _alias.definition_id
-          '_pd_refln_phase_id' 
-    _description.text                   
+    _definition.id                '_pd_refln.phase_id'
+    _alias.definition_id          '_pd_refln_phase_id'
+    _definition.update            2016-11-09
+    _description.text
 ;
-      A code which identifies the particular phase to which
-      this reflection belongs.
+    A code which identifies the particular phase to which
+    this reflection belongs.
 ;
-    _name.category_id            refln
-    _name.object_id              phase_id
-    _name.linked_object_id       '_pd_phase.id'
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    _name.category_id             refln
+    _name.object_id               phase_id
+    _name.linked_object_id        '_pd_phase.id'
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
-save__pd_refln.peak_id
+save_refln.f_complex
 
-    _definition.id               '_pd_refln.peak_id'
-    _definition.update           2014-06-20
-    loop_
-      _alias.definition_id
-          '_pd_refln_peak_id' 
-    _description.text                   
+    _definition.id                '_refln.F_complex'
+    _alias.definition_id          '_refln_F_complex'
+    _definition.update            2017-03-07
+    _description.text
+;
+    The structure factor vector for the reflection calculated from
+    the atom site data for the phase given by phase_id.
+;
+    _name.category_id             refln
+    _name.object_id               F_complex
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Complex
+    _enumeration.default          0.
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
 ;
 
-      Code which identifies the powder diffraction peak that
-      contains the current reflection. This code must match a
-      _pd_peak.id code. 
+save_
+
+save_refln.f_squared_meas
+
+    _definition.id                '_refln.F_squared_meas'
+    _alias.definition_id          '_refln_F_squared_meas'
+    _definition.update            2017-03-22
+    _description.text
 ;
-    _name.category_id            refln
-    _name.object_id              peak_id
-    _name.linked_item_id         '_pd_peak.id'
-    _type.purpose                Link
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Code
+    The structure factor amplitude for the reflection derived by partitioning
+    the background-subtracted observed intensity _pd_proc.intensity_net between
+    reflections in the same proportion as those reflections contribute to
+    the corresponding background-free calculated point in _pd_calc.intensity_net
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.default          0.
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =
+    "femtometre_squared" Else If (_diffrn_radiation.probe == "electron")
+    _units.code =  "volt_squared" Else
+      _units.code =  "electron_squared"
+;
 
 save_
 
 save_refln.wavelength_id
 
-    _definition.id               '_refln.wavelength_id'
-    _definition.update           2021-12-06
+    _definition.id                '_refln.wavelength_id'
+
     loop_
       _alias.definition_id
-          '_refln_wavelength_id'
-          '_pd_refln.wavelength_id'
-          '_pd_refln_wavelength_id'
-    _description.text                   
+         '_refln_wavelength_id'
+         '_pd_refln.wavelength_id'
+         '_pd_refln_wavelength_id'
+
+    _definition.update            2021-12-06
+    _description.text
 ;
-      _pd_refln.wavelength_id is DEPRECATED. _refln.wavelength_id should
-      be used instead.
+    _pd_refln.wavelength_id is DEPRECATED. _refln.wavelength_id should
+    be used instead.
 ;
-    _name.category_id            refln
-    _name.object_id              wavelength_id
-    _name.linked_item_id         '_diffrn_radiation_wavelength.id'
-    _type.purpose                Link
-    _type.source                 Related
-    _type.container              Single
-    _type.contents               Word
+    _name.category_id             refln
+    _name.object_id               wavelength_id
+    _name.linked_item_id          '_diffrn_radiation_wavelength.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
-loop_
-  _dictionary_audit.version
-  _dictionary_audit.date
-  _dictionary_audit.revision
-         2.0.1    2014-06-20
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         2.0.1                    2014-06-20
 ;
-     Initial conversion to DDLm (Syd Hall)
+       Initial conversion to DDLm (Syd Hall)
 ;
-         2.0.2    2016-10-21
+         2.0.2                    2016-10-21
 ;
-     Substantial edits to conform to current DDLm, CIF2 syntax
-     and intended DDL1 usage (James Hester).
+       Substantial edits to conform to current DDLm, CIF2 syntax
+       and intended DDL1 usage (James Hester).
 ;
-         2.0.3    2016-11-03
+         2.0.3                    2016-11-03
 ;
-     Removed pd_refln category and pd_refln.phase_id, remaining
-     datanames assigned to core REFLN category (James Hester).
+       Removed pd_refln category and pd_refln.phase_id, remaining
+       datanames assigned to core REFLN category (James Hester).
 ;
-         2.1      2016-11-09
+         2.1                      2016-11-09
 ;
-     Changed PD_PHASE to Set category. Multiple phases are now
-     covered by an extension dictionary. (James Hester)
+       Changed PD_PHASE to Set category. Multiple phases are now
+       covered by an extension dictionary. (James Hester)
 ;
-         2.2      2016-11-12
+         2.2                      2016-11-12
 ;
-     Added _pd_calib_offset.detector_id to allow for per-detector
-     2 theta offsets (James Hester)
+       Added _pd_calib_offset.detector_id to allow for per-detector
+       2 theta offsets (James Hester)
 ;
-         2.3      2017-01-26
+         2.3                      2017-01-26
 ;
-     Returned pd_phase and pd_refln.phase_id to dictionary after
-     acceptance of _dictionary.formalism mechanism. Set
-     _dictionary.formalism to 'powder'.
+       Returned pd_phase and pd_refln.phase_id to dictionary after
+       acceptance of _dictionary.formalism mechanism. Set
+       _dictionary.formalism to 'powder'.
 ;
-         2.4      2017-04-05
+         2.4                      2017-04-05
 ;
-     Added definition for _refln.F_meas after consultation with
-     PD DMG. (James Hester)
+       Added definition for _refln.F_meas after consultation with
+       PD DMG. (James Hester)
 ;
-         2.4.1    2021-12-06
+         2.4.1                    2021-12-06
 ;
-     Changed the content type of multiple data items from 'Count'
-     to 'Integer' and assigned the appropriate enumeration range
-     if needed.
+       Changed the content type of multiple data items from 'Count'
+       to 'Integer' and assigned the appropriate enumeration range
+       if needed.
 
-     Corrected the object id of the _pd_proc.2theta_range_inc data item.
+       Corrected the object id of the _pd_proc.2theta_range_inc data item.
 
-     Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
+       Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -807,7 +807,7 @@ save_pd_char.mass_atten_coef_mu_calc
     units of square millimetres per gram, also known as the
     mass absorption coefficient. The calculated \\m* will
     be obtained from the atomic content of each phase and
-    the radiation wavelength.    
+    the radiation wavelength.
 ;
     _name.category_id            pd_char
     _name.object_id              mass_atten_coef_mu_calc


### PR DESCRIPTION
This pull request fixes #18 and adds automatic checking of layout when any pull request is made. It rearranges the entire dictionary and adjusts whitespace, but does not change any semantics. I have used the `compare.jl` tool in my `julia_cif_tools` repository to check that yes, indeed, no semantics are changed.