### PR TITLE
add phase_id and diffractogram_id to PD_PREF_ORIENT_SPHERICAL_HARMONICS and  _MARCH_DOLLASE

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6138,8 +6138,7 @@ save_
 
 save_pd_pref_orient_March_Dollase.phase_id
 
-    _definition.id
-        '_pd_pref_orient_March_Dollase.phase_id'
+    _definition.id                '_pd_pref_orient_March_Dollase.phase_id'
     _definition.update            2023-01-06
     _description.text
 ;
@@ -6400,8 +6399,7 @@ save_
 
 save_pd_pref_orient_spherical_harmonics.phase_id
 
-    _definition.id
-        '_pd_pref_orient_spherical_harmonics.phase_id'
+    _definition.id                '_pd_pref_orient_spherical_harmonics.phase_id'
     _definition.update            2023-01-06
     _description.text
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5864,7 +5864,7 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
     _definition.id                PD_PREF_ORIENT_MARCH_DOLLASE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-11-17
+    _definition.update            2023-01-06
     _description.text
 ;
     This section contains a description of March_Dollase
@@ -5881,7 +5881,11 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
     _name.category_id             PD_GROUP
     _name.object_id               PD_PREF_ORIENT_MARCH_DOLLASE
 
-    _category_key.name            '_pd_pref_orient_March_Dollase.id'
+    loop_
+      _category_key.name
+         '_pd_pref_orient_March_Dollase.diffractogram_id'
+         '_pd_pref_orient_March_Dollase.id'
+         '_pd_pref_orient_March_Dollase.phase_id'
 
 save_
 
@@ -5903,6 +5907,26 @@ save_pd_pref_orient_March_Dollase.diffractogram_block_id
     _name.object_id               diffractogram_block_id
     _type.purpose                 Encode
     _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_March_Dollase.diffractogram_id
+
+    _definition.id
+        '_pd_pref_orient_March_Dollase.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A diffractogram id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -6112,6 +6136,26 @@ save_pd_pref_orient_March_Dollase.phase_block_id
 
 save_
 
+save_pd_pref_orient_March_Dollase.phase_id
+
+    _definition.id
+        '_pd_pref_orient_March_Dollase.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A phase id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_pref_orient_March_Dollase.r
 
     _definition.id                '_pd_pref_orient_March_Dollase.r'
@@ -6188,7 +6232,11 @@ save_PD_PREF_ORIENT_SPHERICAL_HARMONICS
     _name.category_id             PD_GROUP
     _name.object_id               PD_PREF_ORIENT_SPHERICAL_HARMONICS
 
-    _category_key.name            '_pd_pref_orient_spherical_harmonics.id'
+    loop_
+      _category_key.name
+         '_pd_pref_orient_spherical_harmonics.diffractogram_id'
+         '_pd_pref_orient_spherical_harmonics.id'
+         '_pd_pref_orient_spherical_harmonics.phase_id'
 
 save_
 
@@ -6246,6 +6294,26 @@ save_pd_pref_orient_spherical_harmonics.diffractogram_block_id
     _name.object_id               diffractogram_block_id
     _type.purpose                 Encode
     _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.diffractogram_id
+
+    _definition.id
+        '_pd_pref_orient_spherical_harmonics.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A diffractogram id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -6325,6 +6393,26 @@ save_pd_pref_orient_spherical_harmonics.phase_block_id
     _name.object_id               phase_block_id
     _type.purpose                 Encode
     _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.phase_id
+
+    _definition.id
+        '_pd_pref_orient_spherical_harmonics.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A phase id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -8257,4 +8345,7 @@ save_
 
        Changed _pd_meas.step_count_time and _pd_meas.time_of_flight from
        Integer to Real.
+
+       Added phase_id and diffractogram_id to PD_PREF_ORIENT_MARCH_DOLLASE and
+       PD_PREF_ORIENT_SPHERICAL_HARMONICS.
 ;


### PR DESCRIPTION
I don't know if the `_dictionary_audit.revision` entry is required, as they are completely new categories...