### PR TITLE
Add pd_diffractogram category.

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -463,7 +463,7 @@ save_pd_calib_d_to_tof.coeff
         _units.code = "microseconds_per_angstrom_cubed"
     }
     else if (pc.power == -1) {
-        _units.code = "microsecond_angstroms"
+        _units.code = "angstroms_per_microsecond"
     }
     else _units.code = UNKNOWN
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5747,15 +5747,14 @@ save_pd_phase_mass.percent
     Total mass of the phase expressed as a percentage of the total
     mass of the specimen.
 
-    If _pd_qpa_int_std.mass_percent or
-    _pd_qpa_ext_std.k_factor is present, the
-    values given are assumed to be in absolute terms.
+    If _pd_qpa_int_std.mass_percent or _pd_qpa_ext_std.k_factor is
+    present, the values given are assumed to be in absolute terms.
 
-    The value of _pd_phase_mass.percent given to the internal 
-    standard represents the total crystalline contribution of 
-    that standard. That is, if 1 g of a 90% crystalline internal 
-    standard is added to 3 g of sample, the value of 
-    _pd_phase.mass_percent for the standard is 22.5%.
+    The value of the mass percent given to the internal standard
+    represents the total crystalline contribution of that standard.
+    That is, if 1 g of a 90% crystalline internal standard is added
+    to 3 g of sample, the value of _pd_phase.mass_percent for the
+    standard is 22.5%.
 ;
     _name.category_id             pd_phase_mass
     _name.object_id               percent

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1398,7 +1398,7 @@ save_pd_data.diffractogram_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -1542,7 +1542,7 @@ save_pd_calc.diffractogram_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -2031,7 +2031,7 @@ save_pd_meas.diffractogram_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -2521,7 +2521,7 @@ save_pd_proc.diffractogram_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -5684,7 +5684,7 @@ save_pd_phase_block.phase_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
     _enumeration.default          .
 
 save_
@@ -5728,7 +5728,7 @@ save_pd_phase_mass.diffractogram_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -5798,7 +5798,7 @@ save_pd_phase_mass.phase_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -7398,7 +7398,7 @@ save_pd_qpa_ext_std.phase_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -7545,7 +7545,7 @@ save_pd_qpa_int_std.phase_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -7686,7 +7686,7 @@ save_pd_qpa_rir.std_phase_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -8078,7 +8078,7 @@ save_pd_refln.phase_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3059,11 +3059,6 @@ save_pd_diffractogram.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default = _pd_block.id
-;
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6893,7 +6893,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-12-03
+         2.5.0                    2022-12-16
 ;
        ## Retain above version number and increment date until final
        ##release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5662,7 +5662,7 @@ save_PD_PHASE_MASS
     _description.text
 ;
     This category describes the percent composition by mass of
-    phases in a specimen. Values are derived from modelling a 
+    phases in a specimen. Values are derived from modelling a
     particular diffraction measurement on a specimen and should
     not be used where the mass composition has been determined
     by other means.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5512,7 +5512,7 @@ save_PD_PHASE_BLOCK
     _definition.update            2022-12-03
     _description.text
 ;
-	 NEW DESCRIPTION NEEDS TO GO HERE
+    NEW DESCRIPTION NEEDS TO GO HERE
 
     The _pd_phase_block.id entry points to the CIF block with
     structural parameters for each crystalline phase. The

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-11-18
+    _dictionary.date              2022-11-21
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -6780,7 +6780,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-11-18
+         2.5.0                    2022-11-21
 ;
        ## Retain above version number and increment date until final
        ##release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5163,7 +5163,7 @@ save_pd_proc_ls.weight
 
     _definition.id                '_pd_proc_ls.weight'
     _alias.definition_id          '_pd_proc_ls_weight'
-    _definition.update            2022-09-28
+    _definition.update            2022-10-10
     _description.text
 ;
     Weight applied to each profile point. These values
@@ -5174,7 +5174,7 @@ save_pd_proc_ls.weight
     point not used for refinement (see
     _pd_proc.info_excluded_regions).
 ;
