### PR TITLE
Fix typos

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3524,7 +3524,7 @@ save_pd_instr.slit_eq_mono_spec
     containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Ollimation between the monochromator and the specimen.
+    collimation between the monochromator and the specimen.
     Note that *_src_spec is used in place of *_src_mono and
     *_mono_spec if there is no monochromator in use.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4428,7 +4428,7 @@ save_pd_instr.soller_eq_spec_detc
     instrument. Values are the maximum divergence angles in degrees,
     as limited by Soller slits located between the specimen and the
     detectoomator in use, and *_spec_detc is used in place of
-    *_spec_anal and *_anal_detc if there is no analys er in use.
+    *_spec_anal and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
     _name.object_id               soller_eq_spec_detc
@@ -5560,8 +5560,8 @@ save_PD_PREF_ORIENT
     _description.text
 ;
     This section contains a description of preferred-orientation
-    corrections applied to a phase when modelling it's contribution
-    to a hisotgram.
+    corrections applied to a phase when modelling its contribution
+    to a histogram.
 
     March_Dollase and spherical harmonics corrections can be
     given explicitly. For other methods, use the special_details.
@@ -5623,7 +5623,7 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
 ;
     This section contains a description of March_Dollase
     preferred-orientation corrections applied to a phase
-    when modelling it's contribution to a hisotgram.
+    when modelling its contribution to a histogram.
 
     For spherical harmonics corrections, see
     PD_PREF_ORIENT_SPHERICALHARMONICS. For other methods,
@@ -5929,8 +5929,8 @@ save_PD_PREF_ORIENT_SPHERICALHARMONICS
 ;
     This section contains a description of spherical
     harmonics preferred-orientation corrections applied
-    to a phase when modelling it's contribution to a
-    hisotgram.
+    to a phase when modelling its contribution to a
+    histogram.
 
     For March_Dollase corrections, see
     PD_PREF_ORIENT_MARCH-DOLLASE. For other methods,
@@ -6014,7 +6014,7 @@ save_pd_pref_orient_sphericalharmonics.geom
     Code identifying the geometry of the preferred-orientation
     correction, as distinct from the geometry of data collection.
 
-    The functional form of thespherical harmonics correction depends
+    The functional form of the spherical harmonics correction depends
     on whether the data were collected in symmetric or asymmetric
     reflection or transmission, or capillary geometries. See
     Section 3, Rowles & Buckley (2017) J. Appl. Cryst. (2017).
@@ -6098,7 +6098,7 @@ save_pd_pref_orient_sphericalharmonics.texture_index
     and infty is an ideal single crystal.
 
     Bunge, H.J., (2015) "Texture Analysis in Materials Science:
-    Mathemical Methods", Helga and Hans-Peter Bunge,
+    Mathematical Methods", Helga and Hans-Peter Bunge,
     Wolfratshausen.
 ;
     _name.category_id             pd_pref_orient_sphericalharmonics
@@ -6179,7 +6179,7 @@ save_pd_pref_orient_sphericalharmonics.y_ij
     valid orders are positive, even integers, and possible
     terms are in the range -i:i. Valid terms are restricted
     by space-group symmetry. The parity of the term is given
-    by it's sign; odd parity is negative, even is positive.
+    by its sign; odd parity is negative, even is positive.
 
     Omitting _pd_pref_orient.* implies that no preferred-
     orientation correction has been used.
@@ -6213,7 +6213,7 @@ save_pd_pref_orient_sphericalharmonics.y_j
 ;
     The term (j) of the given order (i) of the spherical harmonics
     preferred-orientation correction. The parity of the term
-    is given by it's sign; odd parity is negative, even is positive.
+    is given by its sign; odd parity is negative, even is positive.
 
     In general, possible values are in the range -i:i. Valid values
     are dependent on the space-group of the phase.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7089,7 +7089,7 @@ save_pd_qpa_ext_std.k_factor
     _definition.update            2023-01-03
     _description.text
 ;
-    The value of the diffractometer constant, K,applied to the
+    The value of the diffractometer constant, K, applied to the
     quantification of the phases present in the given diffractogram.
 
     The external standard method is described by O'Connor and Raven.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3291,7 +3291,7 @@ save_pd_instr.divg_eq_src_mono
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) between the radiation source
-    and monochromator Values are the maximum divergence angles in
+    and monochromator. Values are the maximum divergence angles in
     degrees, as limited by slits or beamline optics
     other than Soller slits (see _pd_instr.soller_eq_).
     Note that *_src_spec is used in place of *_src_mono and

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3850,7 +3850,7 @@ save_pd_instr.2theta_monochr_post
     _description.text
 ;
     The 2\\q angle for a post-specimen
-    monochromator (also called an analyzer)
+    monochromator (also called an analyser)
     (see also _pd_instr.monochr_post_spec).
 ;
     _name.category_id             pd_instr_detector

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3472,7 +3472,7 @@ save_pd_instr.slit_ax_src_mono
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Collimation between the radiation source and monochromator.
+    collimation between the radiation source and monochromator.
     Note that *_src_spec is used in place of *_src_mono and
     *_mono_spec if there is no monochromator in use.
 ;
@@ -3498,7 +3498,7 @@ save_pd_instr.slit_ax_src_spec
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Collimation between the radiation source and the specimen. Note
+    collimation between the radiation source and the specimen. Note
     that *_src_spec is used in place of *_src_mono and *_mono_spec
     if there is no monochromator in use.
 ;
@@ -3550,7 +3550,7 @@ save_pd_instr.slit_eq_src_mono
     containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Collimation between the radiation source and monochromator.
