### PR TITLE
updating of calc/meas/proc/.count/intensity definitions

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-11-17
+    _dictionary.date              2022-12-04
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -1393,7 +1393,7 @@ save_
 save_pd_calc.component_intensity_net_list
 
     _definition.id                '_pd_calc.component_intensity_net_list'
-    _definition.update            2022-11-17
+    _definition.update            2022-12-04
     _description.text
 ;
     List of intensity values for the contributions of an
@@ -1437,7 +1437,7 @@ save_pd_calc.component_intensity_total_list
 ;
     List of intensity values for the contributions of an
     arbitrary number of individual phases to a computed
-    diffractogram at each angle setting. Values are listed
+    diffractogram at each data point. Values are listed
     in the order given by _pd_calc_overall.component_presentation_order.
     Values should be computed at the same locations as the
     processed diffractogram, and thus the numbers of points
@@ -1472,11 +1472,11 @@ save_pd_calc.intensity_net
 
     _definition.id                '_pd_calc.intensity_net'
     _alias.definition_id          '_pd_calc_intensity_net'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
     Intensity values for a computed diffractogram at
-    each angle setting. Values should be computed at the
+    each data point. Values should be computed at the
     same locations as the processed diffractogram, and thus
     the numbers of points will be defined by
     _pd_proc.number_of_points and point positions may
@@ -1487,6 +1487,7 @@ save_pd_calc.intensity_net
     does not contain background or normalization corrections
     and thus is specified on the same scale as the
     _pd_proc.intensity_net values.
+
     If an observed pattern is included, _pd_calc.intensity_*
     should be looped with either _pd_proc.intensity_net,
     _pd_meas.counts_* or _pd_meas.intensity_*.
@@ -1515,11 +1516,11 @@ save_pd_calc.intensity_total
 
     _definition.id                '_pd_calc.intensity_total'
     _alias.definition_id          '_pd_calc_intensity_total'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
     Intensity values for a computed diffractogram at
-    each angle setting. Values should be computed at the
+    each data point. Values should be computed at the
     same locations as the processed diffractogram, and thus
     the numbers of points will be defined by
     _pd_proc.number_of_points and point positions may
@@ -1558,13 +1559,13 @@ save_pd_calc.point_id
 
     _definition.id                '_pd_calc.point_id'
     _alias.definition_id          '_pd_calc_point_id'
-    _definition.update            2014-06-20
+    _definition.update            2022-12-04
     _description.text
 ;
     Arbitrary label identifying a calculated data point. Used to
     identify a specific entry in a list of values forming the
     calculated diffractogram. The role of this identifier may
-    be adopted by _pd_data.point_id if measured, processed and
+    be adopted by _pd_data.point_id if measured, processed, and/or
     calculated intensity values are combined in a single list.
 ;
     _name.category_id             pd_calc
@@ -1702,14 +1703,15 @@ save_pd_meas.counts_background
 
     _definition.id                '_pd_meas.counts_background'
     _alias.definition_id          '_pd_meas_counts_background'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Counts measured at the measurement point as a function of
-    angle, time, channel or some other variable (see
-    _pd_meas.2theta_ etc.).  Scattering measured without
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_ etc.). These counts are measured without
     a specimen, specimen mounting etc., often referred to
     as the instrument background.
+
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead use
     _pd_proc.intensity_* for corrected diffractograms.
@@ -1726,7 +1728,7 @@ save_pd_meas.counts_background
     _name.category_id             pd_meas
     _name.object_id               counts_background
     _type.purpose                 Number
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            0:
@@ -1738,13 +1740,15 @@ save_pd_meas.counts_container
 
     _definition.id                '_pd_meas.counts_container'
     _alias.definition_id          '_pd_meas_counts_container'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Counts measured at the measurement point as a function of
-    angle, time, channel or some other variable (see
-    _pd_meas.2theta_* etc.). from specimen container or mounting
-    without a specimen, includes background.
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These counts are measured from a
+    specimen container or mounting without a specimen, includes
+    background.
+
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead use
     _pd_proc.intensity_* for corrected diffractograms.
@@ -1761,7 +1765,7 @@ save_pd_meas.counts_container
     _name.category_id             pd_meas
     _name.object_id               counts_container
     _type.purpose                 Number
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            0:
@@ -1773,13 +1777,14 @@ save_pd_meas.counts_monitor
 
     _definition.id                '_pd_meas.counts_monitor'
     _alias.definition_id          '_pd_meas_counts_monitor'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Counts measured at the measurement point as a function of