-    _name.category_id             pd_proc_ls
+    _name.category_id             pd_proc
     _name.object_id               weight
     _type.purpose                 Number
     _type.source                  Derived

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-12-30
+    _dictionary.date              2023-01-04
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -56,8 +56,8 @@ save_PD_BLOCK
 ;
     _pd_block.id is used to assign a unique ID code to a data block.
     This code is then used for references between different blocks
-    (see _pd_block_diffractogram.id, _pd_calib.std_external_block_id
-    and _pd_phase.block_id).
+    (see _pd_block_diffractogram.id, _pd_calib_std.external_block_id
+    and _pd_phase_block.id).
 
     Note that a data block may contain only a single diffraction
     data set or information about a single crystalline phase.
@@ -213,7 +213,7 @@ save_pd_block_diffractogram.id
 
     _definition.id                '_pd_block_diffractogram.id'
     _alias.definition_id          '_pd_block_diffractogram_id'
-    _definition.update            2016-10-18
+    _definition.update            2023-01-05
     _description.text
 ;
     A block ID code (see _pd_block.id) that identifies
@@ -264,7 +264,7 @@ save_pd_calc_component.block_id
     data block other than the current block. The data
     block containing the crystallographic information
     for this phase will be identified with a _pd_block.id
-    code matching the code in _pd_phase.block_id. The data
+    code matching the code in _pd_phase_block.id. The data
     block containing the diffractogram to which this component
     belongs will be identified with a _pd_block.id
     code matching the code in _pd_block_diffractogram.id.
@@ -1353,7 +1353,7 @@ save_PD_DATA
     _definition.id                PD_DATA
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2014-06-20
+    _definition.update            2022-10-11
     _description.text
 ;
     The PD_DATA category is a "container" category that is defined
@@ -1422,7 +1422,7 @@ save_PD_CALC
     _definition.id                PD_CALC
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-10-17
+    _definition.update            2022-10-11
     _description.text
 ;
     This section is used for storing a computed diffractogram trace.
@@ -1653,7 +1653,7 @@ save_PD_MEAS
     _definition.id                PD_MEAS
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-10-17
+    _definition.update            2022-10-11
     _description.text
 ;
     This section contains the measured diffractogram prior to
@@ -2396,7 +2396,7 @@ save_PD_PROC
     _definition.id                PD_PROC
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2014-06-20
+    _definition.update            2022-10-11
     _description.text
 ;
     This section contains the diffraction data set after processing
@@ -5576,7 +5576,7 @@ save_PD_PHASE
     performed, the structural results will be placed in different
     data blocks, using CIF entries from the core CIF dictionary.
 
-    The _pd_phase.block_id entry points to the CIF block with
+    The _pd_phase_block.id entry points to the CIF block with
     structural parameters for each crystalline phase.
 ;
     _name.category_id             PD_GROUP

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5661,8 +5661,14 @@ save_PD_PHASE_MASS
     _definition.update            2022-12-03
     _description.text
 ;
-    NEW DESCRIPTION NEEDS TO GO HERE
-    ALSO NEED KEYS BASED ON _pd_phase.id AND _pd_diffractogram.id?
+    This category contains infomation pertaining to the
+    percent composition of the specified crystal phase
+    expressed as the total mass of the component
+    with respect to the total mass of the specimen.
+
+    The specific combination of relevent phase and diffractogram
+    is given by _pd_phase_mass.diffractogram_id and
+    _pd_phase_mass.phase_id
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5566,8 +5566,8 @@ save_PD_PHASE
 
     _definition.id                PD_PHASE
     _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2016-11-09
+    _definition.class             Set
+    _definition.update            2023-01-04
     _description.text
 ;
     This section contains a description of the crystalline phases
@@ -5591,7 +5591,7 @@ save_pd_phase.id
     _definition.update            2022-12-03
     _description.text
 ;
-    Arbitrary label identifying a phase.
+    Arbitrary label uniquely identifying a phase.
 ;
     _name.category_id             pd_phase
     _name.object_id               id
@@ -7707,7 +7707,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-12-30
+         2.5.0                    2023-01-04
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -7729,19 +7729,19 @@ save_
 
        Made PD_BLOCK a Loop category.
 
