### PR TITLE
add more keys to PD_PREF_ORIENT_SPHERICAL_HARMONICS and MARCH_DOLLASE to ensure uniqueness

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5880,7 +5880,11 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
     _name.category_id             PD_GROUP
     _name.object_id               PD_PREF_ORIENT_MARCH_DOLLASE
 
-    _category_key.name            '_pd_pref_orient_March_Dollase.id'
+    loop_
+      _category_key.name
+         '_pd_pref_orient_March_Dollase.diffractogram_id'
+         '_pd_pref_orient_March_Dollase.id'
+         '_pd_pref_orient_March_Dollase.phase_id'
 
 save_
 
@@ -6188,7 +6192,11 @@ save_PD_PREF_ORIENT_SPHERICAL_HARMONICS
     _name.category_id             PD_GROUP
     _name.object_id               PD_PREF_ORIENT_SPHERICAL_HARMONICS
 
-    _category_key.name            '_pd_pref_orient_spherical_harmonics.id'
+    loop_
+      _category_key.name
+         '_pd_pref_orient_spherical_harmonics.diffractogram_id'
+         '_pd_pref_orient_spherical_harmonics.id'
+         '_pd_pref_orient_spherical_harmonics.phase_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5911,6 +5911,29 @@ save_pd_pref_orient_March_Dollase.diffractogram_block_id
 
 save_
 
+save_pd_pref_orient_March_Dollase.diffractogram_id
+
+    _definition.id
+        '_pd_pref_orient_March_Dollase.diffractogram_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) identifying the
+    diffractogram to which the preferred-orientation correction applies.
+
+    The diffraction data will be identified via a _pd_diffractogram.id code
+    matching the code in _pd_pref_orient_March_Dollase.diffractogram_id.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_pd_pref_orient_March_Dollase.fract
 
     _definition.id                '_pd_pref_orient_March_Dollase.fract'
@@ -6115,6 +6138,28 @@ save_pd_pref_orient_March_Dollase.phase_block_id
 
 save_
 
+save_pd_pref_orient_March_Dollase.phase_id
+
+    _definition.id                '_pd_pref_orient_March_Dollase.phase_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    A phase ID code (see _pd_phase.id) identifying the phase to which the
+    preferred-orientation correction applies.
+
+    The phase will be identified by a _pd_phase.id code matching the code in
+    _pd_pref_orient_March_Dollase.phase_id.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_pd_pref_orient_March_Dollase.r
 
     _definition.id                '_pd_pref_orient_March_Dollase.r'
@@ -6259,6 +6304,29 @@ save_pd_pref_orient_spherical_harmonics.diffractogram_block_id
 
 save_
 
+save_pd_pref_orient_spherical_harmonics.diffractogram_id
+
+    _definition.id
+        '_pd_pref_orient_spherical_harmonics.diffractogram_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) identifying the
+    diffractogram to which the preferred-orientation correction applies.
+
+    The diffraction data will be identified via a _pd_diffractogram.id code
+    matching the code in _pd_pref_orient_spherical_harmonics.diffractogram_id.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_pd_pref_orient_spherical_harmonics.geom
 
     _definition.id                '_pd_pref_orient_spherical_harmonics.geom'
@@ -6335,6 +6403,28 @@ save_pd_pref_orient_spherical_harmonics.phase_block_id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.phase_id
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.phase_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    A phase ID code (see _pd_phase.id) identifying the phase to which the
+    preferred-orientation correction applies.
+
+    The phase will be identified by a _pd_phase.id code matching the code in
+    _pd_pref_orient_spherical_harmonics.phase_id.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
 
 save_
 


### PR DESCRIPTION
Previously, the only key in each category was `_pd_*.id`. It is now `_pd_*.id`, `_pd_*.diffractogram_id`, and `_pd_*.phase_id`.

`_pd_*.diffractogram_id` and `_pd_*.phase_id` are linked to `_pd_diffractogram.id` and `_pd_phase.id`, respectively.