-    angle, time, channel or some other variable (see
-    _pd_meas.2theta_* etc.). Counts measured by an incident-
-    beam monitor to calibrate the flux on the specimen.
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These counts are measured by an
+    incident-beam monitor to calibrate the flux on the specimen.
+
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead use
     _pd_proc.intensity_* for corrected diffractograms.
@@ -1796,7 +1801,7 @@ save_pd_meas.counts_monitor
     _name.category_id             pd_meas
     _name.object_id               counts_monitor
     _type.purpose                 Number
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            0:
@@ -1808,14 +1813,15 @@ save_pd_meas.counts_total
 
     _definition.id                '_pd_meas.counts_total'
     _alias.definition_id          '_pd_meas_counts_total'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Counts measured at the measurement point as a function of
-    angle, time, channel or some other variable (see
-    _pd_meas.2theta_ etc.). Total scattering from the specimen
-    with background, specimen mounting or container
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_ etc.). These counts are measured from the
+    specimen with background, specimen mounting, and/or container
     scattering included.
+
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead use
     _pd_proc.intensity_* for corrected diffractograms.
@@ -1832,7 +1838,7 @@ save_pd_meas.counts_total
     _name.category_id             pd_meas
     _name.object_id               counts_total
     _type.purpose                 Number
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            0:
@@ -1871,13 +1877,15 @@ save_pd_meas.intensity_background
 
     _definition.id                '_pd_meas.intensity_background'
     _alias.definition_id          '_pd_meas_intensity_background'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Intensity measurements at the measurement point (see
-    the definition of _pd_meas.2theta_*). Scattering measured
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_ etc.). These intensities are measured
     without a specimen, specimen mounting etc., often
     referred to as the instrument background.
+
     Use these entries for measurements where intensity
     values are not counts (use _pd_meas.counts_* for event-counting
     measurements where the standard uncertainty is
@@ -1893,7 +1901,7 @@ save_pd_meas.intensity_background
     _name.category_id             pd_meas
     _name.object_id               intensity_background
     _type.purpose                 Measurand
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   none
@@ -1921,12 +1929,15 @@ save_pd_meas.intensity_container
 
     _definition.id                '_pd_meas.intensity_container'
     _alias.definition_id          '_pd_meas_intensity_container'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Intensity measurements at the measurement point (see
-    the definition of _pd_meas.2theta_*). The specimen container
-    or mounting without a specimen, includes background.
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_ etc.). These intensities are measured from
+    the specimen container or mounting without a specimen, includes
+    background.
+
     Use these entries for measurements where intensity
     values are not counts (use _pd_meas.counts_* for event-counting
     measurements where the standard uncertainty is
@@ -1942,7 +1953,7 @@ save_pd_meas.intensity_container
     _name.category_id             pd_meas
     _name.object_id               intensity_container
     _type.purpose                 Measurand
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   none
@@ -1970,12 +1981,14 @@ save_pd_meas.intensity_monitor
 
     _definition.id                '_pd_meas.intensity_monitor'
     _alias.definition_id          '_pd_meas_intensity_monitor'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Intensity measurements at the measurement point (see
-    the definition of _pd_meas.2theta_*). Intensity measured by an
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_ etc.). These intensities are measured by an
     incident-beam monitor to calibrate the flux on the specimen.