-       Made PD_BLOCK a Loop category
-
        Updated intensity/count definitions in PD_CALC, PD_MEAS, and PD_PROC.
 
        Updated descriptions of _pd_meas.counts, _pd_meas.intensity_background,
-       _pd_meas.intensity_container, and _pd_meas.intensity_monitor
+       _pd_meas.intensity_container, and _pd_meas.intensity_monitor.
 
-       Removed enumeration range for _pd_proc.intensity_net
+       Removed enumeration range for _pd_proc.intensity_net.
 
        Added ability to record detector circle radius, both fixed and
        varying by measurement point.
 
-       Updated many datanames from Number to Measurand
+       Updated many datanames from Number to Measurand.
 
-       Made PD_BLOCK a Loop category
+       Made PD_BLOCK a Loop category.
+
+       Made PD_PHASE a Set category.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -213,7 +213,7 @@ save_pd_block_diffractogram.id
 
     _definition.id                '_pd_block_diffractogram.id'
     _alias.definition_id          '_pd_block_diffractogram_id'
-    _definition.update            2023-01-05
+    _definition.update            2022-10-11
     _description.text
 ;
     A block ID code (see _pd_block.id) that identifies
@@ -1380,9 +1380,9 @@ save_pd_data.diffractogram_id
     _description.text
 ;
     Label identifying the diffraction measurement that the
-    data tabulated in the PD_DATA category belong to. This may be omitted in the usual
-    case that only one diffraction measurement is present
-    in a data block.
+    data tabulated in the PD_DATA category belong to. This
+    may be omitted in the usual case that only one diffraction
+    measurement is present in a data block.
 ;
     _name.category_id             pd_data
     _name.object_id               diffractogram_id
@@ -2013,9 +2013,9 @@ save_pd_meas.diffractogram_id
     _description.text
 ;
     Label identifying the diffraction measurement that the
-        data tabulated in the PD_MEAS category belong to. This may be omitted in the usual
-    case that only one diffraction measurement is present
-    in a data block.
+    data tabulated in the PD_MEAS category belong to. This
+    may be omitted in the usual case that only one diffraction
+    measurement is present in a data block.
 ;
     _name.category_id             pd_meas
     _name.object_id               diffractogram_id
@@ -2503,9 +2503,9 @@ save_pd_proc.diffractogram_id
     _description.text
 ;
     Label identifying the diffraction measurement that the
-    data tabulated in the PD_PROC category belong to. This may be omitted in the usual
-    case that only one diffraction measurement is present
-    in a data block.
+    data tabulated in the PD_PROC category belong to. This
+    may be omitted in the usual case that only one diffraction
+    measurement is present in a data block.
 ;
     _name.category_id             pd_proc
     _name.object_id               diffractogram_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1419,26 +1419,6 @@ save_PD_CALC
 
 save_
 
-save_pd_calc.diffractogram_id
-
-    _definition.id                '_pd_calc.diffractogram_id'
-    _definition.update            2022-10-11
-    _description.text
-;
-    Label identifying the calculated diffractogram that the
-    calculated data belong to. This may be omitted in the usual
-    case that only one calculation is present in a data block.
-;
-    _name.category_id             pd_calc
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_data.diffractogram_id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Code
-
-save_
-
 save_pd_calc.component_intensity_net_list
 
     _definition.id                '_pd_calc.component_intensity_net_list'
@@ -1514,6 +1494,26 @@ save_pd_calc.component_intensity_total_list
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   none
+
+save_
+
+save_pd_calc.diffractogram_id
+
+    _definition.id                '_pd_calc.diffractogram_id'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Label identifying the calculated diffractogram that the
+    calculated data belong to. This may be omitted in the usual
+    case that only one calculation is present in a data block.
+;
+    _name.category_id             pd_calc
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2152,7 +2152,7 @@ save_pd_proc.diffractogram_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-    
+
 save_
 
 save_pd_proc.energy_detection
@@ -2649,7 +2649,7 @@ save_pd_proc.wavelength_su
     _units.code                   angstroms
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-    
+
 save_
 
 save_PD_DIFFRACTOGRAM