+    collimation between the radiation source and monochromator.
     Note that *_src_spec is used in place of *_src_mono and
     *_mono_spec if there is no monochromator in use.
 ;
@@ -4197,7 +4197,7 @@ save_pd_instr.slit_ax_spec_detc
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Collimation between the specimen and the detector. Note that
+    collimation between the specimen and the detector. Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
     there is no analyser in use.
 ;
@@ -4248,7 +4248,7 @@ save_pd_instr.slit_eq_spec_anal
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) for the instrument
     as a slit width (as opposed to a divergence angle). Values are
-    the width of the slit (in millimetres) defining Collimation
+    the width of the slit (in millimetres) defining collimation
     between the specimen and the analyser. Note that *_spec_detc is
     used in place of *_spec_anal and *_anal_detc if there is no
     analyser in use.
@@ -4274,7 +4274,7 @@ save_pd_instr.slit_eq_spec_detc
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) for the instrument
     as a slit width (as opposed to a divergence angle). Values are
-    the width of the slit (in millimetres) defining Collimation
+    the width of the slit (in millimetres) defining collimation
     between the specimen and the detector. Note that *_spec_detc is
     used in place of *_spec_anal and *_anal_detc if there is no
     analyser in use.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4427,7 +4427,7 @@ save_pd_instr.soller_eq_spec_detc
     containing the incident and diffracted beams) for the
     instrument. Values are the maximum divergence angles in degrees,
     as limited by Soller slits located between the specimen and the
-    detectoomator in use, and *_spec_detc is used in place of
+    detector in use, and *_spec_detc is used in place of
     *_spec_anal and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3941,7 +3941,7 @@ save_pd_instr.divg_ax_anal_detc
     the plane containing the incident and diffracted beams) between
     the analyser and the detector. Values are the maximum divergence
     angles in degrees, as limited by slits or beamline optics other
-    than Soller slits (see _pd_instr.soller_ax_): Note that
+    than Soller slits (see _pd_instr.soller_ax_). Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
     there is no analyser in use.
 ;
@@ -3969,8 +3969,7 @@ save_pd_instr.divg_ax_spec_anal
     Values are the maximum divergence angles in
     degrees, as limited by slits or beamline optics
     other than Soller slits (see _pd_instr.soller_ax_).
-    Note that
-    *_spec_detc is used in place of *_spec_anal and *_anal_detc
+    Note that *_spec_detc is used in place of *_spec_anal and *_anal_detc
     if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -3996,7 +3995,7 @@ save_pd_instr.divg_ax_spec_detc
     and diffracted beams) between the specimen and the detector.
     Values are the maximum divergence angles in
     degrees, as limited by slits or beamline optics
-    other than Soller slits (see _pd_instr.soller_ax_).
+    other than Soller slits (see _pd_instr.soller_ax_). Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc
     if there is no analyser in use.
 ;
@@ -4074,9 +4073,9 @@ save_pd_instr.divg_eq_spec_detc
     containing the incident and diffracted beams) between the
     specimen and the detector. Values are the maximum divergence
     angles in degrees, as limited by slits or beamline optics other
-    than Soller slits (see _pd_instr.soller_eq_): *_spec_detc is
-    used in place of *_spec_anal and *_anal_detc if there is no
-    analyser in use.
+    than Soller slits (see _pd_instr.soller_eq_). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
     _name.object_id               divg_eq_spec_detc
@@ -4327,7 +4326,7 @@ save_pd_instr.soller_ax_spec_anal
     the plane containing the incident and diffracted beams) for the
     instrument.  Values are the maximum divergence angles in
     degrees, as limited by Soller slits located between the specimen
-    and the analyser; Note that *_spec_detc is used in place of
+    and the analyser. Note that *_spec_detc is used in place of
     *_spec_anal and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -4377,7 +4376,7 @@ save_pd_instr.soller_eq_anal_detc
     containing the incident and diffracted beams) for the
     instrument. Values are the maximum divergence angles in degrees,
     as limited by Soller slits located between the analyser and the
-    detector; Note that *_spec_detc is used in place of *_spec_anal
+    detector. Note that *_spec_detc is used in place of *_spec_anal
     and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -4427,7 +4426,7 @@ save_pd_instr.soller_eq_spec_detc
     containing the incident and diffracted beams) for the
     instrument. Values are the maximum divergence angles in degrees,
     as limited by Soller slits located between the specimen and the
-    detector in use, and *_spec_detc is used in place of
+    detector in use. Note that *_spec_detc is used in place of
     *_spec_anal and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7027,7 +7027,7 @@ save_PD_QPA_EXT_STD
     an indication of amorphous content. This method requires the
     mass attenuation coefficient of the specimen to be measured or
     calculated. For a review on quantitative phase analysis, see
-    Chapter 3.9 of Internation Tables, Vol. H, and references therein.
+    Chapter 3.9 of International Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_EXT_STD
@@ -7207,7 +7207,7 @@ save_PD_QPA_INT_STD
     giving an indication of amorphous content.
 
     For a review on quantitative phase analysis, see Chapter 3.9 of
-    Internation Tables, Vol. H, and references therein.
+    International Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_INT_STD
@@ -7374,7 +7374,7 @@ save_PD_QPA_RIR
     The sum is taken over all phases present in the specimen.
 
     For a review on quantitative phase analysis, see Chapter 3.9 of
-    Internation Tables, Vol. H, and references therein.
+    International Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_INT_STD

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5563,7 +5563,7 @@ save_PD_PREF_ORIENT
     corrections applied to a phase when modelling its contribution
     to a histogram.
 
