### PR TITLE
Correct a typo in the PD_CALIB_D_TO_TOF category description.

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-10-10
+    _dictionary.date              2022-10-11
     _dictionary.uri
   https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -371,7 +371,7 @@ save_PD_CALIB_D_TO_TOF
     _definition.id                PD_CALIB_D_TO_TOF
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-09-30
+    _definition.update            2022-10-11
     _description.text
 ;
     This section defines the parameters used for the calibration
@@ -382,7 +382,7 @@ save_PD_CALIB_D_TO_TOF
     TOF = sum_i [ c_i * d^p_i ]
 
     where TOF is the time-of-flight in microseconds, d is the
-    d-spacing in Angstroms, c_i is the ith coefficient, and
+    d-spacing in angstroms, c_i is the ith coefficient, and
     p_i is the ith power.
 
     A loop is used to specify all terms of the correction
@@ -5852,7 +5852,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-10-10
+         2.5.0                    2022-10-11
 ;
        ## Retain above version number and increment date until final
        ##release
@@ -5863,4 +5863,6 @@ save_
        Corrected datetime examples to proper RFC3339 compliance.
 
        Added pd_calib_d_to_tof.
+
+       Corrected a typo in the PD_CALIB_D_TO_TOF category description.
 ;


### PR DESCRIPTION
The angstrom unit should not be capitalised.