@@ -6534,8 +6534,8 @@ save_
        Corrected a typo in the PD_CALIB_D_TO_TOF category description.
 
        Add pd_diffractogram category and linked data names.
-       
+
        Updated many datanames from Number to Measurand
-       
+
        Made PD_BLOCK a Loop category
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-12-03
+    _dictionary.date              2022-12-16
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -202,7 +202,7 @@ save_pd_block_diffractogram.diffractogram_id
     _name.category_id             pd_block_diffractogram
     _name.object_id               diffractogram_id
     _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Encode
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -228,7 +228,7 @@ save_pd_block_diffractogram.id
     _name.category_id             pd_block_diffractogram
     _name.object_id               id
     _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Encode
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1060,7 +1060,32 @@ save_PD_DATA
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_DATA
-    _category_key.name            '_pd_data.point_id'
+
+    loop_
+      _category_key.name
+         '_pd_data.point_id'
+         '_pd_data.diffractogram_id'
+
+save_
+
+save_pd_data.diffractogram_id
+
+    _definition.id                '_pd_data.diffractogram_id'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Label identifying the diffraction measurement that the
+    tabulated data belong to. This may be omitted in the usual
+    case that only one diffraction measurement is present
+    in a data block.
+;
+    _name.category_id             pd_data
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
@@ -1101,7 +1126,31 @@ save_PD_CALC
 ;
     _name.category_id             PD_DATA
     _name.object_id               PD_CALC
-    _category_key.name            '_pd_calc.point_id'
+
+    loop_
+      _category_key.name
+         '_pd_calc.point_id'
+         '_pd_calc.diffractogram_id'
+
+save_
+
+save_pd_calc.diffractogram_id
+
+    _definition.id                '_pd_calc.diffractogram_id'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Label identifying the calculated diffractogram that the
+    calculated data belong to. This may be omitted in the usual
+    case that only one calculation is present in a data block.
+;
+    _name.category_id             pd_calc
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
@@ -1225,7 +1274,11 @@ save_PD_MEAS
 ;
     _name.category_id             PD_DATA
     _name.object_id               PD_MEAS
-    _category_key.name            '_pd_meas.point_id'
+
+    loop_
+      _category_key.name
+         '_pd_meas.point_id'
+         '_pd_meas.diffractogram_id'
 
 save_
 
@@ -1464,6 +1517,27 @@ save_pd_meas.detector_id
     _name.object_id               detector_id
     _type.purpose                 Encode
     _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_meas.diffractogram_id
+
+    _definition.id                '_pd_meas.diffractogram_id'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Label identifying the diffraction measurement that the
+    tabulated data belong to. This may be omitted in the usual
+    case that only one diffraction measurement is present
+    in a data block.
+;
+    _name.category_id             pd_meas
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Code
 
@@ -1782,7 +1856,11 @@ save_PD_PROC
 ;
     _name.category_id             PD_DATA
     _name.object_id               PD_PROC
-    _category_key.name            '_pd_proc.point_id'
+
+    loop_
+      _category_key.name
+         '_pd_proc.point_id'
+         '_pd_proc.diffractogram_id'
 
 save_
 
@@ -1831,6 +1909,27 @@ save_pd_proc.d_spacing
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   angstroms
+
+save_
+
+save_pd_proc.diffractogram_id
+
+    _definition.id                '_pd_proc.diffractogram_id'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Label identifying the diffraction measurement that the
+    tabulated data belong to. This may be omitted in the usual
+    case that only one diffraction measurement is present
+    in a data block.
+;
+    _name.category_id             pd_proc
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
@@ -2260,6 +2359,46 @@ save_pd_proc.wavelength
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   angstroms
+
+save_
+
+save_PD_DIFFRACTOGRAM
+
+    _definition.id                PD_DIFFRACTOGRAM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-10-11
+    _description.text
+;
+    This category includes data names relating to a diffractogram
+    as a whole.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_DIFFRACTOGRAM
+    _category_key.name            '_pd_diffractogram.id'
+
+save_
+
+save_pd_diffractogram.id
+
+    _definition.id                '_pd_diffractogram.id'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Arbitrary label identifying a powder diffraction measurement.
+    If missing, _pd_block.id is used.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _pd_diffractogram.id = _pd_block.id
+;
 
 save_
 