+
     Use these entries for measurements where intensity
     values are not counts (use _pd_meas.counts_* for event-counting
     measurements where the standard uncertainty is
@@ -1991,7 +2004,7 @@ save_pd_meas.intensity_monitor
     _name.category_id             pd_meas
     _name.object_id               intensity_monitor
     _type.purpose                 Measurand
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   none
@@ -2019,13 +2032,15 @@ save_pd_meas.intensity_total
 
     _definition.id                '_pd_meas.intensity_total'
     _alias.definition_id          '_pd_meas_intensity_total'
-    _definition.update            2022-09-28
+    _definition.update            2022-12-04
     _description.text
 ;
-    Intensity measurements at the measurement point (see
-    the definition of _pd_meas.2theta_*). Scattering from
-    the specimen (with background, specimen mounting or container
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_ etc.). These intensities are measured from
+    the specimen, with background, specimen mounting, and/or container
     scattering included.
+
     Use these entries for measurements where intensity
     values are not counts (use _pd_meas.counts_* for event-counting
     measurements where the standard uncertainty is
@@ -2041,7 +2056,7 @@ save_pd_meas.intensity_total
     _name.category_id             pd_meas
     _name.object_id               intensity_total
     _type.purpose                 Measurand
-    _type.source                  Derived
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   none
@@ -2069,13 +2084,13 @@ save_pd_meas.point_id
 
     _definition.id                '_pd_meas.point_id'
     _alias.definition_id          '_pd_meas_point_id'
-    _definition.update            2014-06-20
+    _definition.update            2022-12-04
     _description.text
 ;
     Arbitrary label identifying a measured data point. Used to
     identify a specific entry in a list of measured intensities.
     The role of this identifier may be adopted by
-    _pd_data.point_id if measured, processed and calculated
+    _pd_data.point_id if measured, processed, and/or calculated
     intensity values are combined in a single list.
 ;
     _name.category_id             pd_meas
@@ -2549,15 +2564,16 @@ save_pd_proc.intensity_net
 
     _definition.id                '_pd_proc.intensity_net'
     _alias.definition_id          '_pd_proc_intensity_net'
-    _definition.update            2014-06-20
+    _definition.update            2022-12-04
     _description.text
 ;
-    _pd_proc.intensity_net contains intensity values for the
-    processed diffractogram for each data point (see
-    _pd_proc.2theta_, _pd_proc.wavelength etc.) after
-    correction and normalization factors have been applied
-    (in contrast to _pd_meas.counts_ values, which are
-    uncorrected).
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    Intensity values for the processed diffractogram for
+    each data point (see _pd_proc.2theta_, _pd_proc.wavelength
+    etc.) after correction and normalization factors have been applied
+    (in contrast to _pd_meas.counts_ or _pd_meas.intensity_
+    values, which are uncorrected).
 ;
     _name.category_id             pd_proc
     _name.object_id               intensity_net
@@ -2649,10 +2665,10 @@ save_pd_proc.intensity_total
 ;
     Inclusion of s.u.'s for these values is strongly recommended.
 
-    _pd_proc.intensity_total contains intensity values for the
-    processed diffractogram for each data point where
-    background, normalization, and other corrections have not
-    been applied.
+    Intensity values for the processed diffractogram at each data
+    point as a function of angle, time, channel, or some other
+    variable (see _pd_meas.2theta_* etc.), where background, normalization,
+    or other corrections have not been applied.
 ;
     _name.category_id             pd_proc
     _name.object_id               intensity_total
@@ -6641,7 +6657,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-11-17
+         2.5.0                    2022-12-04
 ;
        ## Retain above version number and increment date until final
        ##release
@@ -6660,4 +6676,6 @@ save_
        Updated many datanames from Number to Measurand
 
        Made PD_BLOCK a Loop category
+
+       Updated intensity/count definitions in PD_CALC, PD_MEAS, and PD_PROC.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2022-12-04
+    _dictionary.date              2022-12-30
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -1703,7 +1703,7 @@ save_pd_meas.counts_background
 
     _definition.id                '_pd_meas.counts_background'
     _alias.definition_id          '_pd_meas_counts_background'
-    _definition.update            2022-12-04
+    _definition.update            2022-12-30
     _description.text
 ;
     Counts recorded at each measurement point as a function of
@@ -1713,8 +1713,10 @@ save_pd_meas.counts_background
     as the instrument background.
 
     Corrections for background, detector dead time etc.
-    should not have been made to these values. Instead use
-    _pd_proc.intensity_* for corrected diffractograms.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
 
     Note that counts-per-second values should be converted to
     total counts. If the counting time varies for different
@@ -1877,7 +1879,7 @@ save_pd_meas.intensity_background
 
     _definition.id                '_pd_meas.intensity_background'
     _alias.definition_id          '_pd_meas_intensity_background'
-    _definition.update            2022-12-04
+    _definition.update            2022-12-30
     _description.text
 ;
     Intensity recorded at each measurement point as a function of
@@ -1891,9 +1893,11 @@ save_pd_meas.intensity_background
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
 
-    Corrections for background, detector dead time etc.,
-    should not have been made to these values. Instead use
-    _pd_proc.intensity_* for corrected diffractograms.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
 
     _pd_meas.units_of_intensity should be used to specify
     the units of the intensity measurements.
@@ -1929,7 +1933,7 @@ save_pd_meas.intensity_container
 
     _definition.id                '_pd_meas.intensity_container'
     _alias.definition_id          '_pd_meas_intensity_container'
-    _definition.update            2022-12-04
+    _definition.update            2022-12-30
     _description.text
 ;
     Intensity recorded at each measurement point as a function of
@@ -1943,9 +1947,11 @@ save_pd_meas.intensity_container
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
 
-    Corrections for background, detector dead time etc.,
-    should not have been made to these values. Instead use
-    _pd_proc.intensity_* for corrected diffractograms.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
 
     _pd_meas.units_of_intensity should be used to specify
     the units of the intensity measurements.
@@ -1981,7 +1987,7 @@ save_pd_meas.intensity_monitor
 
     _definition.id                '_pd_meas.intensity_monitor'
     _alias.definition_id          '_pd_meas_intensity_monitor'
-    _definition.update            2022-12-04
+    _definition.update            2022-12-30
     _description.text
 ;
     Intensity recorded at each measurement point as a function of
@@ -1994,9 +2000,11 @@ save_pd_meas.intensity_monitor
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
 
-    Corrections for background, detector dead time etc.,
-    should not have been made to these values. Instead use
-    _pd_proc.intensity_* for corrected diffractograms.
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
 
     _pd_meas.units_of_intensity should be used to specify
     the units of the intensity measurements.
@@ -2032,7 +2040,7 @@ save_pd_meas.intensity_total
 
     _definition.id                '_pd_meas.intensity_total'
     _alias.definition_id          '_pd_meas_intensity_total'
-    _definition.update            2022-12-04
+    _definition.update            2022-12-30
     _description.text
 ;
     Intensity recorded at each measurement point as a function of
@@ -2564,16 +2572,17 @@ save_pd_proc.intensity_net
 
     _definition.id                '_pd_proc.intensity_net'
     _alias.definition_id          '_pd_proc_intensity_net'
-    _definition.update            2022-12-04
+    _definition.update            2022-12-30
     _description.text
 ;
     Inclusion of s.u.'s for these values is strongly recommended.
 
     Intensity values for the processed diffractogram for
     each data point (see _pd_proc.2theta_, _pd_proc.wavelength
-    etc.) after correction and normalization factors have been applied
-    (in contrast to _pd_meas.counts_ or _pd_meas.intensity_
-    values, which are uncorrected).
+    etc.) after background subtraction, normalization, and other
+    correction factors have been applied (in contrast to
+    _pd_meas.counts_ or _pd_meas.intensity_ values, which are
+    uncorrected).
 ;
     _name.category_id             pd_proc
     _name.object_id               intensity_net
@@ -2581,7 +2590,6 @@ save_pd_proc.intensity_net
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _enumeration.range            0.0:
     _units.code                   none
 
 save_
@@ -2612,10 +2620,14 @@ save_pd_proc.intensity_norm
 ;
     Inclusion of s.u.'s for these values is strongly recommended.
 
-    Background values should be on the same scale as the
-    _pd_proc.intensity_net values. Thus normalization and correction
-    factors should be applied before background subtraction (or
-    should be applied to the background values equally).
+    Values in this data item are normalisation-corrected and contain
+    a background component.
+
+    Background values (for example, given by _pd_proc.intensity_bkg_calc)
+    should be on the same scale as the _pd_proc.intensity_net values.
+    Thus normalization and correction factors should be applied before
+    background subtraction (or should be applied to the background values
+    equally).
 
     Normalization factors applied to the data set (for
     example, Lp corrections, compensation for variation in
@@ -6657,10 +6669,10 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2022-12-04
+         2.5.0                    2022-12-30
 ;
        ## Retain above version number and increment date until final
-       ##release
+       ## release
 
        Added mass absorption coefficient and improved absorption
        definitions. Added missing su definitions.
@@ -6678,4 +6690,9 @@ save_
        Made PD_BLOCK a Loop category
 
        Updated intensity/count definitions in PD_CALC, PD_MEAS, and PD_PROC.
+
+       Updated descriptions of _pd_meas.counts, _pd_meas.intensity_background,
+       _pd_meas.intensity_container, and _pd_meas.intensity_monitor
+
+       Removed enumeration range for _pd_proc.intensity_net
 ;


### PR DESCRIPTION
Was initially looking just to address #42 .

But I now have other questions:
- `pd_meas.counts/intensity_` should be `Recorded`, not `Derived` - Addressed in this initial commit.
- Some ambiguity in definitions of `_pd_proc.intensity_norm` and `_pd_proc.intensity_net`: which one contains a bkg? From the definition of `_pd_calc.intensity_net`, I'm guessing `_pd_proc.intensity_net` is background-corrected and normalisation-corrected, and the other is just normalisation-corrected.
- Should all `_pd_proc.intensity_*` and `_pd_calc.intensity_*` have their values limited to be > 0 (as is currently)? ( c.f. discussion in [cif_core](https://github.com/COMCIFS/cif_core/pull/315#issuecomment-1328622630))
- The definitions of `_pd_meas.counts/intensity_background/container/monitor` say (amongst other things...)
   -  >    Corrections for background, detector dead time etc. should not have been made to these values. Instead use `_pd_proc.intensity_*` for corrected diffractograms.
   - There is no direct `_pd_proc.` equivalent to these data names. Does this above paragraph mean that you should use `_pd_proc.intensity_net/norm/total` as appropriate, after doing the corrections? or are there missing `_pd_proc.intensity_background/container/monitor` data names?
