### PR TITLE
adding diffractogram_id and phase_id to per-phase intensities

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -249,7 +249,12 @@ save_PD_CALC_COMPONENT
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALC_COMPONENT
-    _category_key.name            '_pd_calc_component.point_id'
+
+    loop_
+      _category_key.name
+         '_pd_calc_component.diffractogram_id'
+         '_pd_calc_component.point_id'
+         '_pd_calc_component.phase_id'
 
 save_
 
@@ -374,6 +379,25 @@ save_pd_calc_component.intensity_total
 
 save_
 
+save_pd_calc_component.phase_id
+
+    _definition.id                '_pd_calc_component.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The phase (see _pd_phase.id) from which the component intensities
+    were calculated.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_calc_component.point_id
 
     _definition.id                '_pd_calc_component.point_id'
@@ -434,25 +458,6 @@ save_pd_calc.method
     _name.object_id               method
     _type.purpose                 Describe
     _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_calc_component.phase_id
-
-    _definition.id                '_pd_calc_component.phase_id'
-    _definition.update            2023-01-06
-    _description.text
-;
-    The phase (see _pd_phase.id) from which the component intensities
-    were calculated.
-;
-    _name.category_id             pd_calc_overall
-    _name.object_id               phase_id
-    _name.linked_item_id          '_pd_phase.id'
-    _type.purpose                 Link
-    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8253,7 +8253,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-06
+         2.5.0                    2023-01-08
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -240,7 +240,7 @@ save_PD_CALC_COMPONENT
     _definition.id                PD_CALC_COMPONENT
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-10-12
+    _definition.update            2023-01-08
     _description.text
 ;
     This section is used for storing the phase-specific

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-06
+    _dictionary.date              2023-01-08
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -278,6 +278,26 @@ save_pd_calc_component.block_id
 
 save_
 
+save_pd_calc_component.diffractogram_id
+
+    _definition.id                '_pd_calc_component.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The diffractogram(s) (see _pd_diffractogram.id) to which these component
+    intensities form part of the _pd_calc.intensity_total or
+    _pd_calc.intensity_net values.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_calc_component.intensity_net
 
     _definition.id                '_pd_calc_component.intensity_net'
@@ -414,26 +434,6 @@ save_pd_calc.method
     _name.object_id               method
     _type.purpose                 Describe
     _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_calc_component.diffractogram_id
-
-    _definition.id                '_pd_calc_component.diffractogram_id'
-    _definition.update            2023-01-06
-    _description.text
-;
-    The diffractogram (see _pd_diffractogram.id) to which these component
-    intensities form part of the _pd_calc.intensity_total or
-    _pd_calc.intensity_net values.
-;
-    _name.category_id             pd_calc_overall
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -419,6 +419,45 @@ save_pd_calc.method
 
 save_
 
+save_pd_calc_component.diffractogram_id
+
+    _definition.id                '_pd_calc_component.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which these component
+    intensities form part of the _pd_calc.intensity_total or
+    _pd_calc.intensity_net values.
+;
+    _name.category_id             pd_calc_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calc_component.phase_id
+
+    _definition.id                '_pd_calc_component.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The phase (see _pd_phase.id) from which the component intensities
+    were calculated.
+;
+    _name.category_id             pd_calc_overall
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_calc_overall.component_presentation_order
 
     _definition.id


### PR DESCRIPTION
I've added diffractogram_id and phase_id to the categories that allow the addition of per-phase intensities.


~~I've initially done something naughty, and put them in `PD_CALC_OVERALL` (this is a `Set` category),  but named them `_pd_calc_component.diffractogram/phase_id` (`_PD_CALC_COMPONENET` is a `Loop` category). I've chosen to do this as the new data items should be single-valued, and it allows for all `_pd_calc_component.*` data names to be used in a data block, as:~~ Ignore - I was talking bollocks.

`_PD_CALC_COMPONENT` now has `_pd_calc_component.diffractogram_id`,  `_pd_calc_component.phase_id`, as well as  `_pd_calc_component.point_id` to identify values.

```
data_component1
_pd_calc_component.phase_id		the_first_phase
_pd_calc_component.diffractogram_id	the_diff_patt
	
loop_
_pd_calc_component.point_id
_pd_calc_component.intensity_total
	1	5
	2	5.1
	3	6.0
	#...
```