-    March_Dollase and spherical harmonics corrections can be
+    March-Dollase and spherical harmonics corrections can be
     given explicitly. For other methods, use the special_details.
 
     See Dollase, W. A. (1986). J. Appl. Cryst. 19, 267-272 and
@@ -5583,7 +5583,7 @@ save_pd_pref_orient.special_details
 ;
     Description of the preferred-orientation correction if
     such a correction is used, and it cannot be described
-    as a March_Dollase or spherical harmonics correction.
+    as a March-Dollase or spherical harmonics correction.
 
     or
 
@@ -5591,7 +5591,7 @@ save_pd_pref_orient.special_details
     used in the application of a preferred-orientation model
     that cannot be specified elsewhere.
 
-    If the correction can be described as a March_Dollase
+    If the correction can be described as a March-Dollase
     or spherical harmonics correction, use
     _pd_pref_orient_March_Dollase.* or
     _pd_pref_orient_sphericalharmonics.*, as
@@ -5621,7 +5621,7 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
     _definition.update            2022-11-17
     _description.text
 ;
-    This section contains a description of March_Dollase
+    This section contains a description of March-Dollase
     preferred-orientation corrections applied to a phase
     when modelling its contribution to a histogram.
 
@@ -5668,7 +5668,7 @@ save_pd_pref_orient_March_Dollase.fract
     _definition.update            2022-11-17
     _description.text
 ;
-    In the case of multiple March_Dollase preferred-orientation
+    In the case of multiple March-Dollase preferred-orientation
     directions for a single phase, this denotes the fractional
     amount of preferred orientation in each direction.
 
@@ -5711,7 +5711,7 @@ save_pd_pref_orient_March_Dollase.geom
     Code identifying the geometry of the preferred-orientation
     correction, as distinct from the geometry of data collection.
 
-    The functional form of the March_Dollase correction depends
+    The functional form of the March-Dollase correction depends
     on whether the data were collected in symmetric or asymmetric
     reflection or transmission, or capillary geometries. See
     Section 3, Rowles & Buckley (2017) J. Appl. Cryst. (2017).
@@ -5746,7 +5746,7 @@ save_pd_pref_orient_March_Dollase.hkl
     _definition.update            2022-11-17
     _description.text
 ;
-    Miller indices of the March_Dollase preferred-orientation
+    Miller indices of the March-Dollase preferred-orientation
     direction.
 ;
     _name.category_id             pd_pref_orient_March_Dollase
@@ -5775,7 +5775,7 @@ save_pd_pref_orient_March_Dollase.id
     _definition.update            2022-11-17
     _description.text
 ;
-    A code to uniquely identify each March_Dollase
+    A code to uniquely identify each March-Dollase
     preferred-orientation correction.
 ;
     _name.category_id             pd_pref_orient_March_Dollase
@@ -5794,7 +5794,7 @@ save_pd_pref_orient_March_Dollase.index_h
     _definition.update            2022-11-17
     _description.text
 ;
-    The h Miller index of the March_Dollase preferred-orientation
+    The h Miller index of the March-Dollase preferred-orientation
     direction.
 ;
     _name.category_id             pd_pref_orient_March_Dollase
@@ -5813,7 +5813,7 @@ save_pd_pref_orient_March_Dollase.index_k
     _definition.update            2022-11-17
     _description.text
 ;
-    The k Miller index of the March_Dollase preferred-orientation
+    The k Miller index of the March-Dollase preferred-orientation
     direction.
 ;
     _name.category_id             pd_pref_orient_March_Dollase
@@ -5832,7 +5832,7 @@ save_pd_pref_orient_March_Dollase.index_l
     _definition.update            2022-11-17
     _description.text
 ;
-    The l Miller index of the March_Dollase preferred-orientation
+    The l Miller index of the March-Dollase preferred-orientation
     direction.
 ;
     _name.category_id             pd_pref_orient_March_Dollase
@@ -5932,7 +5932,7 @@ save_PD_PREF_ORIENT_SPHERICALHARMONICS
     to a phase when modelling its contribution to a
     histogram.
 
-    For March_Dollase corrections, see
+    For March-Dollase corrections, see
     PD_PREF_ORIENT_MARCH-DOLLASE. For other methods,
     use _pd_pref_orient.special_details.
 
@@ -6612,7 +6612,7 @@ save_pd_proc_ls.pref_orient_corr
     _description.text
 ;
     DEPRECATED. Use _pd_pref_orient.special_details, or if
-    the correction can be described as a March_Dollase
+    the correction can be described as a March-Dollase
     or spherical harmonics correction, use
     _pd_pref_orient.March_Dollase* or
     _pd_pref_orient.sphericalharmonics*, as

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -142,7 +142,7 @@ save_pd_block.id
 
     The sections are separated with vertical rules '|' which are
     not allowed within the sections. Blank spaces may also
-    not be used.  Capitalization may be used within the ID code
+    not be used. Capitalization may be used within the ID code
     but should not be considered significant - searches for
     data-set ID names should be case-insensitive.
 
@@ -386,7 +386,7 @@ save_pd_calc.method
     calculated from crystal structure data for a single phase, the
     atom coordinates and other crystallographic information should
     be included in the datablock using the core CIF ATOM_SITE and
-    CELL data items.  If multiple phases were used, these should
+    CELL data items. If multiple phases were used, these should
     be listed in the pd_phase category.
 ;
     _name.category_id             pd_calc_overall
@@ -890,7 +890,7 @@ save_pd_calib_offset.id
     _description.text
 ;
     An arbitrary code which identifies a particular 2\\q offset
