### PR TITLE
Improve calibration metadata in pdCIF files

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -724,6 +724,230 @@ save_pd_calib_d_to_tof.power
 
 save_
 
+save_PD_CALIB_INTENSITY
+
+    _definition.id                PD_CALIB_INTENSITY
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-04
+    _description.text
+;
+    This section defines the parameters used for the intensity
+    calibration of the instrument that are used directly or
+    indirectly in the interpretation of this data set. The
+    information in this section of the CIF should generally be
+    written when the intensities are first measured, but from then
+    on should remain unchanged. Loops should only be used for calibration
+    information that differs by detector channel.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_INTENSITY
+
+    loop_
+      _category_key.name
+      '_pd_calib_intensity.detector_id'
+      '_pd_calib_intensity.id'
+
+save_
+
+save_pd_calib_intensity.block_id
+
+    _definition.id                '_pd_calib_intensity.block_id'
+    _definition.update            2023-01-04
+    _description.text
+;
+    A block ID code identifying the diffractogram from which the
+    intensity calibration was taken, if it was calibrated by a
+    specimen.
+
+    The data block containing the diffraction pattern will be
+    identified with a _pd_block.id code matching the code in
+    _pd_calib_intensity.block_id.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               block_id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_intensity.detector_id
+
+    _definition.id                '_pd_calib_intensity.detector_id'
+    _definition.update            2023-01-04
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument. Note that this code should match the code name used
+    for _pd_meas.detector_id.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_meas.detector_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_intensity.detector_response
+
+    _definition.id                '_pd_calib_intensity.detector_response'
+    _definition.update            2023-01-04
+    _description.text
+;
+    A value that indicates the relative sensitivity of each
+    detector. This can compensate for differences in electronics,
+    size and collimation. Usually, one detector or the mean for
+    all detectors will be assigned the value of 1.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               detector_response
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calib_intensity.detector_response_su
+
+    _definition.id                '_pd_calib_intensity.detector_response_su'
+    _definition.update            2023-01-04
+    _description.text
+;
+    Standard uncertainty of _pd_calib_intensity.detector_response.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               detector_response_su
+    _name.linked_item_id          '_pd_calib_intensity.detector_response'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_intensity.id
+
+    _definition.id                '_pd_calib_intensity.id'
+    _definition.update            2023-01-04
+    _description.text
+;
+    A code to uniquely identify each intensity calibration.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _enumeration.default          .
+
+save_
+
+save_pd_calib_intensity.incident_intensity
+
+    _definition.id                '_pd_calib_intensity.incident_intensity'
+    _definition.update            2023-01-04
+    _description.text
+;
+    A value that indicates the intensity incident on the specimen.
+    This value should be a constant for each diffractgram. For
+    point-wise corrections, see _pd_meas.intensity_monitor.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               incident_intensity
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calib_intensity.incident_intensity_su
+
+    _definition.id                '_pd_calib_intensity.incident_intensity_su'
+    _definition.update            2023-01-04
+    _description.text
+;
+    Standard uncertainty of _pd_calib_intensity.incident_intensity.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               incident_intensity_su
+    _name.linked_item_id          '_pd_calib_intensity.incident_intensity'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_intensity.phase_id
+
+    _definition.id                '_pd_calib_intensity.phase_id'
+    _definition.update            2023-01-04
+    _description.text
+;
+    A code which identifies the particular phase from which
+    this intensity was taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_intensity.phase_name
+
+    _definition.id                '_pd_calib_intensity.phase_name'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Identity of material(s) used as an intensity standard.
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               phase_name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'NIST 640a Silicon standard'
+         'Al2O3'
+
+save_
+
+save_pd_calib_intensity.special_details
+
+    _definition.id                '_pd_calib_intensity.special_details'
+    _definition.update            2023-01-04
+    _description.text
+;
+    Description of intensity calibration details that cannot otherwise
+    be recorded using other PD_CALIB_INTENSITY data items
+;
+    _name.category_id             pd_calib_intensity
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_PD_CALIB_OFFSET
 
     _definition.id                PD_CALIB_OFFSET
@@ -2051,6 +2275,9 @@ save_pd_meas.intensity_monitor
     angle, time, channel, or some other variable (see
     _pd_meas.2theta_ etc.). These intensities are measured by an
     incident-beam monitor to calibrate the flux on the specimen.
+
+    For intensity corrections which are a constant for each diffractogram,
+    rather than for each point, see _pd_calib_intensity.incident_intensity.
 
     Use these entries for measurements where intensity
     values are not counts (use _pd_meas.counts_* for event-counting


### PR DESCRIPTION
Originally from #46, then a new issue in #53, now a PR.

This initial commit creates `PD_CALIB_INTENSITY`