@@ -5865,4 +6004,7 @@ save_
        Added pd_calib_d_to_tof.
 
        Corrected a typo in the PD_CALIB_D_TO_TOF category description.
+
+       Add pd_diffractogram category and linked data names.
+
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5580,11 +5580,41 @@ save_PD_PHASE_MASS
     _definition.update            2022-12-03
     _description.text
 ;
-	 NEW DESCRIPTION NEEDS TO GO HERE
-	 ALSO NEED KEYS BASED ON _pd_phase.id AND _pd_diffractogram.id?
+    NEW DESCRIPTION NEEDS TO GO HERE
+    ALSO NEED KEYS BASED ON _pd_phase.id AND _pd_diffractogram.id?
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE
+
+    loop_
+      _category_key.name
+         '_pd_phase_mass.diffractogram_id'
+         '_pd_phase_mass.phase_id'
+
+save_
+
+save_pd_phase_mass.diffractogram_id
+
+    _definition.id                '_pd_phase_mass.diffractogram_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    A diffractogram id code (see _pd_diffractogram.id) that
+    links the phase mass percent value to the diffractogram
+    to which it belongs.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _pd_phase_mass.diffractogram_id = _pd_phase.id
+;
 
 save_
 
@@ -5629,6 +5659,31 @@ save_pd_phase_mass.percent_su
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_phase_mass.phase_id
+
+    _definition.id                '_pd_phase_mass.phase_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    A phase id code (see _pd_phase.id) that links the phase
+    mass percent value to the phase id of the phase to which
+    it belongs.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _pd_phase_mass.phase_id = _pd_phase.id
+;
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-11-17
+    _dictionary.date              2022-11-18
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -6780,7 +6780,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-11-17
+         2.5.0                    2022-11-18
 ;
        ## Retain above version number and increment date until final
        ##release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3047,7 +3047,7 @@ save_
 save_pd_diffractogram.id
 
     _definition.id                '_pd_diffractogram.id'
-    _definition.update            2022-10-11
+    _definition.update            2022-01-06
     _description.text
 ;
     Arbitrary label identifying a powder diffraction measurement.
@@ -3059,10 +3059,10 @@ save_pd_diffractogram.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _method.purpose               Evaluation
+    _method.purpose               Definition
     _method.expression
 ;
-    _pd_diffractogram.id = _pd_block.id
+    _enumeration.default = _pd_block.id
 ;
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3058,7 +3058,7 @@ save_pd_diffractogram.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
     _method.purpose               Evaluation
     _method.expression
 ;
@@ -5606,7 +5606,7 @@ save_pd_phase.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-11-21
+    _dictionary.date              2022-12-03
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -175,7 +175,7 @@ save_PD_BLOCK_DIFFRACTOGRAM
     _definition.id                PD_BLOCK_DIFFRACTOGRAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-10-18
+    _definition.update            2022-12-03
     _description.text
 ;
     A number of diffractograms may contribute to the
@@ -186,6 +186,29 @@ save_PD_BLOCK_DIFFRACTOGRAM
     _name.category_id             PD_GROUP
     _name.object_id               PD_BLOCK_DIFFRACTOGRAM
     _category_key.name            '_pd_block_diffractogram.id'
+
+save_
+
+save_pd_block_diffractogram.diffractogram_id
+
+    _definition.id                '_pd_block_diffractogram.diffractogram_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    A diffractogram id code (see _pd_diffractogram.id) that
+    identifies diffraction data contained in a data block other
+    than the current block. This will occur most frequently
+    when more than one set of diffraction data is used for a
+    structure determination. The data block containing the
+    diffraction data will contain a _pd_diffractogram.id code
+    matching the code in _pd_block_diffractogram.diffractogram.id.
+;
+    _name.category_id             pd_block_diffractogram
+    _name.object_id               diffractogram_id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 
@@ -203,7 +226,7 @@ save_pd_block_diffractogram.id
     is used for a structure determination. The data
     block containing the diffraction data will contain
     a _pd_block.id code matching the code in