-    description.  As a default value is defined, this may be
+    description. As a default value is defined, this may be
     omitted if only a single offset is provided.
 ;
     _name.category_id             pd_calib_offset
@@ -2943,7 +2943,7 @@ save_PD_INSTR
     In the PD_INSTR definitions, the term monochromator refers
     to a primary beam (pre-specimen) monochromator and the term
     analyser refers to post-diffraction (post-specimen)
-    monochromator.  The analyser may be fixed for specific
+    monochromator. The analyser may be fixed for specific
     wavelength or may be capable of being scanned.
 
     It is strongly recommended that the core dictionary term
@@ -3140,7 +3140,7 @@ save_pd_instr.dist_src_mono
     _description.text
 ;
     Specifies distance in millimetres from the radiation source to
-    the monochromator.  Note that *_src_spec is used in place of
+    the monochromator. Note that *_src_spec is used in place of
     *_src_mono and *_mono_spec if there is no monochromator in use.
 ;
     _name.category_id             pd_instr
@@ -3162,7 +3162,7 @@ save_pd_instr.dist_src_spec
     _description.text
 ;
     Specifies distances in millimetres from the radiation source to
-    the specimen.  Note that *_src_spec is used in place of
+    the specimen. Note that *_src_spec is used in place of
     *_src_mono and *_mono_spec if there is no monochromator in use
 ;
     _name.category_id             pd_instr
@@ -3212,9 +3212,9 @@ save_pd_instr.divg_ax_src_mono
 ;
     Describes collimation in the axial direction (perpendicular to
     the plane containing the incident and diffracted beams) between
-    the radiation source and monochromator.  Values are the maximum
+    the radiation source and monochromator. Values are the maximum
     divergence angles in degrees, as limited by slits or beamline
-    optics other than Soller slits (see _pd_instr.soller_ax_).  Note
+    optics other than Soller slits (see _pd_instr.soller_ax_). Note
     that *_src_spec is used in place of *_src_mono and *_mono_spec
     if there is no monochromator in use.
 ;
@@ -3317,9 +3317,9 @@ save_pd_instr.divg_eq_src_spec
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) between the
-    radiation source and specimen.  Values are the maximum
+    radiation source and specimen. Values are the maximum
     divergence angles in degrees, as limited by slits or beamline
-    optics other than Soller slits (see _pd_instr.soller_eq_).  Note
+    optics other than Soller slits (see _pd_instr.soller_eq_). Note
     that *_src_spec is used in place of *_src_mono and *_mono_spec
     if there is no monochromator in use.
 ;
@@ -3498,7 +3498,7 @@ save_pd_instr.slit_ax_src_spec
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Collimation between the radiation source and the specimen.  Note
+    Collimation between the radiation source and the specimen. Note
     that *_src_spec is used in place of *_src_mono and *_mono_spec
     if there is no monochromator in use.
 ;
@@ -3600,9 +3600,9 @@ save_pd_instr.soller_ax_mono_spec
 ;
     Describes collimation in the axial direction (perpendicular to
     the plane containing the incident and diffracted beams) for the
-    instrument.  Values are the maximum divergence angles in
+    instrument. Values are the maximum divergence angles in
     degrees, as limited by Soller slits located between the
-    monochromator and specimen.  Note that *_src_spec is used in
+    monochromator and specimen. Note that *_src_spec is used in
     place of *_src_mono and *_mono_spec if there is no monochromator
     in use.
 ;
@@ -3655,9 +3655,9 @@ save_pd_instr.soller_ax_src_spec
 ;
     Describes collimation in the axial direction (perpendicular to
     the plane containing the incident and diffracted beams) for the
-    instrument.  Values are the maximum divergence angles in
+    instrument. Values are the maximum divergence angles in
     degrees, as limited by Soller slits located between the
-    radiation source and specimen.  Note that *_src_spec is used in
+    radiation source and specimen. Note that *_src_spec is used in
     place of *_src_mono and *_mono_spec if there is no monochromator
     in use.
 ;
@@ -3736,7 +3736,7 @@ save_pd_instr.soller_eq_src_spec
     containing the incident and diffracted beams) for the
     instrument. Values are the maximum divergence angles in degrees,
     as limited by Soller slits located between the radiation source
-    and monochromator.  Note that *_src_spec is used in place of
+    and monochromator. Note that *_src_spec is used in place of
     *_src_mono and *_mono_spec if there is no monochromator in use.
 ;
     _name.category_id             pd_instr
@@ -3758,7 +3758,7 @@ save_pd_instr.source_size_ax
     _description.text
 ;
     Axial intrinsic dimension of the radiation source (in
-    millimetres).  The perpendicular to the plane containing the
+    millimetres). The perpendicular to the plane containing the
     incident and scattered beam is the axial (*_ax) direction.
 ;
     _name.category_id             pd_instr
@@ -3780,7 +3780,7 @@ save_pd_instr.source_size_eq
     _description.text
 ;
     Equatorial intrinsic dimension of the radiation source (in
-    millimetres).  The equatorial direction is in the plane
+    millimetres). The equatorial direction is in the plane
     containing the incident and scattered beam.
 ;
     _name.category_id             pd_instr
@@ -3828,7 +3828,7 @@ save_PD_INSTR_DETECTOR
     may be prepared and included with each data set.
 
     The term analyser refers to post-diffraction (post-specimen)
-    monochromator.  The analyser may be fixed for specific
+    monochromator. The analyser may be fixed for specific
     wavelength or may be capable of being scanned.
 
     For multiple-detector instruments it may be necessary to loop the
@@ -3894,7 +3894,7 @@ save_pd_instr.dist_spec_anal
     _description.text
 ;
     Specifies distances in millimetres from the specimen to the
