### PR TITLE
Update definitions of phase names

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-06
+    _dictionary.date              2023-01-07
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -8257,4 +8257,7 @@ save_
 
        Changed _pd_meas.step_count_time and _pd_meas.time_of_flight from
        Integer to Real.
+
+       Update definitions of _pd_phase.name, _pd_qpa_ext_std.phase_name, and
+       _pd_qpa_int_std.phase_name to better represent their contents.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7764,7 +7764,7 @@ save_
 save_pd_qpa_int_std.phase_name
 
     _definition.id                '_pd_qpa_int_std.phase_name'
-    _definition.update            2023-01-07 #
+    _definition.update            2023-01-07
     _description.text
 ;
     Identifies the name of the material used as an internal standard for

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7764,7 +7764,7 @@ save_
 save_pd_qpa_int_std.phase_name
 
     _definition.id                '_pd_qpa_int_std.phase_name'
-    _definition.update            2023-01-07
+    _definition.update            2023-01-07 #
     _description.text
 ;
     Identifies the name of the material used as an internal standard for

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1002,7 +1002,7 @@ save_pd_calib_std.external_name
 
     _definition.id                '_pd_calib_std.external_name'
     _alias.definition_id          '_pd_calib_std_external_name'
-    _definition.update            2022-12-01
+    _definition.update            2023-01-07
     _description.text
 ;
     Identifies the name of the material used as an external standard for
@@ -1010,10 +1010,10 @@ save_pd_calib_std.external_name
 ;
     _name.category_id             pd_calib_std
     _name.object_id               external_name
-    _type.purpose                 Encode
-    _type.source                  Assigned
+    _type.purpose                 Describe
+    _type.source                  Recorded
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -5608,7 +5608,7 @@ save_pd_phase.name
 
     _definition.id                '_pd_phase.name'
     _alias.definition_id          '_pd_phase_name'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-07
     _description.text
 ;
     The name of the crystal phase.
@@ -5616,10 +5616,10 @@ save_pd_phase.name
 ;
     _name.category_id             pd_phase
     _name.object_id               name
-    _type.purpose                 Encode
+    _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -7400,7 +7400,7 @@ save_
 save_pd_qpa_ext_std.phase_name
 
     _definition.id                '_pd_qpa_ext_std.phase_name'
-    _definition.update            2023-01-03
+    _definition.update            2023-01-07
     _description.text
 ;
     Identifies the name of the material used as an external standard for
@@ -7409,10 +7409,10 @@ save_pd_qpa_ext_std.phase_name
 ;
     _name.category_id             pd_qpa_ext_std
     _name.object_id               phase_name
-    _type.purpose                 Encode
-    _type.source                  Assigned
+    _type.purpose                 Describe
+    _type.source                  Recorded
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 
@@ -7547,7 +7547,7 @@ save_
 save_pd_qpa_int_std.phase_name
 
     _definition.id                '_pd_qpa_int_std.phase_name'
-    _definition.update            2023-01-03
+    _definition.update            2023-01-07
     _description.text
 ;
     Identifies the name of the material used as an internal standard for
@@ -7556,10 +7556,10 @@ save_pd_qpa_int_std.phase_name
 ;
     _name.category_id             pd_qpa_int_std
     _name.object_id               phase_name
-    _type.purpose                 Encode
-    _type.source                  Assigned
+    _type.purpose                 Describe
+    _type.source                  Recorded
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1136,7 +1136,7 @@ save_pd_calib_std.external_name
     _name.category_id             pd_calib_std
     _name.object_id               external_name
     _type.purpose                 Describe
-    _type.source                  Recorded
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
 
@@ -7625,7 +7625,7 @@ save_pd_qpa_ext_std.phase_name
     _name.category_id             pd_qpa_ext_std
     _name.object_id               phase_name
     _type.purpose                 Describe
-    _type.source                  Recorded
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
 
@@ -7774,7 +7774,7 @@ save_pd_qpa_int_std.phase_name
     _name.category_id             pd_qpa_int_std
     _name.object_id               phase_name
     _type.purpose                 Describe
-    _type.source                  Recorded
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8209,7 +8209,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-06
+         2.5.0                    2023-01-07
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
Some definitions of data items recording phase names were of type `Encode` and `Code`; this doesn't represent what they do/are, which is `Describe` and `Text`\*.

Also altered source for phase names of standards to be `Recorded`, otherwise `Assigned`.

\* This is one case where it would be nice to have a `_type.contents` value defined as "case-insensitive sequence of CIF2 characters" 