-    _pd_block.diffractogram_id.
+    _pd_block_diffractogram.id.
 ;
     _name.category_id             pd_block_diffractogram
     _name.object_id               id
@@ -5445,90 +5468,20 @@ save_PD_PHASE
 
 save_
 
-save_pd_phase.block_id
-
-    _definition.id                '_pd_phase.block_id'
-    _alias.definition_id          '_pd_phase_block_id'
-    _definition.update            2014-06-20
-    _description.text
-;
-    A block ID code identifying the phase contributing to
-    the diffraction peak. The data block containing the
-    crystallographic information for this phase will be
-    identified with a _pd_block.id code matching the
-    code in _pd_phase.block_id.
-;
-    _name.category_id             pd_phase
-    _name.object_id               block_id
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Code
-
-save_
-
 save_pd_phase.id
 
     _definition.id                '_pd_phase.id'
-    _alias.definition_id          '_pd_phase_id'
-    _definition.update            2014-06-20
+    _definition.update            2022-12-03
     _description.text
 ;
-    A code for each crystal phase used to link with
-    _pd_refln.phase_id.
+    Arbitrary label identifying a phase.
 ;
     _name.category_id             pd_phase
     _name.object_id               id
-    _name.linked_item_id          '_pd_refln.phase_id'
-    _type.purpose                 Link
+    _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _enumeration.default          .
-
-save_
-
-save_pd_phase.mass_percent
-
-    _definition.id                '_pd_phase.mass_percent'
-
-    loop_
-      _alias.definition_id
-         '_pd_phase_mass_percent'
-         '_pd_phase_mass_%'
-
-    _definition.update            2022-10-11
-    _description.text
-;
-    Per cent composition of the specified crystal phase
-    expressed as the total mass of the component
-    with respect to the total mass of the specimen.
-;
-    _name.category_id             pd_phase
-    _name.object_id               mass_percent
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:100.0
-    _units.code                   none
-
-save_
-
-save_pd_phase.mass_percent_su
-
-    _definition.id                '_pd_phase.mass_percent_su'
-    _definition.update            2022-10-27
-    _description.text
-;
-    Standard uncertainty of _pd_phase.mass_percent.
-;
-    _name.category_id             pd_phase
-    _name.object_id               mass_percent_su
-    _name.linked_item_id          '_pd_phase.mass_percent'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -5548,6 +5501,134 @@ save_pd_phase.name
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
+
+save_
+
+save_PD_PHASE_BLOCK
+
+    _definition.id                PD_PHASE_BLOCK
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-12-03
+    _description.text
+;
+	 NEW DESCRIPTION NEEDS TO GO HERE
+
+    The _pd_phase_block.id entry points to the CIF block with
+    structural parameters for each crystalline phase. The
+    _pd_phase_block.phase_id serves to link to _pd_refln.phase_id,
+    which is used to label peaks by phase.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE
+    _category_key.name            '_pd_phase_block.id'
+
+save_
+
+save_pd_phase_block.id
+
+    _definition.id                '_pd_phase_block.id'
+    _alias.definition_id          '_pd_phase_block_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    A block ID code identifying the phase contributing to
+    the diffraction peak. The data block containing the
+    crystallographic information for this phase will be
+    identified with a _pd_block.id code matching the
+    code in _pd_phase_block.id.
+;
+    _name.category_id             pd_phase_block
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_phase_block.phase_id
+
+    _definition.id                '_pd_phase_block.phase_id'
+    _alias.definition_id          '_pd_phase_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    A phase id code (see _pd_phase.id) that identifies phase data
+    contained in a data block other than the current block. This
+    will occur most frequently when the same phase is present in
+    more than one set of diffraction data. The data block containing
+    the phase data will contain a _pd_phase.id code matching the
+    code in _pd_phase_block.phase_id.
+;
+    _name.category_id             pd_phase_block
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_refln.phase_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          .
+
+save_
+
+save_PD_PHASE_MASS
+
+    _definition.id                PD_PHASE_MASS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-12-03
+    _description.text
+;
+	 NEW DESCRIPTION NEEDS TO GO HERE
+	 ALSO NEED KEYS BASED ON _pd_phase.id AND _pd_diffractogram.id?
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE
+
+save_
+
+save_pd_phase_mass.percent
+
+    _definition.id                '_pd_phase_mass.percent'
+
+    loop_
+      _alias.definition_id
+         '_pd_phase_mass_percent'
+         '_pd_phase_mass_%'
+
+    _definition.update            2022-12-03
+    _description.text
+;
+    Per cent composition of the specified crystal phase
+    expressed as the total mass of the component
+    with respect to the total mass of the specimen.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_pd_phase_mass.percent_su
+
+    _definition.id                '_pd_phase_mass.percent_su'
+    _definition.update            2022-12-03
+    _description.text
+;
+    Standard uncertainty of _pd_phase_mass.percent.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               percent_su
+    _name.linked_item_id          '_pd_phase_mass.percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -6780,7 +6861,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-11-21
+         2.5.0                    2022-12-03
 ;
        ## Retain above version number and increment date until final
        ##release