-    analyser.  Note that *_spec_detc is used in place of *_spec_anal
+    analyser. Note that *_spec_detc is used in place of *_spec_anal
     if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -3916,7 +3916,7 @@ save_pd_instr.dist_spec_detc
     _description.text
 ;
     Specifies distance in millimetres from the specimen to the
-    detector.  Note that *_spec_anal and *_anal_detc are used
+    detector. Note that *_spec_anal and *_anal_detc are used
     instead of *_spec_detc if there is an analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -4019,9 +4019,9 @@ save_pd_instr.divg_eq_anal_detc
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) between the
-    analyser and the detector.  Values are the maximum divergence
+    analyser and the detector. Values are the maximum divergence
     angles in degrees, as limited by slits or beamline optics other
-    than Soller slits (see _pd_instr.soller_eq_).  Note that
+    than Soller slits (see _pd_instr.soller_eq_). Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
     there is no analyser in use.
 ;
@@ -4045,7 +4045,7 @@ save_pd_instr.divg_eq_spec_anal
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) between the
-    specimen and the analyser.  Values are the maximum divergence
+    specimen and the analyser. Values are the maximum divergence
     angles in degrees, as limited by slits or beamline optics other
     than Soller slits (see _pd_instr.soller_eq_). Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
@@ -4145,7 +4145,7 @@ save_pd_instr.slit_ax_anal_detc
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    collimation between the analyser and the detector.  Note that
+    collimation between the analyser and the detector. Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
     there is no analyser in use.
 ;
@@ -4171,7 +4171,7 @@ save_pd_instr.slit_ax_spec_anal
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    collimation between the specimen and the analyser.  Note that
+    collimation between the specimen and the analyser. Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
     there is no analyser in use.
 ;
@@ -4197,7 +4197,7 @@ save_pd_instr.slit_ax_spec_detc
     the plane containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Collimation between the specimen and the detector.  Note that
+    Collimation between the specimen and the detector. Note that
     *_spec_detc is used in place of *_spec_anal and *_anal_detc if
     there is no analyser in use.
 ;
@@ -4221,9 +4221,9 @@ save_pd_instr.slit_eq_anal_detc
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) for the instrument
-    as a slit width (as opposed to a divergence angle).  Values are
+    as a slit width (as opposed to a divergence angle). Values are
     the width of the slit (in millimetres) defining collimation
-    between the analyser and the detector.  Note that *_spec_detc is
+    between the analyser and the detector. Note that *_spec_detc is
     used in place of *_spec_anal and *_anal_detc if there is no
     analyser in use.
 ;
@@ -4247,9 +4247,9 @@ save_pd_instr.slit_eq_spec_anal
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) for the instrument
-    as a slit width (as opposed to a divergence angle).  Values are
+    as a slit width (as opposed to a divergence angle). Values are
     the width of the slit (in millimetres) defining Collimation
-    between the specimen and the analyser.  Note that *_spec_detc is
+    between the specimen and the analyser. Note that *_spec_detc is
     used in place of *_spec_anal and *_anal_detc if there is no
     analyser in use.
 ;
@@ -4273,9 +4273,9 @@ save_pd_instr.slit_eq_spec_detc
 ;
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) for the instrument
-    as a slit width (as opposed to a divergence angle).  Values are
+    as a slit width (as opposed to a divergence angle). Values are
     the width of the slit (in millimetres) defining Collimation
-    between the specimen and the detector.  Note that *_spec_detc is
+    between the specimen and the detector. Note that *_spec_detc is
     used in place of *_spec_anal and *_anal_detc if there is no
     analyser in use.
 ;
@@ -4299,9 +4299,9 @@ save_pd_instr.soller_ax_anal_detc
 ;
     Describes collimation in the axial direction (perpendicular to
     the plane containing the incident and diffracted beams) for the
-    instrument.  Values are the maximum divergence angles in
+    instrument. Values are the maximum divergence angles in
     degrees, as limited by Soller slits located between the analyser
-    and the detector.  Note that *_spec_detc is used in place of
+    and the detector. Note that *_spec_detc is used in place of
     *_spec_anal and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -4324,7 +4324,7 @@ save_pd_instr.soller_ax_spec_anal
 ;
     Describes collimation in the axial direction (perpendicular to
     the plane containing the incident and diffracted beams) for the
-    instrument.  Values are the maximum divergence angles in
+    instrument. Values are the maximum divergence angles in
     degrees, as limited by Soller slits located between the specimen
     and the analyser. Note that *_spec_detc is used in place of
     *_spec_anal and *_anal_detc if there is no analyser in use.
@@ -4349,9 +4349,9 @@ save_pd_instr.soller_ax_spec_detc
 ;
     Describes collimation in the axial direction (perpendicular to
     the plane containing the incident and diffracted beams) for the
-    instrument.  Values are the maximum divergence angles in
+    instrument. Values are the maximum divergence angles in
     degrees, as limited by Soller slits located between the specimen
-    and the detector.  Note that *_spec_detc is used in place of
+    and the detector. Note that *_spec_detc is used in place of
     *_spec_anal and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -4401,7 +4401,7 @@ save_pd_instr.soller_eq_spec_anal
     containing the incident and diffracted beams) for the
     instrument. Values are the maximum divergence angles in degrees,
     as limited by Soller slits located between the specimen and the
-    analyser.  Note that *_spec_detc is used in place of *_spec_anal
+    analyser. Note that *_spec_detc is used in place of *_spec_anal
     and *_anal_detc if there is no analyser in use.
 ;
     _name.category_id             pd_instr_detector
