### PR TITLE
create PD_PHASE_LIST and PD_DIFFRACTOGRAM_LIST

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3212,7 +3212,7 @@ save_pd_diffractogram_list.diffractogram_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
 
 save_
 
@@ -3229,7 +3229,7 @@ save_pd_diffractogram_list.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
 
 save_
 
@@ -5866,7 +5866,7 @@ save_pd_phase_list.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
 
 save_
 
@@ -5892,7 +5892,7 @@ save_pd_phase_list.phase_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-09
+    _dictionary.date              2023-01-13
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -249,7 +249,7 @@ save_PD_BLOCK_DIFFRACTOGRAM
     _definition.id                PD_BLOCK_DIFFRACTOGRAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-12-03
+    _definition.update            2023-01-13
     _description.text
 ;
     A number of diffractograms may contribute to the
@@ -260,26 +260,6 @@ save_PD_BLOCK_DIFFRACTOGRAM
     _name.category_id             PD_GROUP
     _name.object_id               PD_BLOCK_DIFFRACTOGRAM
     _category_key.name            '_pd_block_diffractogram.id'
-
-save_
-
-save_pd_block_diffractogram.diffractogram_id
-
-    _definition.id                '_pd_block_diffractogram.diffractogram_id'
-    _definition.update            2022-12-03
-    _description.text
-;
-    A diffractogram id code (see _pd_diffractogram.id) that
-    identifies the diffraction data contained in the data block
-    pointed to by _pd_block_diffractogram.id.
-;
-    _name.category_id             pd_block_diffractogram
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -3187,6 +3167,72 @@ save_pd_diffractogram.id
 
 save_
 
+save_PD_DIFFRACTOGRAM_LIST
+
+    _definition.id                PD_DIFFRACTOGRAM_LIST
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-13
+    _description.text
+;
+    A number of diffractograms may contribute to the determination of the
+    structure of a single phase, or need to otherwise be listed. This category
+    enables the looping of values corresponding to _pd_diffractogram.id values.
+    See also PD_DIFFRACTOGRAM.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_DIFFRACTOGRAM_LIST
+    loop_
+      _category_key.name
+         '_pd_diffractogram_list.diffractogram_id'
+         '_pd_diffractogram_list.id'
+
+save_
+
+save_pd_diffractogram_list.diffractogram_id
+
+    _definition.id                '_pd_diffractogram_list.diffractogram_id'
+    _definition.update            2023-01-13
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) that identifies
+    diffraction data pertinent to the current block which is present in a
+    different data block.
+
+    This data item is used to provide a list of diffractogram ID values. This
+    will occur if more than one set of diffraction data is used, for example, in
+    a structure determination, or in situ experiment.
+
+    The diffraction data will be identified by a _pd_diffractogram.id code
+    matching the code in _pd_diffractogram_list.diffractogram_id.
+;
+    _name.category_id             pd_diffractogram_list
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_pd_diffractogram_list.id
+
+    _definition.id                '_pd_diffractogram_list.id'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Arbitrary label identifying a _pd_diffractogram_list.diffractogram_id value.
+;
+    _name.category_id             pd_diffractogram_list
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_PD_INSTR
 
     _definition.id                PD_INSTR
@@ -5752,7 +5798,7 @@ save_PD_PHASE_BLOCK
     _definition.id                PD_PHASE_BLOCK
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-12-03
+    _definition.update            2023-01-13
     _description.text
 ;
     A table of phases relevant to the current data
@@ -5786,24 +5832,67 @@ save_pd_phase_block.id
 
 save_
 
-save_pd_phase_block.phase_id
+save_PD_PHASE_LIST
 
-    _definition.id                '_pd_phase_block.phase_id'
-    _alias.definition_id          '_pd_phase_id'
-    _definition.update            2022-12-03
+    _definition.id                PD_PHASE_LIST
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-13
     _description.text
 ;
-    A phase id code (see _pd_phase.id) that identifies the phase
-    contained in the data block pointed to by _pd_phase_block.id
+    A number of phases may contribute to a single diffractogram, or need to
+    otherwise be listed. The _pd_phase.ids of those phases can be listed here.
+    See also PD_PHASE.
 ;