@@ -6794,7 +6875,7 @@ save_
 
        Corrected a typo in the PD_CALIB_D_TO_TOF category description.
 
-       Add pd_diffractogram category and linked data names.
+       Add PD_DIFFRACTOGRAM category and linked data names.
 
        Added PD_CALC_COMPONENT and related data names.
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5661,14 +5661,11 @@ save_PD_PHASE_MASS
     _definition.update            2022-12-03
     _description.text
 ;
-    This category contains infomation pertaining to the
-    percent composition of the specified crystal phase
-    expressed as the total mass of the component
-    with respect to the total mass of the specimen.
-
-    The specific combination of relevent phase and diffractogram
-    is given by _pd_phase_mass.diffractogram_id and
-    _pd_phase_mass.phase_id
+    This category describes the percent composition by mass of
+    phases in a specimen. Values are derived from modelling a 
+    particular diffraction measurement on a specimen and should
+    not be used where the mass composition has been determined
+    by other means.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE
@@ -5686,8 +5683,8 @@ save_pd_phase_mass.diffractogram_id
     _definition.update            2022-12-03
     _description.text
 ;
-    A diffractogram id code that links the phase mass percent value to
-    the diffractogram to which it belongs.
+    A diffractogram id to which the phase mass percent value
+    relates.
 ;
     _name.category_id             pd_phase_mass
     _name.object_id               diffractogram_id
@@ -5711,9 +5708,8 @@ save_pd_phase_mass.percent
     _definition.update            2022-12-03
     _description.text
 ;
-    Per cent composition of the specified crystal phase
-    expressed as the total mass of the component
-    with respect to the total mass of the specimen.
+    Total mass of the component as a percentage of the total
+    mass of the specimen.
 ;
     _name.category_id             pd_phase_mass
     _name.object_id               percent
@@ -5749,9 +5745,7 @@ save_pd_phase_mass.phase_id
     _definition.update            2022-12-03
     _description.text
 ;
-    A phase id code (see _pd_phase.id) that links the phase
-    mass percent value to the phase id of the phase to which
-    it belongs.
+    The phase (see _pd_phase.id) to which the percent mass relates.
 ;
     _name.category_id             pd_phase_mass
     _name.object_id               phase_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -205,7 +205,7 @@ save_pd_block_diffractogram.diffractogram_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -196,15 +196,12 @@ save_pd_block_diffractogram.diffractogram_id
     _description.text
 ;
     A diffractogram id code (see _pd_diffractogram.id) that
-    identifies diffraction data contained in a data block other
-    than the current block. This will occur most frequently
-    when more than one set of diffraction data is used for a
-    structure determination. The data block containing the
-    diffraction data will contain a _pd_diffractogram.id code
-    matching the code in _pd_block_diffractogram.diffractogram.id.
+    identifies the diffraction data contained in the data block
+    pointed to by _pd_block_diffractogram.id.
 ;
     _name.category_id             pd_block_diffractogram
     _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
@@ -230,6 +227,7 @@ save_pd_block_diffractogram.id
 ;
     _name.category_id             pd_block_diffractogram
     _name.object_id               id