@@ -4450,7 +4450,7 @@ save_pd_instr_detector.id
     position-sensitive, energy-dispersive or other multiple-detector
     instrument for which individual instrument geometry is being
     defined. Note that this code should match the code name used for
-    _pd_meas.detector_id.  Where a single detector is used, this
+    _pd_meas.detector_id. Where a single detector is used, this
     may be omitted.
 ;
     _name.category_id             pd_instr_detector

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-03
+    _dictionary.date              2023-01-06
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3286,7 +3286,7 @@ save_pd_instr.divg_eq_src_mono
 
     _definition.id                '_pd_instr.divg_eq_src_mono'
     _alias.definition_id          '_pd_instr_divg_eq_src/mono'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -3517,7 +3517,7 @@ save_pd_instr.slit_eq_mono_spec
 
     _definition.id                '_pd_instr.slit_eq_mono_spec'
     _alias.definition_id          '_pd_instr_slit_eq_mono/spec'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -3569,7 +3569,7 @@ save_pd_instr.slit_eq_src_spec
 
     _definition.id                '_pd_instr.slit_eq_src_spec'
     _alias.definition_id          '_pd_instr_slit_eq_src/spec'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -3846,7 +3846,7 @@ save_pd_instr.2theta_monochr_post
 
     _definition.id                '_pd_instr.2theta_monochr_post'
     _alias.definition_id          '_pd_instr_2theta_monochr_post'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     The 2\\q angle for a post-specimen
@@ -4217,7 +4217,7 @@ save_pd_instr.slit_eq_anal_detc
 
     _definition.id                '_pd_instr.slit_eq_anal_detc'
     _alias.definition_id          '_pd_instr_slit_eq_anal/detc'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4420,7 +4420,7 @@ save_pd_instr.soller_eq_spec_detc
 
     _definition.id                '_pd_instr.soller_eq_spec_detc'
     _alias.definition_id          '_pd_instr_soller_eq_spec/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -5556,7 +5556,7 @@ save_PD_PREF_ORIENT
     _definition.id                PD_PREF_ORIENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     This section contains a description of preferred-orientation
@@ -5578,7 +5578,7 @@ save_
 save_pd_pref_orient.special_details
 
     _definition.id                '_pd_pref_orient.special_details'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     Description of the preferred-orientation correction if
@@ -5618,7 +5618,7 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
     _definition.id                PD_PREF_ORIENT_MARCH_DOLLASE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     This section contains a description of March-Dollase
@@ -5665,7 +5665,7 @@ save_
 save_pd_pref_orient_March_Dollase.fract
 
     _definition.id                '_pd_pref_orient_March_Dollase.fract'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     In the case of multiple March-Dollase preferred-orientation
@@ -5705,7 +5705,7 @@ save_
 save_pd_pref_orient_March_Dollase.geom
 
     _definition.id                '_pd_pref_orient_March_Dollase.geom'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     Code identifying the geometry of the preferred-orientation
@@ -5743,7 +5743,7 @@ save_
 save_pd_pref_orient_March_Dollase.hkl
 
     _definition.id                '_pd_pref_orient_March_Dollase.hkl'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     Miller indices of the March-Dollase preferred-orientation
@@ -5772,7 +5772,7 @@ save_
 save_pd_pref_orient_March_Dollase.id
 
     _definition.id                '_pd_pref_orient_March_Dollase.id'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     A code to uniquely identify each March-Dollase
@@ -5791,7 +5791,7 @@ save_
 save_pd_pref_orient_March_Dollase.index_h
 
     _definition.id                '_pd_pref_orient_March_Dollase.index_h'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     The h Miller index of the March-Dollase preferred-orientation
@@ -5810,7 +5810,7 @@ save_
 save_pd_pref_orient_March_Dollase.index_k
 
     _definition.id                '_pd_pref_orient_March_Dollase.index_k'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     The k Miller index of the March-Dollase preferred-orientation
@@ -5829,7 +5829,7 @@ save_
 save_pd_pref_orient_March_Dollase.index_l
 
     _definition.id                '_pd_pref_orient_March_Dollase.index_l'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     The l Miller index of the March-Dollase preferred-orientation
@@ -5924,7 +5924,7 @@ save_PD_PREF_ORIENT_SPHERICALHARMONICS
     _definition.id                PD_PREF_ORIENT_SPHERICALHARMONICS
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     This section contains a description of spherical
@@ -6008,7 +6008,7 @@ save_
 save_pd_pref_orient_sphericalharmonics.geom
 
     _definition.id                '_pd_pref_orient_sphericalharmonics.geom'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     Code identifying the geometry of the preferred-orientation
@@ -6088,7 +6088,7 @@ save_pd_pref_orient_sphericalharmonics.texture_index
 
     _definition.id
         '_pd_pref_orient_sphericalharmonics.texture_index'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     The texture index, as described by equation 4.212
@@ -6165,7 +6165,7 @@ save_
 save_pd_pref_orient_sphericalharmonics.y_ij
 
     _definition.id                '_pd_pref_orient_sphericalharmonics.y_ij'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     The order (i) and  term (j) of the spherical harmonic
@@ -6208,7 +6208,7 @@ save_
 save_pd_pref_orient_sphericalharmonics.y_j
 
     _definition.id                '_pd_pref_orient_sphericalharmonics.y_j'
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     The term (j) of the given order (i) of the spherical harmonics
@@ -6608,7 +6608,7 @@ save_pd_proc_ls.pref_orient_corr
     _definition_replaced.id       1
     _definition_replaced.by       '_pd_pref_orient.special_details'
     _alias.definition_id          '_pd_proc_ls_pref_orient_corr'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     DEPRECATED. Use _pd_pref_orient.special_details, or if
