### PR TITLE
adding phase_id and/or diffractogram_id to categories as keys

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-29
+    _dictionary.date              2023-02-02
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -8489,6 +8489,28 @@ save_pd_qpa_internal_std.crystallinity_percent_su
 
 save_
 
+save_pd_qpa_internal_std.diffractogram_id
+
+    _definition.id                '_pd_qpa_internal_std.diffractogram_id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) identifying the
+    diffractogram to which the internal standard relates.
+
+    The diffractogram will be identified by a _pd_diffractogram.id code matching
+    the code in _pd_qpa_overall.diffractogram_id.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_qpa_internal_std.mass_percent
 
     _definition.id                '_pd_qpa_internal_std.mass_percent'
@@ -9347,7 +9369,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-29
+         2.5.0                    2023-02-02
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4822,7 +4822,7 @@ save_PD_MEAS_INFO_AUTHOR
 
     loop_
       _category_key.name
-         '_pd_meas_info.diffractogram_id'
+         '_pd_meas_info_author.diffractogram_id'
          '_pd_meas_info_author.name'
 
 save_
@@ -4847,16 +4847,16 @@ save_pd_meas_info_author.address
 
 save_
 
-save_pd_meas_info.diffractogram_id
+save_pd_meas_info_author.diffractogram_id
 
-    _definition.id                '_pd_meas_info.diffractogram_id'
+    _definition.id                '_pd_meas_info_author.diffractogram_id'
     _definition.update            2023-01-12
     _description.text
 ;
     The diffractogram (see _pd_diffractogram.id) to which the author details
     relate.
 ;
-    _name.category_id             pd_meas_info
+    _name.category_id             pd_meas_info_author
     _name.object_id               diffractogram_id
     _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6031,7 +6031,7 @@ save_PD_PREF_ORIENT
     _definition.id                PD_PREF_ORIENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-06
+    _definition.update            2023-01-12
     _description.text
 ;
     This section contains a description of preferred-orientation
@@ -6047,6 +6047,49 @@ save_PD_PREF_ORIENT
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PREF_ORIENT
+
+    loop_
+      _category_key.name
+         '_pd_pref_orient.diffractogram_id'
+         '_pd_pref_orient.phase_id'
+
+save_
+
+save_pd_pref_orient.diffractogram_id
+
+    _definition.id                '_pd_pref_orient.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the preferred-
+    orientation correction relates.
+;
+    _name.category_id             pd_pref_orient
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient.phase_id
+
+    _definition.id                '_pd_pref_orient.phase_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the preferred-orientation
+    correction relates.
+;
+    _name.category_id             pd_pref_orient
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -8598,6 +8641,6 @@ save_
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
        PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
-       PD_MEAS_OVERALL,
+       PD_MEAS_OVERALL, PD_PREF_ORIENT
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7010,7 +7010,7 @@ save_PD_PROC_INFO_AUTHOR
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PROC_INFO_AUTHOR
-    _category_key.name            '_pd_proc_info_author.name'
+
     loop_
       _category_key.name
          '_pd_proc_info_author.diffractogram_id'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8176,7 +8176,7 @@ save_PD_SPEC
     _definition.id                PD_SPEC
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2014-06-20
+    _definition.update            2023-01-12
     _description.text
 ;
     This section contains information about the specimen used
@@ -8186,6 +8186,7 @@ save_PD_SPEC
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_SPEC
+    _category_key.name            '_pd_spec.diffractogram_id'
 
 save_
 
@@ -8203,6 +8204,25 @@ save_pd_spec.description
     _name.object_id               description
     _type.purpose                 Describe
     _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_spec.diffractogram_id
+
+    _definition.id                '_pd_spec.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the specimen-
+    preparation details relate.
+;
+    _name.category_id             pd_spec
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -8703,6 +8723,7 @@ save_
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
        PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
-       PD_MEAS_OVERALL, PD_PREF_ORIENT, PD_PROC_INFO_AUTHOR, PD_PROC_OVERALL
+       PD_MEAS_OVERALL, PD_PREF_ORIENT, PD_PROC_INFO_AUTHOR, PD_PROC_OVERALL,
+       PD_SPEC
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7875,11 +7875,6 @@ save_pd_qpa_calib_factor.I_over_Ic
     _type.contents                Real
     _units.code                   none
 