-    _name.category_id             pd_phase_block
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE_LIST
+    loop_
+      _category_key.name
+         '_pd_phase_list.id'
+         '_pd_phase_list.phase_id'
+
+save_
+
+save_pd_phase_list.id
+
+    _definition.id                '_pd_phase_list.id'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Arbitrary label identifying a _pd_phase_list.phase_id value.
+;
+    _name.category_id             pd_phase_list
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_pd_phase_list.phase_id
+
+    _definition.id                '_pd_phase_list.phase_id'
+    _definition.update            2023-01-13
+    _description.text
+;
+    A phase ID code (see _pd_phase.id) that identifies a phase pertinent to the
+    current block which is present in a different data block.
+
+    This data item is used to provide a list of phase ID values. This will occur
+    if more than one phase is present in a diffractogram, as in, for example,
+    quantitative phase analysis.
+
+    The phase data will be identified with a _pd_phase.id code matching the code
+    in _pd_phase_list.phase_id.
+;
+    _name.category_id             pd_phase_list
     _name.object_id               phase_id
     _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
-    _enumeration.default          .
+    _type.contents                Word
 
 save_
 
@@ -8427,7 +8516,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-09
+         2.5.0                    2023-01-13
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -8489,4 +8578,6 @@ save_
 
        Updated data items to hold block ID values to be of type Link, and to
        link them formally to _pd_block.id
+
+       Created PD_PHASE_LIST and PD_DIFFRACTOGRAM_LIST.
 ;


### PR DESCRIPTION
## In this PR

Creation of two new `Loop` categories, `PD_PHASE_LIST` and `PD_DIFFRACTOGRAM_LIST`, to deal with cases when we need to loop `_pd_phase.id`s and `_pd_diffractogram.id`s. See also #74.

The behaviour is analagous to `_pd_block.id` with `PD_PHASE_BLOCK` or `PD_BLOCK_DIFFRACTOGRAM`.

`_pd_phase_block.phase_id` and `_pd_block_diffractogram.diffractogram_id` (which is where these ID values were previously able to be looped) have been removed to disconnect the different methodologies of linking with block pointers and the new way..

The structure is:

- `PD_PHASE_LIST`
   - `_pd_phase_list.id` 
      - Is an arbitrary code identifying a `_pd_phase_list.phase_id`.
      - Is a category key.
      - **is (possibly) unique only within the block it is used** If this is true, does everything still work?
   - `_pd_phase_list.phase_id` 
      - Acts as `Link` back to `_pd_phase.id` (which should be unique in the entire world). 
      - Is a category key.
- `PD_DIFFRACTOGRAM_LIST`
   - `_pd_diffractogram_list.id` 
      - Is an arbitrary code identifying a `_pd_diffractogram_list.diffractogram_id` .
      - Is a category key.
      - **is (possibly) unique only within the block it is used** If this is true, does everything still work?
   - `_pd_diffractogram_list.diffractogram_id`
      - Acts as `Link` back to `_pd_diffractogram.id` (which should be unique in the entire world).
      - Is a category key.

These two categories would allow for the looping of phase and diffractogram ids in data blocks where necessary, such as in a block containing a diffractogram with many phases.

## In a future PR (or commit to this PR)

Further to the creation of these two categories, other categories that have `_categoryname.phase_id` and/or `_categoryname.diffractogram_id` should also have `_categoryname.phase_list_id` and/or `_categoryname.diffractogram_list_id` to be able reference a `_pd_phase_list.id` or `_pd_diffractogram_list.id`. This should allow for shorter arbitrary labels to be (re)used to refer to the long, unique phase/diffractogram_id (exactly analagous to the OG _pd_phase_id and _pd_refln.phase_id)

Something like: 
```
data_DIFFPATT_1
_pd_diffractogram.id	DIFFPAT_1_LONG_UNIQUE_STRING

loop_
_pd_phase_list.id  
_pd_phase_list.phase_id
1   # the idea is that this value can repeat in different blocks
ALUMINA_A_BIG_LONG_STRING_THAT_IS_GLOBALLY_UNIQUE  # this must be unique at least in the data collection, preferablly in the entire world.
2  
SILICON_ANOTHER_STRING_THAT_IS_SUPPOSED_TO_BE_ALONE

loop_
_pd_phase_mass.phase_list_id
_pd_phase_mass.percent
1   72.11
2   27.89

loop_
_refln.index_h
_refln.index_k
_refln.index_l
_pd_refln.phase_list_id  # this would have _pd_refln_phase_id as an alias
_refln.d_spacing
0    0   12 1 1.082702
1    0  -14 1 0.905365
2    2    0 2 1.920168
3    1    1 2 1.637525
#...
   
 loop_
_pd_meas.2theta_scan
_pd_proc.intensity_total
_pd_calc.intensity_total
5.001    63.364    35.994
5.004    78.007    36.200
5.007    78.318    36.404
#...
```
## Question

If I want to be able to reuse the same `_pd_phase_list.id` value in different blocks to refer to different (or even the same) phases, does there need to be some key based on the block? 