@@ -7011,7 +7011,7 @@ save_PD_QPA_EXT_STD
     _definition.id                PD_QPA_EXT_STD
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-01-03
+    _definition.update            2023-01-06
     _description.text
 ;
     This category identifies the external standard used for
@@ -7086,7 +7086,7 @@ save_
 save_pd_qpa_ext_std.k_factor
 
     _definition.id                '_pd_qpa_ext_std.k_factor'
-    _definition.update            2023-01-03
+    _definition.update            2023-01-06
     _description.text
 ;
     The value of the diffractometer constant, K, applied to the
@@ -7193,7 +7193,7 @@ save_PD_QPA_INT_STD
     _definition.id                PD_QPA_INT_STD
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-03
+    _definition.update            2023-01-06
     _description.text
 ;
     This category identifies the internal standard used for
@@ -7340,7 +7340,7 @@ save_PD_QPA_RIR
     _definition.id                PD_QPA_RIR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-03
+    _definition.update            2023-01-06
     _description.text
 ;
     This category identifies the reference intensity ratio used for
@@ -7963,7 +7963,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-03
+         2.5.0                    2023-01-06
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -89,7 +89,7 @@ save_pd_block.id
 
     _definition.id                '_pd_block.id'
     _alias.definition_id          '_pd_block_id'
-    _definition.update            2022-09-30
+    _definition.update            2023-01-06
     _description.text
 ;
     Used to assign a unique character string to a block.
@@ -378,7 +378,7 @@ save_pd_calc.method
 
     _definition.id                '_pd_calc.method'
     _alias.definition_id          '_pd_calc_method'
-    _definition.update            2016-10-18
+    _definition.update            2023-01-06
     _description.text
 ;
     A description of the method used for the calculation of the
@@ -886,7 +886,7 @@ save_
 save_pd_calib_offset.id
 
     _definition.id                '_pd_calib_offset.id'
-    _definition.update            2016-10-19
+    _definition.update            2023-01-06
     _description.text
 ;
     An arbitrary code which identifies a particular 2\\q offset
@@ -2912,7 +2912,7 @@ save_PD_INSTR
     _definition.id                PD_INSTR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     This section contains information relevant to the instrument
@@ -3136,7 +3136,7 @@ save_pd_instr.dist_src_mono
 
     _definition.id                '_pd_instr.dist_src_mono'
     _alias.definition_id          '_pd_instr_dist_src/mono'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Specifies distance in millimetres from the radiation source to
@@ -3158,7 +3158,7 @@ save_pd_instr.dist_src_spec
 
     _definition.id                '_pd_instr.dist_src_spec'
     _alias.definition_id          '_pd_instr_dist_src/spec'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Specifies distances in millimetres from the radiation source to