-    loop_
-      _category_key.name
-         '_pd_qpa_int_std.diffractogram_id'
-         '_pd_qpa_int_std.phase_id'
-
 save_
 
 save_pd_qpa_calib_factor.I_over_Ic_su
@@ -8414,6 +8409,11 @@ save_PD_QPA_INTERNAL_STD
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_INTERNAL_STD
+
+    loop_
+      _category_key.name
+         '_pd_qpa_internal_std.diffractogram_id'
+         '_pd_qpa_internal_std.phase_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7017,7 +7017,6 @@ save_PD_PROC_INFO_AUTHOR
          '_pd_proc_info_author.name'
          '_pd_proc_info_author.phase_id'
 
-
 save_
 
 save_pd_proc_info_author.address

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7472,6 +7472,7 @@ save_PD_PROC_OVERALL
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PROC_OVERALL
+    _category_key.name            '_pd_proc_overall.diffractogram_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7924,13 +7924,15 @@ save_pd_qpa_int_std.diffractogram_id
     The diffractogram (see _pd_diffractogram.id) to which the internal standard
     relates.
 ;
-    _name.category_id             save_pd_qpa_int_std
+    _name.category_id             pd_qpa_int_std
     _name.object_id               diffractogram_id
     _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
+
+save_
 
 save_pd_qpa_int_std.mass_percent
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7011,6 +7011,12 @@ save_PD_PROC_INFO_AUTHOR
     _name.category_id             PD_GROUP
     _name.object_id               PD_PROC_INFO_AUTHOR
     _category_key.name            '_pd_proc_info_author.name'
+    loop_
+      _category_key.name
+         '_pd_proc_info_author.diffractogram_id'
+         '_pd_proc_info_author.name'
+         '_pd_proc_info_author.phase_id'
+
 
 save_
 
@@ -7018,7 +7024,7 @@ save_pd_proc_info_author.address
 
     _definition.id                '_pd_proc_info_author.address'
     _alias.definition_id          '_pd_proc_info_author_address'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-12
     _description.text
 ;
     The address of the person who processed the data.
@@ -7029,6 +7035,25 @@ save_pd_proc_info_author.address
     _name.object_id               address
     _type.purpose                 Describe
     _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.diffractogram_id
+
+    _definition.id                '_pd_proc_info_author.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the processing
+    author relates.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -7093,6 +7118,24 @@ save_pd_proc_info_author.name
     _name.object_id               name
     _type.purpose                 Describe
     _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.phase_id
+
+    _definition.id                '_pd_proc_info_author.phase_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the processing author relates.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -8641,6 +8684,6 @@ save_
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
        PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
-       PD_MEAS_OVERALL, PD_PREF_ORIENT
+       PD_MEAS_OVERALL, PD_PREF_ORIENT, PD_PROC_INFO_AUTHOR
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4819,7 +4819,11 @@ save_PD_MEAS_INFO_AUTHOR
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_MEAS_INFO_AUTHOR
-    _category_key.name            '_pd_meas_info_author.name'
+
+    loop_
+      _category_key.name
+         '_pd_meas_info.diffractogram_id'
+         '_pd_meas_info_author.name'
 
 save_
 
@@ -4827,7 +4831,7 @@ save_pd_meas_info_author.address
 
     _definition.id                '_pd_meas_info_author.address'
     _alias.definition_id          '_pd_meas_info_author_address'
-    _definition.update            2014-06-20
+    _definition.update            2023-01-12
     _description.text
 ;
     The address of the person who measured the data set. If there
@@ -4838,6 +4842,25 @@ save_pd_meas_info_author.address
     _name.object_id               address
     _type.purpose                 Describe
     _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info.diffractogram_id
+
+    _definition.id                '_pd_meas_info.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the author details
+    relate.
+;
+    _name.category_id             pd_meas_info
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -8554,6 +8577,6 @@ save_
        link them formally to _pd_block.id
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
-       PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR,
+       PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7921,8 +7921,8 @@ save_pd_qpa_int_std.diffractogram_id
     _definition.update            2023-01-15
     _description.text
 ;
