### PR TITLE
clarify definition of _pd_calib.std_internal_mass_percent

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -329,8 +329,8 @@ save_pd_calib.std_internal_mass_percent
 ;
     Per cent presence of the internal standard specified by the
     data item _pd_calib.std_internal_name expressed as 100 times
-    the ratio of the amount of standard added to the original
-    sample mass.
+    the mass of standard added divided by the sum of the mass of
+    standard added and the original sample mass.
 ;
     _name.category_id             pd_calib
     _name.object_id               std_internal_mass_percent


### PR DESCRIPTION
The (relevant part of the) current definition is

>100 times the ratio of the amount of standard added to the original sample mass.

which reads, to me, as: std wt% = 100 * mass(std) / mass(original sample) -> 100 * 1 / 3 = 33.3 wt% internal std 
which I believe is wrong, as you've added 1 g std to 3 g of original sample, giving 4 g. The mixed sample now contains 25% std.

The new definition is

> 100 times the mass of standard added divided by the sum of the mass of standard added and the original sample mass.

which reads, to me, as: std wt% = 100 * mass(std) / (mass(std) + mass(original sample)) -> 100 * 1 / (1+3) = 25 wt% internal std 