@@ -3207,7 +3207,7 @@ save_pd_instr.divg_ax_src_mono
 
     _definition.id                '_pd_instr.divg_ax_src_mono'
     _alias.definition_id          '_pd_instr_divg_ax_src/mono'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -3312,7 +3312,7 @@ save_pd_instr.divg_eq_src_spec
 
     _definition.id                '_pd_instr.divg_eq_src_spec'
     _alias.definition_id          '_pd_instr_divg_eq_src/spec'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -3465,7 +3465,7 @@ save_pd_instr.slit_ax_src_mono
 
     _definition.id                '_pd_instr.slit_ax_src_mono'
     _alias.definition_id          '_pd_instr_slit_ax_src/mono'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -3491,7 +3491,7 @@ save_pd_instr.slit_ax_src_spec
 
     _definition.id                '_pd_instr.slit_ax_src_spec'
     _alias.definition_id          '_pd_instr_slit_ax_src/spec'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -3543,7 +3543,7 @@ save_pd_instr.slit_eq_src_mono
 
     _definition.id                '_pd_instr.slit_eq_src_mono'
     _alias.definition_id          '_pd_instr_slit_eq_src/mono'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -3595,7 +3595,7 @@ save_pd_instr.soller_ax_mono_spec
 
     _definition.id                '_pd_instr.soller_ax_mono_spec'
     _alias.definition_id          '_pd_instr_soller_ax_mono/spec'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -3650,7 +3650,7 @@ save_pd_instr.soller_ax_src_spec
 
     _definition.id                '_pd_instr.soller_ax_src_spec'
     _alias.definition_id          '_pd_instr_soller_ax_src/spec'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -3729,7 +3729,7 @@ save_pd_instr.soller_eq_src_spec
 
     _definition.id                '_pd_instr.soller_eq_src_spec'
     _alias.definition_id          '_pd_instr_soller_eq_src/spec'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -3754,7 +3754,7 @@ save_pd_instr.source_size_ax
 
     _definition.id                '_pd_instr.source_size_ax'
     _alias.definition_id          '_pd_instr_source_size_ax'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Axial intrinsic dimension of the radiation source (in
@@ -3776,7 +3776,7 @@ save_pd_instr.source_size_eq
 
     _definition.id                '_pd_instr.source_size_eq'
     _alias.definition_id          '_pd_instr_source_size_eq'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Equatorial intrinsic dimension of the radiation source (in
@@ -3819,7 +3819,7 @@ save_PD_INSTR_DETECTOR
     _definition.id                PD_INSTR_DETECTOR
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     This section contains information relevant to the detector
@@ -3890,7 +3890,7 @@ save_pd_instr.dist_spec_anal
 
     _definition.id                '_pd_instr.dist_spec_anal'
     _alias.definition_id          '_pd_instr_dist_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Specifies distances in millimetres from the specimen to the
@@ -3912,7 +3912,7 @@ save_pd_instr.dist_spec_detc
 
     _definition.id                '_pd_instr.dist_spec_detc'
     _alias.definition_id          '_pd_instr_dist_spec/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Specifies distance in millimetres from the specimen to the
@@ -3934,7 +3934,7 @@ save_pd_instr.divg_ax_anal_detc
 
     _definition.id                '_pd_instr.divg_ax_anal_detc'
     _alias.definition_id          '_pd_instr_divg_ax_anal/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -3960,7 +3960,7 @@ save_pd_instr.divg_ax_spec_anal
 
     _definition.id                '_pd_instr.divg_ax_spec_anal'
     _alias.definition_id          '_pd_instr_divg_ax_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction
@@ -3987,7 +3987,7 @@ save_pd_instr.divg_ax_spec_detc
 
     _definition.id                '_pd_instr.divg_ax_spec_detc'
     _alias.definition_id          '_pd_instr_divg_ax_spec/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction
@@ -4014,7 +4014,7 @@ save_pd_instr.divg_eq_anal_detc
 
     _definition.id                '_pd_instr.divg_eq_anal_detc'
     _alias.definition_id          '_pd_instr_divg_eq_anal/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4040,7 +4040,7 @@ save_pd_instr.divg_eq_spec_anal
 
     _definition.id                '_pd_instr.divg_eq_spec_anal'
     _alias.definition_id          '_pd_instr_divg_eq_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4066,7 +4066,7 @@ save_pd_instr.divg_eq_spec_detc
 
     _definition.id                '_pd_instr.divg_eq_spec_detc'
     _alias.definition_id          '_pd_instr_divg_eq_spec/detc'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4138,7 +4138,7 @@ save_pd_instr.slit_ax_anal_detc
 
     _definition.id                '_pd_instr.slit_ax_anal_detc'
     _alias.definition_id          '_pd_instr_slit_ax_anal/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -4164,7 +4164,7 @@ save_pd_instr.slit_ax_spec_anal
 
     _definition.id                '_pd_instr.slit_ax_spec_anal'
     _alias.definition_id          '_pd_instr_slit_ax_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -4190,7 +4190,7 @@ save_pd_instr.slit_ax_spec_detc
 
     _definition.id                '_pd_instr.slit_ax_spec_detc'
     _alias.definition_id          '_pd_instr_slit_ax_spec/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -4242,7 +4242,7 @@ save_pd_instr.slit_eq_spec_anal
 
     _definition.id                '_pd_instr.slit_eq_spec_anal'
     _alias.definition_id          '_pd_instr_slit_eq_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4268,7 +4268,7 @@ save_pd_instr.slit_eq_spec_detc
 
     _definition.id                '_pd_instr.slit_eq_spec_detc'
     _alias.definition_id          '_pd_instr_slit_eq_spec/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4294,7 +4294,7 @@ save_pd_instr.soller_ax_anal_detc
 
     _definition.id                '_pd_instr.soller_ax_anal_detc'
     _alias.definition_id          '_pd_instr_soller_ax_anal/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -4319,7 +4319,7 @@ save_pd_instr.soller_ax_spec_anal
 
     _definition.id                '_pd_instr.soller_ax_spec_anal'
     _alias.definition_id          '_pd_instr_soller_ax_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -4344,7 +4344,7 @@ save_pd_instr.soller_ax_spec_detc
 
     _definition.id                '_pd_instr.soller_ax_spec_detc'
     _alias.definition_id          '_pd_instr_soller_ax_spec/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the axial direction (perpendicular to
@@ -4369,7 +4369,7 @@ save_pd_instr.soller_eq_anal_detc
 
     _definition.id                '_pd_instr.soller_eq_anal_detc'
     _alias.definition_id          '_pd_instr_soller_eq_anal/detc'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4394,7 +4394,7 @@ save_pd_instr.soller_eq_spec_anal
 
     _definition.id                '_pd_instr.soller_eq_spec_anal'
     _alias.definition_id          '_pd_instr_soller_eq_spec/anal'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     Describes collimation in the equatorial plane (the plane
@@ -4443,7 +4443,7 @@ save_
 save_pd_instr_detector.id
 
     _definition.id                '_pd_instr_detector.id'
-    _definition.update            2016-10-20
+    _definition.update            2023-01-06
     _description.text
 ;
     A code which identifies the detector or channel number in a

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3576,7 +3576,7 @@ save_pd_instr.slit_eq_src_spec
     containing the incident and diffracted beams) for the
     instrument as a slit width (as opposed to a divergence angle).
     Values are the width of the slit (in millimetres) defining
-    Ollimation between the radiation source and the specimen.
+    collimation between the radiation source and the specimen.
     Note that *_src_spec is used in place of *_src_mono and
     *_mono_spec if there is no monochromator in use.
 ;
@@ -4223,7 +4223,7 @@ save_pd_instr.slit_eq_anal_detc
     Describes collimation in the equatorial plane (the plane
     containing the incident and diffracted beams) for the instrument
     as a slit width (as opposed to a divergence angle).  Values are
-    the width of the slit (in millimetres) defining Ollimation
+    the width of the slit (in millimetres) defining collimation
     between the analyser and the detector.  Note that *_spec_detc is
     used in place of *_spec_anal and *_anal_detc if there is no
     analyser in use.


### PR DESCRIPTION
I tried to be quite conservative with the changes, but please check diligently since in some cases the original intent was not completely clear (e.g. "detectoomator" -> "datector").