+    _name.linked_item_id          '_pd_block.id'
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
@@ -1378,7 +1376,7 @@ save_
 save_pd_data.diffractogram_id
 
     _definition.id                '_pd_data.diffractogram_id'
-    _definition.update            2022-10-11
+    _definition.update            2022-12-16
     _description.text
 ;
     Label identifying the diffraction measurement that the
@@ -1532,7 +1530,7 @@ save_pd_calc.diffractogram_id
 ;
     _name.category_id             pd_calc
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -1956,7 +1954,7 @@ save_pd_meas.diffractogram_id
 ;
     _name.category_id             pd_meas
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -2431,7 +2429,7 @@ save_pd_proc.diffractogram_id
 ;
     _name.category_id             pd_proc
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -5458,9 +5456,7 @@ save_PD_PHASE
     data blocks, using CIF entries from the core CIF dictionary.
 
     The _pd_phase.block_id entry points to the CIF block with
-    structural parameters for each crystalline phase. The
-    _pd_phase.id serves to link to _pd_refln.phase_id, which is
-    used to label peaks by phase.
+    structural parameters for each crystalline phase.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE
@@ -5512,12 +5508,11 @@ save_PD_PHASE_BLOCK
     _definition.update            2022-12-03
     _description.text
 ;
-    NEW DESCRIPTION NEEDS TO GO HERE
-
-    The _pd_phase_block.id entry points to the CIF block with
-    structural parameters for each crystalline phase. The
-    _pd_phase_block.phase_id serves to link to _pd_refln.phase_id,
-    which is used to label peaks by phase.
+    A table of phases relevant to the current data
+    block. Each phase is identified by the block identifier
+    of the data block containing the phase information,
+    and the _pd_phase.id of the phase contained within
+    that block.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE
@@ -5532,11 +5527,8 @@ save_pd_phase_block.id
     _definition.update            2022-12-03
     _description.text
 ;
-    A block ID code identifying the phase contributing to
-    the diffraction peak. The data block containing the
-    crystallographic information for this phase will be
-    identified with a _pd_block.id code matching the
-    code in _pd_phase_block.id.
+    A block ID code identifying a block containing phase
+    information.
 ;
     _name.category_id             pd_phase_block
     _name.object_id               id
@@ -5554,16 +5546,12 @@ save_pd_phase_block.phase_id
     _definition.update            2022-12-03
     _description.text
 ;
-    A phase id code (see _pd_phase.id) that identifies phase data
-    contained in a data block other than the current block. This
-    will occur most frequently when the same phase is present in
-    more than one set of diffraction data. The data block containing
-    the phase data will contain a _pd_phase.id code matching the
-    code in _pd_phase_block.phase_id.
+    A phase id code (see _pd_phase.id) that identifies the phase
+    contained in the data block pointed to by _pd_phase_block.id
 ;
     _name.category_id             pd_phase_block
     _name.object_id               phase_id
-    _name.linked_item_id          '_pd_refln.phase_id'
+    _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
@@ -5599,22 +5587,16 @@ save_pd_phase_mass.diffractogram_id
     _definition.update            2022-12-03
     _description.text
 ;
-    A diffractogram id code (see _pd_diffractogram.id) that
-    links the phase mass percent value to the diffractogram
-    to which it belongs.
+    A diffractogram id code that links the phase mass percent value to
+    the diffractogram to which it belongs.
 ;
     _name.category_id             pd_phase_mass
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_phase.id'
+    _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _pd_phase_mass.diffractogram_id = _pd_phase.id
-;
 
 save_
 
@@ -5679,11 +5661,6 @@ save_pd_phase_mass.phase_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _pd_phase_mass.phase_id = _pd_phase.id
-;
 
 save_
 


### PR DESCRIPTION
Closes #21 . The current PR adds the category and child data names of `_pd_diffractogram.id`. This has the effect of linking the tabulated diffraction scan data to the concept of a diffractogram. When loops containing per-diffractogram, per-something-else information (e.g. per diffractogram per phase) are created, adding child data names of `_pd_diffractogram.id` formally states that the information in those loops depends on a particular diffractogram.

This is intended to be complementary to the block pointers used in pdCIF, and will work in situations where software is dictionary-aware but not pdCIF-aware.