### PR TITLE
changed _pd_meas.time_of_flight and _pd_meas.step_count_time from Integer to Real

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2243,7 +2243,7 @@ save_pd_meas.step_count_time
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _enumeration.range            0:
+    _enumeration.range            0.0:
     _units.code                   seconds
 
 save_
@@ -2282,7 +2282,7 @@ save_pd_meas.time_of_flight
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _enumeration.range            0:
+    _enumeration.range            0.0:
     _units.code                   microseconds
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7963,7 +7963,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-03
+         2.5.0                    2023-01-06
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-03
+    _dictionary.date              2023-01-06
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -2232,7 +2232,7 @@ save_pd_meas.step_count_time
 
     _definition.id                '_pd_meas.step_count_time'
     _alias.definition_id          '_pd_meas_step_count_time'
-    _definition.update            2022-10-11
+    _definition.update            2023-01-06
     _description.text
 ;
     The count time in seconds for each intensity measurement.
@@ -2242,7 +2242,7 @@ save_pd_meas.step_count_time
     _type.purpose                 Measurand
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Integer
+    _type.contents                Real
     _enumeration.range            0:
     _units.code                   seconds
 
@@ -2269,7 +2269,7 @@ save_pd_meas.time_of_flight
 
     _definition.id                '_pd_meas.time_of_flight'
     _alias.definition_id          '_pd_meas_time_of_flight'
-    _definition.update            2022-10-11
+    _definition.update            2023-01-06
     _description.text
 ;
     Measured time in microseconds for time-of-flight neutron
@@ -2281,7 +2281,7 @@ save_pd_meas.time_of_flight
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Integer
+    _type.contents                Real
     _enumeration.range            0:
     _units.code                   microseconds
 
@@ -6188,7 +6188,7 @@ save_pd_pref_orient_sphericalharmonics.y_ij
     further information.
 ;
     _name.category_id             pd_pref_orient_sphericalharmonics
-    _name.object_id               y_ijp
+    _name.object_id               y_ij
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Matrix
@@ -8002,4 +8002,7 @@ save_
 
        Created PD_QPA_RIR to record quantitative phase analysis by
        the reference intensity ratio approach.
+
+       Changed _pd_meas.step_count_time and _pd_meas.time_of_flight from
+       Integer to Real
 ;


### PR DESCRIPTION
from #60 

The only things that are still integers are:

- `_pd_meas.counts_background`, `counts_container`, `counts_monitor`, and `counts_total`.
- `_pd_meas.number_of_points`
- `_pd_pref_orient_March_Dollase.hkl`, `index_h`, `index_k`, `index_l`
- `_pd_pref_orient_sphericalharmonics.y_i`, `y_ij`, `y_j`
- `_pd_proc.number_of_points`