-    The diffractogram (see _pd_diffractogram.id) to which the internal standard
-    relates.
+    The diffractogram (see _pd_diffractogram.id) which is being calibrated by
+    the internal standard.
 ;
     _name.category_id             pd_qpa_int_std
     _name.object_id               diffractogram_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7917,7 +7917,7 @@ save_
 
 save_pd_qpa_int_std.diffractogram_id
 
-    _definition.id                'save_pd_qpa_int_std.diffractogram_id'
+    _definition.id                '_pd_qpa_int_std.diffractogram_id'
     _definition.update            2023-01-15
     _description.text
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-09
+    _dictionary.date              2023-01-12
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -511,6 +511,7 @@ save_PD_CALC_OVERALL
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALC_OVERALL
+    _category_key.name            '_pd_calc_overall.diffractogram_id'
 
 save_
 
@@ -556,6 +557,25 @@ save_pd_calc_overall.component_presentation_order
     _type.container               Array
     _type.dimension               '[]'
     _type.contents                Code
+
+save_
+
+save_pd_calc_overall.diffractogram_id
+
+    _definition.id                '_pd_calc_overall.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the associated
+    features relate.
+;
+    _name.category_id             pd_calc_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -8427,7 +8447,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-09
+         2.5.0                    2023-01-12
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -8489,4 +8509,8 @@ save_
 
        Updated data items to hold block ID values to be of type Link, and to
        link them formally to _pd_block.id
+
+       Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
+       PD_CALC_OVERALL,
+
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3235,7 +3235,7 @@ save_PD_INSTR
     _definition.id                PD_INSTR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-06
+    _definition.update            2023-01-12
     _description.text
 ;
     This section contains information relevant to the instrument
@@ -3275,6 +3275,7 @@ save_PD_INSTR
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_INSTR
+    _category_key.name            '_pd_instr.diffractogram_id'
 
 save_
 
@@ -3430,6 +3431,25 @@ save_pd_instr.detector_circle_radius
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   millimetres
+
+save_
+
+save_pd_instr.diffractogram_id
+
+    _definition.id                '_pd_instr.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the instrument
+    settings relate.
+;
+    _name.category_id             pd_instr
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -8534,6 +8554,6 @@ save_
        link them formally to _pd_block.id
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
-       PD_CALC_OVERALL,
+       PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR,
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4956,7 +4956,7 @@ save_PD_MEAS_OVERALL
     _definition.id                PD_MEAS_OVERALL
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2016-10-18
+    _definition.update            2023-01-12
     _description.text
 ;
     This section contains information about the conditions used for
@@ -4969,6 +4969,7 @@ save_PD_MEAS_OVERALL
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_MEAS_OVERALL
+    _category_key.name            '_pd_meas_overall.diffractogram_id'
 
 save_
 
@@ -5394,6 +5395,25 @@ save_pd_meas.units_of_intensity
          'estimated from strip chart'
          'arbitrary, from film density'
          'counts, with automatic dead-time correction applied'
+
+save_
+
+save_pd_meas_overall.diffractogram_id
+
+    _definition.id                '_pd_meas_overall.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the measurement
+    conditions relate.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -8578,5 +8598,6 @@ save_
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
        PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
+       PD_MEAS_OVERALL,
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3740,7 +3740,6 @@ save_pd_instr.id
 
 save_
 
-
 save_pd_instr.location
 
     _definition.id                '_pd_instr.location'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7463,7 +7463,7 @@ save_PD_PROC_OVERALL
     _definition.id                PD_PROC_OVERALL
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2016-10-18
+    _definition.update            2023-01-12
     _description.text
 ;
     This section contains overall information about the diffraction
@@ -7655,6 +7655,25 @@ save_pd_proc.number_of_points
     _type.contents                Integer
     _enumeration.range            1:
     _units.code                   none
+
+save_
+
+save_pd_proc_overall.diffractogram_id
+
+    _definition.id                '_pd_proc_overall.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the overall
+    processing attributes relate.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -8684,6 +8703,6 @@ save_
 
        Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
        PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
-       PD_MEAS_OVERALL, PD_PREF_ORIENT, PD_PROC_INFO_AUTHOR
+       PD_MEAS_OVERALL, PD_PREF_ORIENT, PD_PROC_INFO_AUTHOR, PD_PROC_OVERALL
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-12
+    _dictionary.date              2023-01-15
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -8680,7 +8680,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-12
+         2.5.0                    2023-01-15
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3291,7 +3291,7 @@ save_PD_INSTR
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_INSTR
-    _category_key.name            '_pd_instr.diffractogram_id'
+    _category_key.name            '_pd_instr.id'
 
 save_
 
