### PR TITLE
Fix DDLm checking errors

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -15,7 +15,8 @@ data_CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0-pre-2
     _dictionary.date              2022-09-28
-    _dictionary.uri               www.iucr.org/cif/dic/cif_pow.dic
+    _dictionary.uri
+        https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
     _dictionary.namespace         CifPow
     _description.text
@@ -5583,7 +5584,7 @@ save_refln.f_complex
     _type.source                  Derived
     _type.container               Single
     _type.contents                Complex
-    _enumeration.default          0.
+    _enumeration.default          '0.+0.j'
     _method.purpose               Definition
     _method.expression
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -319,7 +319,6 @@ save_pd_calib.detector_response
     _enumeration.range            0.0:
     _units.code                   none
 
-
 save_
 
 save_pd_calib.std_internal_mass_percent
@@ -568,7 +567,7 @@ save_pd_calib_std.detector_id
 ;
     _name.category_id             pd_calib_std
     _name.object_id               detector_id
-    _name.linked_object_id        '_pd_meas.detector_id'
+    _name.linked_item_id        '_pd_meas.detector_id'
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
@@ -3953,8 +3952,8 @@ save_pd_meas.number_of_points
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
-    _units.code                   none
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -302,7 +302,7 @@ save_pd_calib.detector_response
 
     _definition.id                '_pd_calib.detector_response'
     _alias.definition_id          '_pd_calib_detector_response'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     A value that indicates the relative sensitivity of each
@@ -316,8 +316,9 @@ save_pd_calib.detector_response
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0.0:
+    _units.code                   none
+
 
 save_
 
@@ -325,7 +326,7 @@ save_pd_calib.std_internal_mass_percent
 
     _definition.id                '_pd_calib.std_internal_mass_percent'
     _alias.definition_id          '_pd_calib_std_internal_mass_%'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Per cent presence of the internal standard specified by the
@@ -339,8 +340,8 @@ save_pd_calib.std_internal_mass_percent
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0.0:100.0
+    _units.code                   none
 
 save_
 
@@ -952,7 +953,7 @@ save_pd_calc.intensity_net
 
     _definition.id                '_pd_calc.intensity_net'
     _alias.definition_id          '_pd_calc_intensity_net'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Intensity values for a computed diffractogram at
@@ -977,8 +978,8 @@ save_pd_calc.intensity_net
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   counts
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -986,7 +987,7 @@ save_pd_calc.intensity_total
 
     _definition.id                '_pd_calc.intensity_total'
     _alias.definition_id          '_pd_calc_intensity_total'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Intensity values for a computed diffractogram at
@@ -1011,8 +1012,8 @@ save_pd_calc.intensity_total
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   counts
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1147,7 +1148,7 @@ save_pd_meas.counts_background
 
     _definition.id                '_pd_meas.counts_background'
     _alias.definition_id          '_pd_meas_counts_background'
-    _definition.update            2019-09-25
+    _definition.update            2022-09-28
     _description.text
 ;
     Counts measured at the measurement point as a function of
@@ -1174,8 +1175,8 @@ save_pd_meas.counts_background
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
-    _units.code                   counts
     _enumeration.range            0:
+    _units.code                   counts
 
 save_
 
@@ -1183,7 +1184,7 @@ save_pd_meas.counts_container
 
     _definition.id                '_pd_meas.counts_container'
     _alias.definition_id          '_pd_meas_counts_container'
-    _definition.update            2019-09-25
+    _definition.update            2022-09-28
     _description.text
 ;
     Counts measured at the measurement point as a function of
@@ -1209,8 +1210,8 @@ save_pd_meas.counts_container
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
-    _units.code                   counts
     _enumeration.range            0:
+    _units.code                   counts
 
 save_
 
@@ -1218,7 +1219,7 @@ save_pd_meas.counts_monitor
 
     _definition.id                '_pd_meas.counts_monitor'
     _alias.definition_id          '_pd_meas_counts_monitor'
-    _definition.update            2019-09-25
+    _definition.update            2022-09-28
     _description.text
 ;
     Counts measured at the measurement point as a function of
@@ -1244,8 +1245,8 @@ save_pd_meas.counts_monitor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
-    _units.code                   counts
     _enumeration.range            0:
+    _units.code                   counts
 
 save_
 
@@ -1253,7 +1254,7 @@ save_pd_meas.counts_total
 
     _definition.id                '_pd_meas.counts_total'
     _alias.definition_id          '_pd_meas_counts_total'
-    _definition.update            2019-09-25
+    _definition.update            2022-09-28
     _description.text
 ;
     Counts measured at the measurement point as a function of