@@ -3447,25 +3447,6 @@ save_pd_instr.detector_circle_radius
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   millimetres
-
-save_
-
-save_pd_instr.diffractogram_id
-
-    _definition.id                '_pd_instr.diffractogram_id'
-    _definition.update            2023-01-12
-    _description.text
-;
-    The diffractogram (see _pd_diffractogram.id) to which the instrument
-    settings relate.
-;
-    _name.category_id             pd_instr
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -3723,6 +3704,24 @@ save_pd_instr.geometry
 ;
 
 save_
+
+save_pd_instr.id
+
+    _definition.id                '_pd_instr.id'
+    _definition.update            2023-03-25
+    _description.text
+;
+    Arbitrary label identifying a powder diffraction instrument.
+;
+    _name.category_id             pd_instr
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 
 save_pd_instr.location
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -757,7 +757,11 @@ save_PD_CALIB_D_TO_TOF
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_D_TO_TOF
-    _category_key.name            '_pd_calib_d_to_tof.id'
+
+    loop_
+      _category_key.name
+         '_pd_calib_d_to_tof.diffractogram_id'
+         '_pd_calib_d_to_tof.id'
 
     loop_
       _description_example.case
@@ -851,6 +855,25 @@ save_pd_calib_d_to_tof.coeff_su
     _units.code                   microseconds
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_d_to_tof.diffractogram_id
+
+    _definition.id                '_pd_calib_d_to_tof.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the calibration
+    relates.
+;
+    _name.category_id             pd_calib_d_to_tof
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7884,6 +7884,11 @@ save_PD_QPA_INT_STD
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_INT_STD
 
+    loop_
+      _category_key.name
+         '_pd_qpa_int_std.diffractogram_id'
+         '_pd_qpa_int_std.phase_id'
+
 save_
 
 save_pd_qpa_int_std.block_id
@@ -7909,6 +7914,23 @@ save_pd_qpa_int_std.block_id
     _type.contents                Text
 
 save_
+
+save_pd_qpa_int_std.diffractogram_id
+
+    _definition.id                'save_pd_qpa_int_std.diffractogram_id'
+    _definition.update            2023-01-15
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the internal standard
+    relates.
+;
+    _name.category_id             save_pd_qpa_int_std
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_pd_qpa_int_std.mass_percent
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-02-06
+    _dictionary.date              2023-03-25
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3241,6 +3241,24 @@ save_pd_diffractogram.id
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_diffractogram.spec_id
+
+    _definition.id                '_pd_diffractogram.spec_id'
+    _definition.update            2023-03-25
+    _description.text
+;
+    The specimen (see _pd_spec.id) from which the diffractogram was collected.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               spec_id
+    _name.linked_item_id          '_pd_spec.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -8897,6 +8915,7 @@ save_PD_SPEC
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_SPEC
+    _category_key.name            '_pd_spec.id'
 
 save_
 
@@ -8919,20 +8938,18 @@ save_pd_spec.description
 
 save_
 
-save_pd_spec.diffractogram_id
+save_pd_spec.id
 
-    _definition.id                '_pd_spec.diffractogram_id'
-    _definition.update            2023-01-12
+    _definition.id                '_pd_spec.id'
+    _definition.update            2023-03-25
     _description.text
 ;
-    The diffractogram (see _pd_diffractogram.id) to which the specimen-
-    preparation details relate.
+    Arbitrary label identifying a powder diffraction specimen.
 ;
     _name.category_id             pd_spec
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
 
@@ -9368,7 +9385,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-02-06
+         2.5.0                    2023-03-25
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -9455,4 +9472,6 @@ save_
        Updated description of _pd_proc.wavelength.
 
        Remove '_pd_phase_mass_percent' as an alias for '_pd_phase_mass.percent'.
+
+       Added _pd_spec.id and _pd_diffractogram.spec_id
 ;


### PR DESCRIPTION
as mentioned in #79

Adding phase_id and/or diffractogram_id to categories as keys to allow multiple appearances of the various categories in difference blocks in the same data collection.