@@ -1280,8 +1281,8 @@ save_pd_meas.counts_total
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
-    _units.code                   counts
     _enumeration.range            0:
+    _units.code                   counts
 
 save_
 
@@ -1316,7 +1317,7 @@ save_pd_meas.intensity_background
 
     _definition.id                '_pd_meas.intensity_background'
     _alias.definition_id          '_pd_meas_intensity_background'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Intensity measurements at the measurement point (see
@@ -1341,6 +1342,7 @@ save_pd_meas.intensity_background
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -1355,6 +1357,7 @@ save_pd_meas.intensity_background_su
     _name.category_id             pd_meas
     _name.object_id               intensity_background_su
     _name.linked_item_id          '_pd_meas.intensity_background'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1364,7 +1367,7 @@ save_pd_meas.intensity_container
 
     _definition.id                '_pd_meas.intensity_container'
     _alias.definition_id          '_pd_meas_intensity_container'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Intensity measurements at the measurement point (see
@@ -1388,6 +1391,7 @@ save_pd_meas.intensity_container
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -1402,6 +1406,7 @@ save_pd_meas.intensity_container_su
     _name.category_id             pd_meas
     _name.object_id               intensity_container_su
     _name.linked_item_id          '_pd_meas.intensity_container'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1411,7 +1416,7 @@ save_pd_meas.intensity_monitor
 
     _definition.id                '_pd_meas.intensity_monitor'
     _alias.definition_id          '_pd_meas_intensity_monitor'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Intensity measurements at the measurement point (see
@@ -1435,6 +1440,7 @@ save_pd_meas.intensity_monitor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -1449,6 +1455,7 @@ save_pd_meas.intensity_monitor_su
     _name.category_id             pd_meas
     _name.object_id               intensity_monitor_su
     _name.linked_item_id          '_pd_meas.intensity_monitor'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1458,7 +1465,7 @@ save_pd_meas.intensity_total
 
     _definition.id                '_pd_meas.intensity_total'
     _alias.definition_id          '_pd_meas_intensity_total'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Intensity measurements at the measurement point (see
@@ -1483,6 +1490,7 @@ save_pd_meas.intensity_total
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -1497,6 +1505,7 @@ save_pd_meas.intensity_total_su
     _name.category_id             pd_meas
     _name.object_id               intensity_total_su
     _name.linked_item_id          '_pd_meas.intensity_total'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1735,6 +1744,7 @@ save_pd_proc.intensity_bkg_calc
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1749,6 +1759,7 @@ save_pd_proc.intensity_bkg_calc_su
     _name.category_id             pd_proc
     _name.object_id               intensity_bkg_calc_su
     _name.linked_item_id          '_pd_proc.intensity_bkg_calc'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1790,6 +1801,7 @@ save_pd_proc.intensity_bkg_fix
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1804,6 +1816,7 @@ save_pd_proc.intensity_bkg_fix_su
     _name.category_id             pd_proc
     _name.object_id               intensity_bkg_fix_su
     _name.linked_item_id          '_pd_proc.intensity_bkg_fix'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1837,6 +1850,7 @@ save_pd_proc.intensity_incident
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1851,6 +1865,7 @@ save_pd_proc.intensity_incident_su
     _name.category_id             pd_proc
     _name.object_id               intensity_incident_su
     _name.linked_item_id          '_pd_proc.intensity_incident'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1877,6 +1892,7 @@ save_pd_proc.intensity_net
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1891,6 +1907,7 @@ save_pd_proc.intensity_net_su
     _name.category_id             pd_proc
     _name.object_id               intensity_net_su
     _name.linked_item_id          '_pd_proc.intensity_net'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1928,6 +1945,7 @@ save_pd_proc.intensity_norm
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1942,6 +1960,7 @@ save_pd_proc.intensity_norm_su
     _name.category_id             pd_proc
     _name.object_id               intensity_norm_su
     _name.linked_item_id          '_pd_proc.intensity_norm'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -1968,6 +1987,7 @@ save_pd_proc.intensity_total
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -1982,6 +2002,7 @@ save_pd_proc.intensity_total_su
     _name.category_id             pd_proc
     _name.object_id               intensity_total_su
     _name.linked_item_id          '_pd_proc.intensity_total'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -3727,7 +3748,7 @@ save_pd_meas.2theta_fixed
 
     _definition.id                '_pd_meas.2theta_fixed'
     _alias.definition_id          '_pd_meas_2theta_fixed'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     The 2\\q diffraction angle in degrees for measurements\
@@ -3741,8 +3762,8 @@ save_pd_meas.2theta_fixed
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   degrees
     _enumeration.range            -180.0:360.0
+    _units.code                   degrees
 
 save_
 
@@ -3750,7 +3771,7 @@ save_pd_meas.2theta_range_inc
 
     _definition.id                '_pd_meas.2theta_range_inc'
     _alias.definition_id          '_pd_meas_2theta_range_inc'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     2\\q diffraction angle increment in degrees used for the
@@ -3819,7 +3840,7 @@ save_pd_meas.angle_chi
 
     _definition.id                '_pd_meas.angle_chi'
     _alias.definition_id          '_pd_meas_angle_chi'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     The diffractometer angle in degrees for an instrument with a
@@ -3833,8 +3854,8 @@ save_pd_meas.angle_chi
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   degrees
     _enumeration.range            -180.0:360.0
+    _units.code                   degrees
 
 save_
 
@@ -3842,7 +3863,7 @@ save_pd_meas.angle_omega
 
     _definition.id                '_pd_meas.angle_omega'
     _alias.definition_id          '_pd_meas_angle_omega'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     The diffractometer angle in degrees for an instrument with a
@@ -3856,8 +3877,8 @@ save_pd_meas.angle_omega
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   degrees
     _enumeration.range            -180.0:360.0
+    _units.code                   degrees
 
 save_
 
@@ -3865,7 +3886,7 @@ save_pd_meas.angle_phi
 
     _definition.id                '_pd_meas.angle_phi'
     _alias.definition_id          '_pd_meas_angle_phi'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     The diffractometer angle in degrees for an instrument with a
@@ -3879,8 +3900,8 @@ save_pd_meas.angle_phi
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   degrees
     _enumeration.range            -180.0:360.0
+    _units.code                   degrees
 
 save_
 
@@ -4193,6 +4214,7 @@ save_pd_peak.intensity
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -4207,6 +4229,7 @@ save_pd_peak.intensity_su
     _name.category_id             pd_peak
     _name.object_id               intensity_su
     _name.linked_item_id          '_pd_peak.intensity'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -4231,6 +4254,7 @@ save_pd_peak.pk_height
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -4245,6 +4269,7 @@ save_pd_peak.pk_height_su
     _name.category_id             pd_peak
     _name.object_id               pk_height_su
     _name.linked_item_id          '_pd_peak.pk_height'
+    _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -4432,7 +4457,7 @@ save_pd_phase.mass_percent
          '_pd_phase_mass_percent'
          '_pd_phase_mass_%'
 
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Per cent composition of the specified crystal phase
@@ -4445,8 +4470,8 @@ save_pd_phase.mass_percent
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0.0:100.0
+    _units.code                   none
 
 save_
 
@@ -4814,7 +4839,7 @@ save_pd_proc_ls.prof_r_factor
 
     _definition.id                '_pd_proc_ls.prof_R_factor'
     _alias.definition_id          '_pd_proc_ls_prof_R_factor'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     _pd_proc_ls.prof_R_factor, often called R~p~, is an
@@ -4845,8 +4870,8 @@ save_pd_proc_ls.prof_r_factor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -4854,7 +4879,7 @@ save_pd_proc_ls.prof_wr_expected
 
     _definition.id                '_pd_proc_ls.prof_wR_expected'
     _alias.definition_id          '_pd_proc_ls_prof_wR_expected'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     _pd_proc_ls.prof_wR_expected, sometimes called the
@@ -4890,8 +4915,8 @@ save_pd_proc_ls.prof_wr_expected
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -4899,7 +4924,7 @@ save_pd_proc_ls.prof_wr_factor
 
     _definition.id                '_pd_proc_ls.prof_wR_factor'
     _alias.definition_id          '_pd_proc_ls_prof_wR_factor'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     _pd_proc_ls.prof_wR_factor, often called R~wp~, is a
@@ -4932,8 +4957,8 @@ save_pd_proc_ls.prof_wr_factor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0.0:
+    _units.code                   none
 
 save_
 
@@ -4984,7 +5009,7 @@ save_pd_proc_ls.weight
 
     _definition.id                '_pd_proc_ls.weight'
     _alias.definition_id          '_pd_proc_ls_weight'
-    _definition.update            2014-06-20
+    _definition.update            2022-09-28
     _description.text
 ;
     Weight applied to each profile point. These values
@@ -5001,8 +5026,8 @@ save_pd_proc_ls.weight
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _units.code                   none
     _enumeration.range            0:
+    _units.code                   none
 
 save_
 
@@ -5203,8 +5228,8 @@ save_pd_proc.number_of_points
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
-    _units.code                   none
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -291,7 +291,7 @@ save_pd_calib.detector_id
     _name.category_id             pd_calib
     _name.object_id               detector_id
     _name.linked_item_id          '_pd_meas.detector_id'
-    _type.purpose                 Encode
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -567,8 +567,8 @@ save_pd_calib_std.detector_id
 ;
     _name.category_id             pd_calib_std
     _name.object_id               detector_id
-    _name.linked_item_id        '_pd_meas.detector_id'
-    _type.purpose                 Encode
+    _name.linked_item_id          '_pd_meas.detector_id'
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -3593,7 +3593,7 @@ save_pd_instr_detector.id
     _name.category_id             pd_instr_detector
     _name.object_id               id
     _name.linked_item_id          '_pd_meas.detector_id'
-    _type.purpose                 Key
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -5560,7 +5560,7 @@ save_pd_refln.phase_id
     _name.category_id             refln
     _name.object_id               phase_id
     _name.linked_item_id          '_pd_phase.id'
-    _type.purpose                 Encode
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5584,7 +5584,7 @@ save_refln.f_complex
     _type.source                  Derived
     _type.container               Single
     _type.contents                Complex
-    _enumeration.default          "0.+0.j"
+    _enumeration.default          0.+0.j
     _method.purpose               Definition
     _method.expression
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -290,7 +290,7 @@ save_pd_calib.detector_id
 ;
     _name.category_id             pd_calib
     _name.object_id               detector_id
-    _name.linked_object_id        '_pd_meas.detector_id'
+    _name.linked_item_id          '_pd_meas.detector_id'
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
@@ -3592,7 +3592,7 @@ save_pd_instr_detector.id
 ;
     _name.category_id             pd_instr_detector
     _name.object_id               id
-    _name.linked_object_id        '_pd_meas.detector_id'
+    _name.linked_item_id          '_pd_meas.detector_id'
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
@@ -5559,7 +5559,7 @@ save_pd_refln.phase_id
 ;
     _name.category_id             refln
     _name.object_id               phase_id
-    _name.linked_object_id        '_pd_phase.id'
+    _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -16,7 +16,7 @@ data_CIF_POW
     _dictionary.version           2.5.0-pre-2
     _dictionary.date              2022-09-28
     _dictionary.uri
-        https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
+  https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
     _dictionary.namespace         CifPow
     _description.text
@@ -5584,7 +5584,7 @@ save_refln.f_complex
     _type.source                  Derived
     _type.container               Single
     _type.contents                Complex
-    _enumeration.default          '0.+0.j'
+    _enumeration.default          "0.+0.j"
     _method.purpose               Definition
     _method.expression
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -316,6 +316,7 @@ save_pd_calib.detector_response
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0.0:
 
 save_
@@ -338,6 +339,7 @@ save_pd_calib.std_internal_mass_percent
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0.0:100.0
 
 save_
@@ -497,7 +499,7 @@ save_pd_calib_offset.detector_id
     _name.category_id             pd_calib_offset
     _name.object_id               detector_id
     _name.linked_item_id          '_pd_calib.detector_id'
-    _type.purpose                 Key
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -964,7 +966,7 @@ save_pd_calc.intensity_net
     Use _pd_calc.intensity_net if the computed diffractogram
     does not contain background or normalization corrections
     and thus is specified on the same scale as the
-    _pd_proc_intensity_net values.
+    _pd_proc.intensity_net values.
     If an observed pattern is included, _pd_calc.intensity_*
     should be looped with either _pd_proc.intensity_net,
     _pd_meas.counts_* or _pd_meas.intensity_*.
@@ -975,6 +977,7 @@ save_pd_calc.intensity_net
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   counts
     _enumeration.range            0.0:
 
 save_
@@ -1008,6 +1011,7 @@ save_pd_calc.intensity_total
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   counts
     _enumeration.range            0.0:
 
 save_
@@ -1028,7 +1032,7 @@ save_pd_calc.point_id
     _name.category_id             pd_calc
     _name.object_id               point_id
     _name.linked_item_id          '_pd_data.point_id'
-    _type.purpose                 Key
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -1170,6 +1174,7 @@ save_pd_meas.counts_background
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   counts
     _enumeration.range            0:
 
 save_
@@ -1204,6 +1209,7 @@ save_pd_meas.counts_container
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   counts
     _enumeration.range            0:
 
 save_
@@ -1238,6 +1244,7 @@ save_pd_meas.counts_monitor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   counts
     _enumeration.range            0:
 
 save_
@@ -1273,6 +1280,7 @@ save_pd_meas.counts_total
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   counts
     _enumeration.range            0:
 
 save_
@@ -1510,7 +1518,7 @@ save_pd_meas.point_id
     _name.category_id             pd_meas
     _name.object_id               point_id
     _name.linked_item_id          '_pd_data.point_id'
-    _type.purpose                 Encode
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -1715,7 +1723,7 @@ save_pd_proc.intensity_bkg_calc
 ;
     Inclusion of s.u.'s for these values is strongly recommended.
 
-    _pd_proc_intensity_bkg_calc is intended to contain the
+    _pd_proc.intensity_bkg_calc is intended to contain the
     background intensity for every data point where the
     background function has been fitted or estimated (for example, in
     all Rietveld and profile fits).
@@ -1764,7 +1772,7 @@ save_pd_proc.intensity_bkg_fix
     may be specified using _pd_proc_intensity_bkg_calc.
 
     Background values should be on the same scale as the
-    _pd_proc_intensity_net values. Thus normalization and
+    _pd_proc.intensity_net values. Thus normalization and
     correction factors should be applied before
     background subtraction (or should be applied to the
     background values equally).
@@ -1898,7 +1906,7 @@ save_pd_proc.intensity_norm
     Inclusion of s.u.'s for these values is strongly recommended.
 
     Background values should be on the same scale as the
-    _pd_proc_intensity_net values. Thus normalization and correction
+    _pd_proc.intensity_net values. Thus normalization and correction
     factors should be applied before background subtraction (or
     should be applied to the background values equally).
 
@@ -1911,7 +1919,7 @@ save_pd_proc.intensity_norm
     Note that if the intensities have been corrected for a variation
     of the incident intensity as a function of a data-collection
     variable, the correction function should be specified separately
-    as _pd_proc_intensity_incident.
+    as _pd_proc.intensity_incident.
 ;
     _name.category_id             pd_proc
     _name.object_id               intensity_norm
@@ -1997,7 +2005,7 @@ save_pd_proc.point_id
     _name.category_id             pd_proc
     _name.object_id               point_id
     _name.linked_item_id          '_pd_data.point_id'
-    _type.purpose                 Key
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -3733,6 +3741,7 @@ save_pd_meas.2theta_fixed
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   degrees
     _enumeration.range            -180.0:360.0
 
 save_
@@ -3824,6 +3833,7 @@ save_pd_meas.angle_chi
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   degrees
     _enumeration.range            -180.0:360.0
 
 save_
@@ -3846,6 +3856,7 @@ save_pd_meas.angle_omega
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   degrees
     _enumeration.range            -180.0:360.0
 
 save_
@@ -3868,6 +3879,7 @@ save_pd_meas.angle_phi
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   degrees
     _enumeration.range            -180.0:360.0
 
 save_
@@ -3920,6 +3932,7 @@ save_pd_meas.number_of_points
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
     _enumeration.range            1:
 
 save_
@@ -4170,7 +4183,7 @@ save_pd_peak.intensity
     _description.text
 ;
     Integrated area for the peak, with the same scaling as
-    the _pd_proc_intensity_ values. It is good practice to
+    the _pd_proc.intensity_ values. It is good practice to
     include s.u.'s for these values.
 ;
     _name.category_id             pd_peak
@@ -4208,7 +4221,7 @@ save_pd_peak.pk_height
 ;
     The maximum intensity of the peak, either extrapolated
     or the highest observed intensity value. The same
-    scaling is used for the _pd_proc_intensity_ values.
+    scaling is used for the _pd_proc.intensity_ values.
     It is good practice to include s.u.'s for these values.
 ;
     _name.category_id             pd_peak
@@ -4260,7 +4273,7 @@ save_pd_peak.wavelength_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -4432,6 +4445,7 @@ save_pd_phase.mass_percent
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0.0:100.0
 
 save_
@@ -4831,6 +4845,7 @@ save_pd_proc_ls.prof_r_factor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0.0:
 
 save_
@@ -4875,6 +4890,7 @@ save_pd_proc_ls.prof_wr_expected
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0.0:
 
 save_
@@ -4916,6 +4932,7 @@ save_pd_proc_ls.prof_wr_factor
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0.0:
 
 save_
@@ -4984,6 +5001,7 @@ save_pd_proc_ls.weight
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
     _enumeration.range            0:
 
 save_
@@ -5185,6 +5203,7 @@ save_pd_proc.number_of_points
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
     _enumeration.range            1:
 
 save_


### PR DESCRIPTION
These fixes improve conformance with DDLm requirements:

1. Add `_units.code` values for all numeric items
2. Catch a few DDLm mistakes

Some errors are still flagged in the automated check, most likely to be a problem with the checking code.

Closes #25 