### PR TITLE
update the QPA categories

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7897,6 +7897,7 @@ save_pd_qpa_internal_std.special_details
     _type.contents                Text
 
 save_
+
 save_PD_QPA_OVERALL
 
     _definition.id                PD_QPA_OVERALL

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7897,7 +7897,6 @@ save_pd_qpa_internal_std.special_details
     _type.contents                Text
 
 save_
-
 save_PD_QPA_OVERALL
 
     _definition.id                PD_QPA_OVERALL

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-24
+    _dictionary.date              2023-01-29
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -9112,7 +9112,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-24
+         2.5.0                    2023-01-29
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8192,12 +8192,12 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the
          absorption-diffraction methodology methodology [1].
 
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
-         corresponds to the value C~p~, below. In addition,
+         _pd_qpa_calib_factor.absorption_diffraction should be defined for each
+         phase, which corresponds to C~p~, below. In addition,
          _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
          must be given for the specimen in each diffractogram.
 
-         The absolute weight fraction of phase p, W_p, is given by
+         The absolute weight fraction of phase p, W~p~, is given by
 
              W~p~ = [I~p~ / C~p~] * \mu^*^~m~
 
@@ -8213,10 +8213,10 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the Direct
          Derivation Method [1-6].
 
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
-         corresponds to the value C~p~, below.
+         _pd_qpa_calib_factor.DDM should be defined for each phase, which
+         corresponds to C~p~, below.
 
-         The relative weight fraction of phase p, W_p, is given by
+         The relative weight fraction of phase p, W~p~, is given by
 
              W~p~ = (I~p~ / C~p~) / Sum(I~k~ / C~k~, k=1:P)
 
@@ -8243,9 +8243,9 @@ save_pd_qpa_overall.method
          standard methodology [1] to quantify absolute phase fractions taken
          from Rietveld [2] refinements.
 
-         _pd_qpa_calib_factor.value can be defined for each phase, but data
-         items from the PD_QPA_EXTERNAL_STANDARD category should preferentially
-         used. In addition, _pd_char.mass_atten_coef_mu_calc or
+         _pd_qpa_calib_factor.external_standard can be defined for each phase,
+         but data items from the PD_QPA_EXTERNAL_STANDARD category should be
+         preferentially used. In addition, _pd_char.mass_atten_coef_mu_calc or
          _pd_char.mass_atten_coef_mu_obs must be given for the specimen in each
          diffractogram.
 
@@ -8272,6 +8272,9 @@ save_pd_qpa_overall.method
          value was determined using corundum (\a-alumina) as the standard, and
          the mass ratio of the standard and analyte phases was 50:50.
 
+         _pd_qpa_calib_factor.I_over_Ic should be defined for each phase, which
+         corresponds to C~p~.
+
          For a description of the RIR methodology, see the entry for the 'RIR'.
 ;
          PONKCS
@@ -8279,7 +8282,7 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the Partial Or No
          Known Crystal Structure methodology [1].
 
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         _pd_qpa_calib_factor.PONKCS should be defined for each phase. Its value
          corresponds to the value C~p~, below.
 
          The relative weight fraction of phase p, W~p~, is given by
@@ -8296,10 +8299,12 @@ save_pd_qpa_overall.method
          formula weight, and V is the volume of the unit cell. The subscript p
          denotes the analyte phase, and s denotes the standard phase.
 
-         Once a particular phase has been calibrated, it's value of C~p~ is
-         consistent with ZMV values and can be used in conjunction with the ZMV
-         algorithm with normal, crystalline phases to quantify relative phase
-         fractions in mixtures containing this phase.
+         The intensities of the peaks assigned to the PONKCS phase, when taken
+         in combination with C~p~, act as pseudo-F_squared values. Because of
+         this, once a particular phase has been calibrated, it's value of C~p~
+         is consistent with ZMV values and can be used in conjunction with the
+         ZMV algorithm with normal, crystalline phases to quantify relative
+         phase fractions in mixtures containing this phase.
 
          If any phase in an analysis of a diffractogram uses the PONKCS
          approach, the entire quantification is to be marked as 'PONKCS', and
@@ -8315,14 +8320,14 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the Reference
          Intensity Ratio methodology [1-3].
 
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         _pd_qpa_calib_factor.RIR should be defined for each phase. Its value
          corresponds to the value C~p~, below.
 
          The method of determining the RIR value, and the particular standard
          against which it was calculated should be given in the
          _pd_qpa_calib_factor.special_details for each phase.
 
-         The relative weight fraction of phase p, W_p, is given by
+         The relative weight fraction of phase p, W~p~, is given by
 
          W~p~ = [(I~p~/I~p,rel~) / C~p~] / Sum[(I~k~/I~k,rel~) / C~k~, k=1:P]
 
@@ -8345,8 +8350,8 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the ZMV
          algorithm [1] in conjunction with Rietveld [2] refinements.
 
-         _pd_qpa_calib_factor.value can be defined, if desired, for each phase,
-         but can be otherwise be calculated from the phases' crystal structure
+         _pd_qpa_calib_factor.ZMV can be defined, if desired, for each phase,
+         but can be otherwise be calculated from the phase's crystal structure
          details. Its value corresponds to the value C~p~, below.
 
          The relative weight fraction of phase p, W~p~, is given by

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8539,12 +8539,16 @@ save_pd_qpa_overall.method
 
          The relative weight fraction of phase p, W~p~, is given by
 
-         W~p~ = [(I~p~/I~p,rel~) / C~p~] / Sum[(I~k~/I~k,rel~) / C~k~, k=1:P]
+             W~p~ = [I~p~ / C~p~] / Sum[I~k~ / C~k~, k=1:P]
 
-         where I~p~ is the intensity of the analyte peak of phase p, I~P,rel~
-         is the ratio between the analyte peak and the most intense peak for
-         phase p, and C~p~ is the reference intensity ratio for phase p.
-         The sum is taken over all phases present in the specimen.
+         where I~p~=I~p~^'^/I~p,rel~, where I~p~^'^ is the intensity of the
+         analyte peak of phase p and I~P,rel~ is the intensity ratio between the
+         analyte peak and the most intense peak for phase p. The sum is taken
+         over all phases present in the specimen. C~p~ is the reference
+         intensity ratio for phase p, must be pre-calculated with a known,
+         crystalline internal standard, as
+
+             C~p~ = (W~s~/W~p~) * (I~p~^'^/I~s~^'^) * (I~s,rel~/(I~p,rel~)
 
          [1] Hubbard, C. R., Evans, E. H. & Smith, D. K. (1976). J. Appl.
          Crystallogr. 9, 169-174.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8430,9 +8430,10 @@ save_pd_qpa_overall.method
 
          where I~p~ is the intensity of the analyte peak, \mu^*^~m~ is the mass
          absorption coefficient of the entire specimen, and C~p~ is a previously
-         determined calibration constant. Intensities from unknown specimens
-         must be collected under the same conditions as the calibration was
-         determined, or normalised to match.
+         determined calibration constant which depends on the data collection
+         conditions and the nature of the phase being calibrated. Intensities
+         from unknown specimens must be collected under the same conditions as
+         the calibration was determined, or normalised to match.
 
          _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
          must be given for the specimen in each diffractogram.
@@ -8442,7 +8443,8 @@ save_pd_qpa_overall.method
          _pd_qpa_calib_factor.absorption_diffraction, respectively.
 
          [1] Klug, H.P. & Alexander, L.E. (1974). X-Ray Diffraction Procedures:
-         For Polycrystalline and Amorphous Materials. New York: Wiley.
+         For Polycrystalline and Amorphous Materials. New York: Wiley. pp.
+         532-534.
 ;
          DDM
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8249,8 +8249,8 @@ save_pd_qpa_internal_std.crystallinity_percent
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _enumeration.default          100.0
     _enumeration.range            0.0:100.0
+    _enumeration.default          100.0
     _units.code                   none
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-22
+    _dictionary.date              2023-01-24
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -8373,7 +8373,7 @@ save_
 save_pd_qpa_overall.method
 
     _definition.id                '_pd_qpa_overall.method'
-    _definition.update            2023-01-22
+    _definition.update            2023-01-24
     _description.text
 ;
     The type of quantification method applied to the given diffractogram.
@@ -8461,17 +8461,17 @@ save_pd_qpa_overall.method
 
          The absolute weight fraction of phase p, W~p~, is given by
 
-             W~p~ = [S~p~ / C~p~] * \mu^*^~m~
+             W~p~ = [I~p~ / C~p~] * \mu^*^~m~
 
-         where S~p~ is the Rietveld scale factor of the analyte phase, and
+         where I~p~ = S~p~/K, where S~p~ is the Rietveld scale factor of the
+         analyte phase and K is a previously determined diffractometer constant.
          \mu^*^~m~ is the mass absorption coefficient of the entire specimen.
          C~p~ is given as
 
-             C~p~ = K /(Z * M * V)~p~
+             C~p~ = 1 /(Z * M * V)~p~
 
          where Z is the number of formula units per unit cell, M is the chemical
-         formula weight, and V is the volume of the unit cell, all of phase p,
-         and K is the previously determined diffractometer constant.
+         formula weight, and V is the volume of the unit cell, all of phase p.
 
          [1] O'Connor, B. H. & Raven, M. D. (1988). Powder Diffr. 3, 2-6.
          [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
@@ -9071,7 +9071,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-22
+         2.5.0                    2023-01-24
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-10
+    _dictionary.date              2023-01-16
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -130,7 +130,7 @@ save_PD_BLOCK
 ;
     _pd_block.id is used to assign a unique ID code to a data block.
     This code is then used for references between different blocks
-    (see _pd_block_diffractogram.id, _pd_qpa_ext_std.block_id
+    (see _pd_block_diffractogram.id, _pd_qpa_external_std.block_id
     and _pd_phase.block_id).
 
     Note that a data block may contain only a single diffraction
@@ -647,11 +647,11 @@ save_pd_calib.std_internal_mass_percent
 
     _definition.id                '_pd_calib.std_internal_mass_percent'
     _definition_replaced.id       1
-    _definition_replaced.by       '_pd_qpa_int_std.mass_percent'
+    _definition_replaced.by       '_pd_qpa_internal_std.mass_percent'
     _definition.update            2023-01-06
     _description.text
 ;
-    This item is deprecated. Please see _pd_qpa_int_std.mass_percent.
+    This item is deprecated. Please see _pd_qpa_internal_std.mass_percent.
 
     Per cent presence of the internal standard specified by the
     data item _pd_calib.std_internal_name expressed as 100 times
@@ -673,11 +673,11 @@ save_pd_calib.std_internal_mass_percent_su
 
     _definition.id                '_pd_calib.std_internal_mass_percent_su'
     _definition_replaced.id       1
-    _definition_replaced.by       '_pd_qpa_int_std.mass_percent_su'
+    _definition_replaced.by       '_pd_qpa_internal_std.mass_percent_su'
     _definition.update            2023-01-06
     _description.text
 ;
-    This item is deprecated. Please see _pd_qpa_int_std.mass_percent_su.
+    This item is deprecated. Please see _pd_qpa_internal_std.mass_percent_su.
 
     Standard uncertainty of _pd_calib.std_internal_mass_percent.
 ;
@@ -5865,8 +5865,8 @@ save_pd_phase_mass.percent
     Total mass of the phase expressed as a percentage of the total
     mass of the specimen.
 
-    If _pd_qpa_int_std.mass_percent or _pd_qpa_ext_std.k_factor is
-    present, the values given are assumed to be in absolute terms.
+    If _pd_qpa_internal_std.mass_percent or _pd_qpa_external_std.k_factor
+    is present, the values given are assumed to be in absolute terms.
 
     The value of the mass percent given to the internal standard
     represents the total crystalline contribution of that standard.
@@ -7466,18 +7466,114 @@ save_pd_proc.number_of_points
 
 save_
 
-save_PD_QPA_EXT_STD
+save_PD_QPA_CALIB_FACTOR
 
-    _definition.id                PD_QPA_EXT_STD
+    _definition.id                PD_QPA_CALIB_FACTOR
     _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2023-01-06
+    _definition.class             Set
+    _definition.update            2023-01-15
     _description.text
 ;
-    This category identifies the external standard used for
-    quantitative phase analysis. Loops may be used for calibration
-    information that differs by detector channel, otherwise only a
-    single value should be recorded per diffractogram.
+    This category gives the value of the calibration constant by which the
+    calculated intensity or scale factor associated with the given phase is
+    divided in order to allow quantitative phase analysis to be undertaken.
+    Further normalisation may be necessary, and can be indicated.
+
+    For example, if quantification was undertaken using RIR values, those
+    values can be recorded with _pd_qpa_calib_factor.value
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_CALIB_FACTOR
+    _category_key.name            '_pd_qpa_calib_factor.phase_id'
+
+save_
+
+save_pd_qpa_calib_factor.phase_id
+
+    _definition.id                '_pd_qpa_calib_factor.phase_id'
+    _definition.update            2023-01-15
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the calibration factor applies.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_calib_factor.special_details
+
+    _definition.id                '_pd_qpa_calib_factor.special_details'
+    _definition.update            2023-01-15
+    _description.text
+;
+    Description of calibration factor details that require additional detail,
+    or cannot otherwise be recorded using other PD_QPA_CALIB_FACTOR data items.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_calib_factor.value
+
+    _definition.id                '_pd_qpa_calib_factor.value'
+    _definition.update            2023-01-15
+    _description.text
+;
+    A calibration value by which a calculated intensity or scale factor
+    associated with the given phase is divided by in the process of quantitative
+    phase analysis.
+
+    The type of calibration factor, and hence the correction quantitative phase
+    analysis equation, is given in _pd_qpa_calib_factor.type.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               value
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.value_su
+
+    _definition.id                '_pd_qpa_calib_factor.value_su'
+    _definition.update            2023-01-14
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.value.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               value_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.value'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_QPA_EXTERNAL_STD
+
+    _definition.id                PD_QPA_EXTERNAL_STD
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-15
+    _description.text
+;
+    This category identifies the external diffractogram used for
+    quantitative phase analysis.
 
     Quantification by external standard is typically carried out
     using the O'Connor and Raven algorithm in conjunction with whole-
@@ -7490,18 +7586,14 @@ save_PD_QPA_EXT_STD
     Chapter 3.9 of International Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
-    _name.object_id               PD_QPA_EXT_STD
-
-    loop_
-      _category_key.name
-         '_pd_qpa_ext_std.detector_id'
-         '_pd_qpa_ext_std.block_id'
+    _name.object_id               PD_QPA_EXTERNAL_STD
+    _category_key.name            '_pd_qpa_external_std.diffractogram_id'
 
 save_
 
-save_pd_qpa_ext_std.block_id
+save_pd_qpa_external_std.diffractogram_block_id
 
-    _definition.id                '_pd_qpa_ext_std.block_id'
+    _definition.id                '_pd_qpa_external_std.diffractogram_block_id'
     _definition.update            2023-01-09
     _description.text
 ;
@@ -7512,8 +7604,8 @@ save_pd_qpa_ext_std.block_id
     Further references to additional phases present are given in
     that data block.
 ;
-    _name.category_id             pd_qpa_ext_std
-    _name.object_id               block_id
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               diffractogram_block_id
     _name.linked_item_id          '_pd_block.id'
     _type.purpose                 Link
     _type.source                  Assigned
@@ -7522,31 +7614,28 @@ save_pd_qpa_ext_std.block_id
 
 save_
 
-save_pd_qpa_ext_std.detector_id
+save_pd_qpa_external_std.diffractogram_id
 
-    _definition.id                '_pd_qpa_ext_std.detector_id'
-    _definition.update            2016-10-18
+    _definition.id                '_pd_qpa_external_std.diffractogram_id'
+    _definition.update            2023-01-15
     _description.text
 ;
-    A code which identifies the detector or channel number to which
-    the external standard data applies. Note that this code should
-    match a detector from _pd_meas.detector_id and may be omitted if
-    only one detector is used.
+    The diffractogram (see _pd_diffractogram.id) which is being used to
+    calculate the diffractometer constant.
 ;
-    _name.category_id             pd_qpa_ext_std
-    _name.object_id               detector_id
-    _name.linked_item_id          '_pd_meas.detector_id'
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
-    _type.source                  Assigned
+    _type.source                  Related
     _type.container               Single
-    _type.contents                Code
-    _enumeration.default          .
+    _type.contents                Text
 
 save_
 
-save_pd_qpa_ext_std.k_factor
+save_pd_qpa_external_std.k_factor
 
-    _definition.id                '_pd_qpa_ext_std.k_factor'
+    _definition.id                '_pd_qpa_external_std.k_factor'
     _definition.update            2023-01-06
     _description.text
 ;
@@ -7567,7 +7656,7 @@ save_pd_qpa_ext_std.k_factor
     Refinement Procedure in Assaying Powdered Mixtures. Powder Diffraction,
     3(1), 2-6. doi:10.1017/s0885715600013026
 ;
-    _name.category_id             pd_qpa_ext_std
+    _name.category_id             pd_qpa_external_std
     _name.object_id               k_factor
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -7577,32 +7666,32 @@ save_pd_qpa_ext_std.k_factor
 
 save_
 
-save_pd_qpa_ext_std.k_factor_su
+save_pd_qpa_external_std.k_factor_su
 
-    _definition.id                '_pd_qpa_ext_std.k_factor_su'
+    _definition.id                '_pd_qpa_external_std.k_factor_su'
     _definition.update            2022-12-01
     _description.text
 ;
-    Standard uncertainty of _pd_qpa_ext_std.k_factor.
+    Standard uncertainty of _pd_qpa_external_std.k_factor.
 ;
-    _name.category_id             pd_qpa_ext_std
+    _name.category_id             pd_qpa_external_std
     _name.object_id               k_factor_su
-    _name.linked_item_id          '_pd_qpa_ext_std.k_factor'
+    _name.linked_item_id          '_pd_qpa_external_std.k_factor'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
-save_pd_qpa_ext_std.phase_id
+save_pd_qpa_external_std.phase_id
 
-    _definition.id                '_pd_qpa_ext_std.phase_id'
+    _definition.id                '_pd_qpa_external_std.phase_id'
     _definition.update            2022-12-03
     _description.text
 ;
     The phase (see _pd_phase.id) used as the external standard.
 ;
-    _name.category_id             pd_qpa_ext_std
+    _name.category_id             pd_qpa_external_std
     _name.object_id               phase_id
     _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Link
@@ -7612,9 +7701,9 @@ save_pd_qpa_ext_std.phase_id
 
 save_
 
-save_pd_qpa_ext_std.phase_name
+save_pd_qpa_external_std.phase_name
 
-    _definition.id                '_pd_qpa_ext_std.phase_name'
+    _definition.id                '_pd_qpa_external_std.phase_name'
     _definition.update            2023-01-07
     _description.text
 ;
@@ -7622,7 +7711,7 @@ save_pd_qpa_ext_std.phase_name
     quantitative phase analysis. This should match the value given in
     _pd_phase.name in the data block containing the calibration diffractogram.
 ;
-    _name.category_id             pd_qpa_ext_std
+    _name.category_id             pd_qpa_external_std
     _name.object_id               phase_name
     _type.purpose                 Describe
     _type.source                  Assigned
@@ -7631,16 +7720,16 @@ save_pd_qpa_ext_std.phase_name
 
 save_
 
-save_pd_qpa_ext_std.special_details
+save_pd_qpa_external_std.special_details
 
-    _definition.id                '_pd_qpa_ext_std.special_details'
+    _definition.id                '_pd_qpa_external_std.special_details'
     _definition.update            2023-01-03
     _description.text
 ;
     Description of external standard details that cannot otherwise
     be recorded using other PD_QPA_EXT_STD data items
 ;
-    _name.category_id             pd_qpa_ext_std
+    _name.category_id             pd_qpa_external_std
     _name.object_id               special_details
     _type.purpose                 Describe
     _type.source                  Recorded
@@ -7649,36 +7738,48 @@ save_pd_qpa_ext_std.special_details
 
 save_
 
-save_PD_QPA_INT_STD
+save_PD_QPA_INTERNAL_STD
 
-    _definition.id                PD_QPA_INT_STD
+    _definition.id                PD_QPA_INTERNAL_STD
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-06
+    _definition.update            2023-01-16
     _description.text
 ;
     This category identifies the internal standard used for
     quantitative phase analysis.
 
-    Quantification by internal standard is typically carried out
-    using the Hill and Howard algorithm in conjunction with whole-
-    pattern Rietveld modelling, with the results being scaled to
-    match the included internal standard. The use of an internal
-    standard allows for the calculation of absolute mass fractions,
-    giving an indication of amorphous content.
+    Quantification by internal standard can be carried out by a variety
+    of different methods, including the Reference Intensity Ratio or the
+    Hill & Howard algorithm in conjunction with whole-pattern Rietveld
+    modelling.
+
+    In general, the use of an internal standard converts relative phase
+    mass percentages into absolute mass percentage, allowing determination
+    of the 'unknown' (or 'amorphous', 'noncrystalline', or 'unanalysed')
+    fraction of the specimen.
+
+    This can be done as
+
+        W~p~^abs.^ = W~p~^rel.^ * (W~s~^known^ / W~s~^rel.^)
+
+    where p and s represent the analyte phase and standard phase, respectively,
+    W is the weight fraction, 'abs.' is absolute, 'rel.' is relative, and
+    'known' is the known addition. Here, W~s~^rel.^ is the relative amount of
+    standard as calculated by the quantification algorithm.
 
     For a review on quantitative phase analysis, see Chapter 3.9 of
     International Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
-    _name.object_id               PD_QPA_INT_STD
+    _name.object_id               PD_QPA_INTERNAL_STD
 
 save_
 
-save_pd_qpa_int_std.block_id
+save_pd_qpa_internal_std.block_id
 
-    _definition.id                '_pd_qpa_int_std.block_id'
-    _definition.update            2023-01-09
+    _definition.id                '_pd_qpa_internal_std.block_id'
+    _definition.update            2023-01-16
     _description.text
 ;
     Identifies the _pd_block.id of the phase used as an internal
@@ -7687,9 +7788,9 @@ save_pd_qpa_int_std.block_id
 
     The data block containing the crystallographic information for this
     phase will be identified with a _pd_block.id code matching the
-    code in _pd_qpa_int_std.block_id
+    code in _pd_qpa_internal_std.block_id
 ;
-    _name.category_id             pd_qpa_int_std
+    _name.category_id             pd_qpa_internal_std
     _name.object_id               block_id
     _name.linked_item_id          '_pd_block.id'
     _type.purpose                 Link
@@ -7699,24 +7800,23 @@ save_pd_qpa_int_std.block_id
 
 save_
 
-save_pd_qpa_int_std.mass_percent
+save_pd_qpa_internal_std.mass_percent
 
-    _definition.id                '_pd_qpa_int_std.mass_percent'
+    _definition.id                '_pd_qpa_internal_std.mass_percent'
     _alias.definition_id          '_pd_calib_std_internal_mass_%'
-    _definition.update            2023-01-03
+    _definition.update            2023-01-16
     _description.text
 ;
-    Per cent presence of the internal standard specified by the
-    data item _pd_calib.std_internal_name expressed as 100 times
-    the mass of standard added divided by the sum of the mass of
-    standard added and the original sample mass.
+    Per cent presence of the internal standard specified by the data item
+    _pd_qpa_internal_std.phase_name expressed as 100 times the mass of
+    standard added divided by the sum of the mass of standard added and the
+    original sample mass.
 
-    This value does not take into account the crystallinity of the
-    internal standard. That is, if 1 g of a 90% crystalline internal
-    standard is added to 3 g of sample, the
-    _pd_calib.std_internal_mass_percent is 25%.
+    This value does not take into account the crystallinity of the internal
+    standard. That is, if 1 g of a 90% crystalline internal standard is added
+    to 3 g of sample, the _pd_qpa_internal_std.mass_percent is 25%.
 ;
-    _name.category_id             pd_qpa_int_std
+    _name.category_id             pd_qpa_internal_std
     _name.object_id               mass_percent
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -7726,32 +7826,32 @@ save_pd_qpa_int_std.mass_percent
 
 save_
 
-save_pd_qpa_int_std.mass_percent_su
+save_pd_qpa_internal_std.mass_percent_su
 
-    _definition.id                '_pd_qpa_int_std.mass_percent_su'
-    _definition.update            2023-01-03
+    _definition.id                '_pd_qpa_internal_std.mass_percent_su'
+    _definition.update            2023-01-16
     _description.text
 ;
-    Standard uncertainty of _pd_qpa_int_std.mass_percent.
+    Standard uncertainty of _pd_qpa_internal_std.mass_percent.
 ;
-    _name.category_id             pd_qpa_int_std
+    _name.category_id             pd_qpa_internal_std
     _name.object_id               mass_percent_su
-    _name.linked_item_id          '_pd_qpa_int_std.mass_percent'
+    _name.linked_item_id          '_pd_qpa_internal_std.mass_percent'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
-save_pd_qpa_int_std.phase_id
+save_pd_qpa_internal_std.phase_id
 
-    _definition.id                '_pd_qpa_int_std.phase_id'
-    _definition.update            2022-12-03
+    _definition.id                '_pd_qpa_internal_std.phase_id'
+    _definition.update            2023-01-16
     _description.text
 ;
     The phase (see _pd_phase.id) used as the internal standard.
 ;
-    _name.category_id             pd_qpa_int_std
+    _name.category_id             pd_qpa_internal_std
     _name.object_id               phase_id
     _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Link
@@ -7761,17 +7861,17 @@ save_pd_qpa_int_std.phase_id
 
 save_
 
-save_pd_qpa_int_std.phase_name
+save_pd_qpa_internal_std.phase_name
 
-    _definition.id                '_pd_qpa_int_std.phase_name'
-    _definition.update            2023-01-07
+    _definition.id                '_pd_qpa_internal_std.phase_name'
+    _definition.update            2023-01-16
     _description.text
 ;
     Identifies the name of the material used as an internal standard for
     quantitative phase analysis. This should match the value given in
     _pd_phase.name in the data block containing the calibration diffractogram.
 ;
-    _name.category_id             pd_qpa_int_std
+    _name.category_id             pd_qpa_internal_std
     _name.object_id               phase_name
     _type.purpose                 Describe
     _type.source                  Assigned
@@ -7780,16 +7880,16 @@ save_pd_qpa_int_std.phase_name
 
 save_
 
-save_pd_qpa_int_std.special_details
+save_pd_qpa_internal_std.special_details
 
-    _definition.id                '_pd_qpa_int_std.special_details'
-    _definition.update            2023-01-03
+    _definition.id                '_pd_qpa_internal_std.special_details'
+    _definition.update            2023-01-16
     _description.text
 ;
     Description of internal standard details that cannot otherwise
-    be recorded using other PD_QPA_INT_STD data items
+    be recorded using other PD_QPA_INTERNAL_STD data items
 ;
-    _name.category_id             pd_qpa_int_std
+    _name.category_id             pd_qpa_internal_std
     _name.object_id               special_details
     _type.purpose                 Describe
     _type.source                  Recorded
@@ -7798,165 +7898,270 @@ save_pd_qpa_int_std.special_details
 
 save_
 
-save_PD_QPA_RIR
+save_PD_QPA_OVERALL
 
-    _definition.id                PD_QPA_RIR
+    _definition.id                PD_QPA_OVERALL
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-06
+    _definition.update            2023-01-16
     _description.text
 ;
-    This category identifies the reference intensity ratio used for
-    quantitative phase analysis.
+    This category gives the overall information about the quantitative phase
+    analysis methodology applied to a given diffractogram.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_CALIB_FACTOR
+    _category_key.name            '_pd_qpa_overall.diffractogram_id'
 
-    The reference intensity ratio (RIR) is an instrument-independent phase
-    constant developed  for use in quantitative phase analysis and is
-    defined as the ratio of the most intense peak of phase, p, to the
-    most intense peak of a reference material, s.
+save_
 
-    The generally accepted reference material is corundum due to its
-    relatively simple diffraction pattern, stability, and availability
-    as a highly crystalline and pure single phase. Additionally, the
-    unknown and reference materials are generally accepted to be mixed
-    in a 50:50 mass ratio. If corundum is used, the RIR equates to I/Ic
-    (or 'I over I corundum') for the phase; these are the most commonly
-    reported values in the literature.
+save_pd_qpa_overall.diffractogram_id
 
-    When applied in conjunction with the matrix-flushing method, quantitative
-    phase analysis is able to be undertaken without the presence of a
-    reference material. In this case, the sum of the mass fractions is
-    normalised to 100%.
+    _definition.id                '_pd_qpa_overall.diffractogram_id'
+    _definition.update            2023-01-16
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) identifying the
+    diffractogram to which the quantitative phase analysis information relates.
 
-    The weight fraction of phase p, W_p, is given by
+    The diffractogram will be identified by a _pd_diffractogram.id code matching
+    the code in _pd_qpa_overall.diffractogram_id.
+;
+    _name.category_id             pd_qpa_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
 
-    W_p = [I_p / (RIR_p * I_p,rel)] / Sum_k[I_k / (RIR_k * I_k,rel)]
+save_
 
-    where I_p is the intensity of the analyte peak of phase p, I_P,rel
-    is the ratio between the analyte peak and the most intense peak for
-    phase p, and RIR_p is the reference intensity ratio for phase p.
-    The sum is taken over all phases present in the specimen.
+save_pd_qpa_overall.special_details
+
+    _definition.id                '_pd_qpa_overall.special_details'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Description of overall QPA details that require additional detail,
+    or cannot otherwise be recorded using other PD_QPA_OVERALL data items.
+;
+    _name.category_id             pd_qpa_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_overall.method
+
+    _definition.id                '_pd_qpa_overall.method'
+    _definition.update            2023-01-16
+    _description.text
+;
+    The type of quantification method applied to the given diffractogram.
+
+    This data item allows the origin of the values of _pd_phase_mass.percent
+    to be determined. Additionally, it allows for the proper interpretation
+    of any _pd_qpa_calib_factor.value that is given.
+
+    If 'other' is chosen, further information must be given in
+    _pd_qpa_overall.special_details
 
     For a review on quantitative phase analysis, see Chapter 3.9 of
     International Tables, Vol. H, and references therein.
 ;
-    _name.category_id             PD_GROUP
-    _name.object_id               PD_QPA_RIR
-
-save_
-
-save_pd_qpa_rir.special_details
-
-    _definition.id                '_pd_qpa_rir.special_details'
-    _definition.update            2023-01-03
-    _description.text
-;
-    Description of RIR details that cannot otherwise
-    be recorded using other PD_QPA_RIR data items.
-;
-    _name.category_id             pd_qpa_rir
-    _name.object_id               special_details
-    _type.purpose                 Describe
+    _name.category_id             pd_qpa_overall
+    _name.object_id               method
+    _type.purpose                 State
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Code
 
-save_
-
-save_pd_qpa_rir.std_block_id
-
-    _definition.id                '_pd_qpa_rir.std_block_id'
-    _definition.update            2023-01-09
-    _description.text
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         RIR
 ;
-    Identifies the _pd_block.id of the diffractogram used to determine
-    the reference intensity ratio.
+         For an RIR value made with reference to corundum, see the state
+         'I/Ic'.
 
-    Further references to additional phases present are given in
-    that data block.
+         Quantitative phase analysis was undertaken following the Reference
+         Intensity Ratio methodology [1-3].
+
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below.
+
+         The method of determining the RIR value, and the particular standard
+         against which it was calculated should be given in the
+         _pd_qpa_calib_factor.special_details for each phase.
+
+         The relative weight fraction of phase p, W_p, is given by
+
+         W~p~ = [(I~p~/I~p,rel~) / C~p~] / Sum[(I~k~/I~k,rel~) / C~k~, k=1:P]
+
+         where I~p~ is the intensity of the analyte peak of phase p, I~P,rel~
+         is the ratio between the analyte peak and the most intense peak for
+         phase p, and C~p~ is the reference intensity ratio for phase p.
+         The sum is taken over all phases present in the specimen.
+
+         [1] Hubbard, C. R., Evans, E. H. & Smith, D. K. (1976). J. Appl.
+         Crystallogr. 9, 169-174.
+
+         [2] Hubbard, C. R. & Snyder, R. L. (1988). Powder Diffr. 3, 74-77.
+
+         [3] Snyder, R. L. & Bish, D. L. (1989). In Modern Powder Diffraction,
+         edited by D. L. Bish & J. E. Post, pp. 101-142. Washington DC:
+         Mineralogical Society of America.
 ;
-    _name.category_id             pd_qpa_rir
-    _name.object_id               std_block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_qpa_rir.std_phase_id
-
-    _definition.id                '_pd_qpa_rir.std_phase_id'
-    _definition.update            2022-12-03
-    _description.text
+         I/Ic
 ;
-    The phase (see _pd_phase.id) used as the internal standard in
-    the determination of the reference intensity ratio.
+         A Reference Intensity Ratio in the specific case where the RIR value
+         was determined using corundum (\a-alumina) as the standard, and the
+         mass ratio of the standard and analyte phases was 50:50.
 ;
-    _name.category_id             pd_qpa_rir
-    _name.object_id               phase_id
-    _name.linked_item_id          '_pd_phase.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_qpa_rir.value
-
-    _definition.id                '_pd_qpa_rir.value'
-    _definition.update            2023-01-03
-    _description.text
+         DDM
 ;
-    The value of the reference intensity ratio to be used in
-    quantitative phase analysis, as described by Hubbard et al., 1976,
-    Hubbard & Snyder, 1988, and Snyder & Bish, 1989.
+         Quantitative phase analysis was undertaken following the Direct
+         Derivation Method [1-6].
 
-    The weight fraction of phase p, W_p is given by
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below.
 
-    W_p = [I_p / (RIR_p * I_p,rel)] / Sum_k[I_k / (RIR_k * I_k,rel)]
+         The relative weight fraction of phase p, W_p, is given by
 
-    where I_p is the intensity of the analyte peak of phase p, I_P,rel
-    is the ratio between the analyte peak and the most intense peak for
-    phase p, and RIR_p is the reference intensity ratio for phase p.
-    The sum is taken over all phases present in the specimen.
+             W~p~ = (I~p~ / C~p~) / Sum(I~k~ / C~k~, k=1:P)
 
-    Hubbard, C. R., Evans, E. H. & Smith, D. K. (1976). The reference
-    intensity ratio, I/Ic, for computer simulated powder patterns. J. Appl.
-    Cryst. 9, 169-174.
+         where I~p~ is the integrated, Lp-normalised intensity of the analyte
+         phase over the entire diffractogram. The sum is taken over all phases
+         present. C~p~ is given by
 
-    Hubbard, C. R. & Snyder, R. L. (1988). RIR - measurement and use in
-    quantitative XRD. Powder Diffr. 3, 74-77.
+             C~p~ = (1/M~p~) * Sum(n~i,p~^2^, i=1:N~p~)
 
-    Snyder, R. L. & Bish, D. L. (1989). In Modern Powder Diffraction, edited
-    by D. L. Bish & J. E. Post, pp. 101-142. Washington DC: Mineralogical
-    Society of America.
+         where M~p~ is the chemical formula weight of phase p, n~i,p~ is the
+         number of electrons belonging to the i^th^ atom of phase p, and N~p~ is
+         the number of atoms in the formula unit of phase p.
+
+         [1] Toraya, H. (2016). J. Appl. Crystallogr. 49, 1508-1516.
+         [2] Toraya, H. (2017). J. Appl. Crystallogr. 50, 820-829.
+         [3] Toraya, H. (2017). J. Appl. Crystallogr. 50, 665-665.
+         [4] Toraya, H. (2018). J. Appl. Crystallogr. 51, 446-455.
+         [5] Toraya, H. (2019). J. Appl. Crystallogr. 52, 520-531.
+         [6] Toraya, H. & Omote, K. (2019). J. Appl. Crystallogr. 52, 13-22.
 ;
-    _name.category_id             pd_qpa_rir
-    _name.object_id               value
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   none
-
-save_
-
-save_pd_qpa_rir.value_su
-
-    _definition.id                '_pd_qpa_rir.value_su'
-    _definition.update            2023-01-03
-    _description.text
+         ZMV
 ;
-    Standard uncertainty of _pd_qpa_rir.value.
-;
-    _name.category_id             pd_qpa_rir
-    _name.object_id               value_su
-    _name.linked_item_id          '_pd_qpa_rir.value'
-    _units.code                   none
+         Quantitative phase analysis was undertaken following the ZMV
+         algorithm [1] in conjunction with Rietveld [2] refinements.
 
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+         _pd_qpa_calib_factor.value can be defined, if desired, for each phase,
+         but can be otherwise be calculated from the phases' crystal structure
+         details. Its value corresponds to the value C~p~, below.
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
+
+         where S~p~ is the Rietveld scale factor of the analyte phase. The sum
+         is taken over all phases present, and
+
+             C~p~ = 1/(Z * M * V)~p~
+
+         where Z is the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell, all of phase p.
+
+         [1] Hill,R.J. & Howard, C.J. (1987). J. Appl. Crystallogr. 20, 467-474.
+         [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
+;
+         PONKCS
+;
+         Quantitative phase analysis was undertaken following the Partial Or No
+         Known Crystal Structure methodology [1].
+
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below.
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
+
+         where S~p~ is the Rietveld scale factor of the analyte phase. The sum
+         is taken over all phases present, and
+
+             C~p~ = (W~s~/W~p~) * (S~p~/S~s~) * (1/(ZMV)~s~)
+
+         where W is the weight fraction, S is the Rietveld scale factor, Z is
+         the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell. The subscript p
+         denotes the analyte phase, and s denotes the standard phase.
+
+         Once a particular phase has been calibrated, it's value of C~p~ is
+         consistent with ZMV valuesand can be used in conjunction with the ZMV
+         algorithm with normal, crystalline phases to quantify relative phase
+         fractions in mixtures containing this phase.
+
+         If any phase in an analysis of a diffractogram uses the PONKCS
+         approach, the entire quantification is to be marked as 'PONKCS', and
+         all phases should define _pd_qpa_calib_factor.value.
+
+         [1] Scarlett, N.V.Y. & Madsen, I.C. (2006). Powder Diffr. 21, 278-284.
+;
+         absorption_diffraction
+;
+         Quantitative phase analysis was undertaken following the
+         absorption-diffraction methodology methodology [1].
+
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below. In addition,
+         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
+         must be given for the specimen in each diffractogram.
+
+         The absolute weight fraction of phase p, W_p, is given by
+
+             W~p~ = [I~p~ / C~p~] * \mu^*^~m~
+
+         where I~p~ is the intensity of the analyte peak, \mu^*^~m~ is the mass
+         absorption coefficient of the entire specimen, and C~p~ is a previously
+         determined calibration constant.
+
+         [1] Klug, H.P. & Alexander, L.E. (1974). X-Ray Diffraction Procedures:
+         For Polycrystalline and Amorphous Materials. New York: Wiley.
+;
+         external_standard
+;
+         Quantitative phase analysis was undertaken following the external
+         standard methodology [1] to quantify absolute phase fractions taken
+         from Rietveld [2] refinements.
+
+         _pd_qpa_calib_factor.value can be defined for each phase, but data
+         items from the PD_QPA_EXTERNAL_STANDARD category should preferentially
+         used. In addition, _pd_char.mass_atten_coef_mu_calc or
+         _pd_char.mass_atten_coef_mu_obs must be given for the specimen in each
+         diffractogram.
+
+         The absolute weight fraction of phase p, W~p~, is given by
+
+             W~p~ = [S~p~ / C~p~] * \mu^*^~m~
+
+         where S~p~ is the Rietveld scale factor of the analyte phase, and
+         \mu^*^~m~ is the mass absorption coefficient of the entire specimen.
+         C~p~ is given as
+
+             C~p~ = K /(Z * M * V)~p~
+
+         where Z is the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell, all of phase p,
+         and K is the previously determined diffractometer constant.
+
+         [1] O'Connor, B. H. & Raven, M. D. (1988). Powder Diffr. 3, 2-6.
+         [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
+;
+         other
+;
+         Please give details in _pd_qpa_overall.special_details.
+;
 
 save_
 
@@ -8427,7 +8632,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-10
+         2.5.0                    2023-01-16
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -8467,17 +8672,15 @@ save_
 
        Made PD_PHASE a Set category.
 
-       Created PD_QPA_EXT_STD and PD_QPA_INT_STD to record quantitative
-       phase analysis by the external and internal standard approaches.
-
-       Created PD_QPA_RIR to record quantitative phase analysis by
-       the reference intensity ratio approach.
+       Created PD_QPA_EXTERNAL_STD and PD_QPA_INTERNAL_STD to record
+       quantitative phase analysis by the external and internal standard
+       approaches.
 
        Changed _pd_meas.step_count_time and _pd_meas.time_of_flight from
        Integer to Real.
 
-       Update definitions of _pd_phase.name, _pd_qpa_ext_std.phase_name, and
-       _pd_qpa_int_std.phase_name to better represent their contents.
+       Update definitions of _pd_phase.name, _pd_qpa_external_std.phase_name,
+       and _pd_qpa_internal_std.phase_name to better represent their contents.
 
        Created PD_AMORPHOUS.
 
@@ -8489,4 +8692,7 @@ save_
 
        Updated data items to hold block ID values to be of type Link, and to
        link them formally to _pd_block.id
+
+       Created PD_QPA_OVERALL to record details about the overall quantitative
+       phase analysis method.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7862,9 +7862,9 @@ save_pd_qpa_calib_factor.ZMV
     A ZMV calibration value associated with the given phase which allows
     quantitative phase analysis to be undertaken.
 
-    If this value is not given, please ensure the atoms in the unit cell are
-    given in an ATOM_TYPE list to allow for the correct calculation of
-    _cell.atomic_mass.
+    If this value is not given, please ensure that _cell.volume and either
+    _cell.atomic_mass or the atoms in the unit cell are given in an ATOM_TYPE
+    list, to allow for the correct calculation of ZMV.
 
     A description of the associated quantification procedure can be found in
     the equivalent enumeration in _pd_qpa_overall.method.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8155,6 +8155,53 @@ save_pd_qpa_internal_std.block_id
 
 save_
 
+save_pd_qpa_internal_std.crystallinity_percent
+
+    _definition.id                '_pd_qpa_internal_std.crystallinity_percent'
+    _definition.update            2023-01-23
+    _description.text
+;
+    Per cent crystallinity of the internal standard.
+
+    Materials are rarely 100% crystalline as the crystal structure at the
+    material's surface is able to relax, and/or contain reaction products. This
+    thin, disordered surface layer can account for several mass percent of the
+    standard, and, as such, can affect any resultant quantification based on the
+    standard.
+
+    Knowledge of the internal standard crystallinity allows for the known mass
+    addition to be corrected to a crystalline addition, which is the addition
+    being analysed in a diffraction experiment.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               crystallinity_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_pd_qpa_internal_std.crystallinity_percent_su
+
+    _definition.id
+        '_pd_qpa_internal_std.crystallinity_percent_su'
+    _definition.update            2023-01-23
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_internal_std.crystallinity_percent.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               crystallinity_percent_su
+    _name.linked_item_id          '_pd_qpa_internal_std.crystallinity_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
 save_pd_qpa_internal_std.mass_percent
 
     _definition.id                '_pd_qpa_internal_std.mass_percent'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8130,8 +8130,8 @@ save_pd_qpa_intensity_factor.value
     This value is not, in general, transferable between different program types
     and versions, as each software package may incorporate different constants
     or normalisations into their calculations. However, if all values for a
-    given diffractogram, or CIF container, are self-consistent, then
-    quantification is able to be undertaken.
+    given diffractogram are self-consistent, then quantification is able to be
+    undertaken.
 
     A description of the associated quantification procedure can be found in
     the equivalent enumeration in _pd_qpa_overall.method.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8461,12 +8461,11 @@ save_pd_qpa_overall.method
 
          The absolute weight fraction of phase p, W~p~, is given by
 
-             W~p~ = [I~p~ / C~p~] * \mu^*^~m~
+             W~p~ = [(S~p~/K) / C~p~] * \mu^*^~m~
 
-         where I~p~ = S~p~/K, where S~p~ is the Rietveld scale factor of the
-         analyte phase and K is a previously determined diffractometer constant.
-         \mu^*^~m~ is the mass absorption coefficient of the entire specimen.
-         C~p~ is given as
+         where S~p~ is the Rietveld scale factor of the analyte phase, K is a
+         previously determined diffractometer constant, and \mu^*^~m~ is the
+         mass absorption coefficient of the entire specimen. C~p~ is given as
 
              C~p~ = 1 /(Z * M * V)~p~
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8461,11 +8461,12 @@ save_pd_qpa_overall.method
 
          The absolute weight fraction of phase p, W~p~, is given by
 
-             W~p~ = [(S~p~/K) / C~p~] * \mu^*^~m~
+             W~p~ = [I~p~ / C~p~] * \mu^*^~m~
 
-         where S~p~ is the Rietveld scale factor of the analyte phase, K is a
-         previously determined diffractometer constant, and \mu^*^~m~ is the
-         mass absorption coefficient of the entire specimen. C~p~ is given as
+         where I~p~ = S~p~/K, where S~p~ is the Rietveld scale factor of the
+         analyte phase and K is a previously determined diffractometer constant.
+         \mu^*^~m~ is the mass absorption coefficient of the entire specimen.
+         C~p~ is given as
 
              C~p~ = 1 /(Z * M * V)~p~
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7484,10 +7484,177 @@ save_PD_QPA_CALIB_FACTOR
     calculated intensity or scale factor associated with the given phase is
     divided by in order to allow quantitative phase analysis to be undertaken.
     Further normalisation may be necessary, and can be indicated.
+
+    For a description of the quantification methodologies below, and a review on
+    quantitative phase analysis in general, see Chapter 3.9 of International
+    Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_CALIB_FACTOR
     _category_key.name            '_pd_qpa_calib_factor.phase_id'
+
+save_
+
+save_pd_qpa_calib_factor.absorption_diffraction
+
+    _definition.id                '_pd_qpa_calib_factor.absorption_diffraction'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A absorption-diffraction calibration value associated with the given phase
+    which allows quantitative phase analysis to be undertaken.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               absorption_diffraction
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.absorption_diffraction_su
+
+    _definition.id
+        '_pd_qpa_calib_factor.absorption_diffraction_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.absorption_diffraction.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               absorption_diffraction_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.absorption_diffraction'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.DDM
+
+    _definition.id                '_pd_qpa_calib_factor.DDM'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A Direct-Derivation Methodology (DDM) calibration value associated with the
+    given phase which allows quantitative phase analysis to be undertaken.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               DDM
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.DDM_su
+
+    _definition.id                '_pd_qpa_calib_factor.DDM_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.DDM.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               DDM_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.DDM'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.external_standard
+
+    _definition.id                '_pd_qpa_calib_factor.external_standard'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A external standard calibration value associated with the given phase which
+    allows quantitative phase analysis to be undertaken.
+
+    If the external standard approach is used, the use of PD_EXTERNAL_STD data
+    items is preferred.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               external_standard
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.external_standard_su
+
+    _definition.id                '_pd_qpa_calib_factor.external_standard_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.external_standard.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               external_standard_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.external_standard'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.I_over_Ic
+
+    _definition.id                '_pd_qpa_calib_factor.I_over_Ic'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A Reference Intensity Ratio (RIR) calibration value associated with the
+    given phase which allows quantitative phase analysis to be undertaken.
+
+    This ratio must have been calculated with respect to corundum; for other
+    reference materials, please use _pd_qpa_calib_factor.RIR.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               I_over_Ic
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.I_over_Ic_su
+
+    _definition.id                '_pd_qpa_calib_factor.I_over_Ic_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.I_over_Ic.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               I_over_Ic_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.I_over_Ic'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -7509,6 +7676,94 @@ save_pd_qpa_calib_factor.phase_id
 
 save_
 
+save_pd_qpa_calib_factor.PONKCS
+
+    _definition.id                '_pd_qpa_calib_factor.PONKCS'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A PONKCS calibration value associated with the given phase which allows
+    quantitative phase analysis to be undertaken.
+
+    This value, when coupled with the peak intensities for which it was
+    calibrated, forms a pseudo-ZMV value, and can also be used in
+    quantification with the ZMV algorithm.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               PONKCS
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.PONKCS_su
+
+    _definition.id                '_pd_qpa_calib_factor.PONKCS_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.PONKCS.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               PONKCS_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.PONKCS'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.RIR
+
+    _definition.id                '_pd_qpa_calib_factor.RIR'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A Reference Intensity Ratio (RIR) calibration value associated with the
+    given phase which allows quantitative phase analysis to be undertaken.
+
+    This ratio must NOT have been calculated with respect to corundum; for RIR
+    values calculated with corundum, please use _pd_qpa_calib_factor.I_over_IC.
+
+    Details of the reference material against which this RIR was determined
+    should be given in _pd_qpa_calib_factor.special_details.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               RIR
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.RIR_su
+
+    _definition.id                '_pd_qpa_calib_factor.RIR_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.RIR.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               RIR_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.RIR'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
 save_pd_qpa_calib_factor.special_details
 
     _definition.id                '_pd_qpa_calib_factor.special_details'
@@ -7527,21 +7782,24 @@ save_pd_qpa_calib_factor.special_details
 
 save_
 
-save_pd_qpa_calib_factor.value
+save_pd_qpa_calib_factor.ZMV
 
-    _definition.id                '_pd_qpa_calib_factor.value'
-    _definition.update            2023-01-15
+    _definition.id                '_pd_qpa_calib_factor.ZMV'
+    _definition.update            2023-01-22
     _description.text
 ;
-    A calibration value by which a calculated intensity or scale factor
-    associated with the given phase is divided by in the process of quantitative
-    phase analysis.
+    A ZMV calibration value associated with the given phase which allows
+    quantitative phase analysis to be undertaken.
 
-    The type of calibration factor, and hence the correction quantitative phase
-    analysis equation, is given in _pd_qpa_calib_factor.type.
+    If the ZMV value used in the quantification can be derived from the
+    structural information present with the phase, then this value
+    does not need to be given.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
 ;
     _name.category_id             pd_qpa_calib_factor
-    _name.object_id               value
+    _name.object_id               ZMV
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               Single
@@ -7550,17 +7808,17 @@ save_pd_qpa_calib_factor.value
 
 save_
 
-save_pd_qpa_calib_factor.value_su
+save_pd_qpa_calib_factor.ZMV_su
 
-    _definition.id                '_pd_qpa_calib_factor.value_su'
-    _definition.update            2023-01-14
+    _definition.id                '_pd_qpa_calib_factor.ZMV_su'
+    _definition.update            2023-01-22
     _description.text
 ;
-    Standard uncertainty of _pd_qpa_calib_factor.value.
+    Standard uncertainty of _pd_qpa_calib_factor.ZMV.
 ;
     _name.category_id             pd_qpa_calib_factor
-    _name.object_id               value_su
-    _name.linked_item_id          '_pd_qpa_calib_factor.value'
+    _name.object_id               ZMV_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.ZMV'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
@@ -7872,6 +8130,9 @@ save_PD_QPA_OVERALL
 ;
     This category gives the overall information about the quantitative phase
     analysis methodology applied to a given diffractogram.
+
+    For a review on quantitative phase analysis, see Chapter 3.9 of
+    International Tables, Vol. H, and references therein.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_CALIB_FACTOR
@@ -7915,9 +8176,6 @@ save_pd_qpa_overall.method
 
     If 'other' is chosen, further information must be given in
     _pd_qpa_overall.special_details
-
-    For a review on quantitative phase analysis, see Chapter 3.9 of
-    International Tables, Vol. H, and references therein.
 ;
     _name.category_id             pd_qpa_overall
     _name.object_id               method

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8562,7 +8562,7 @@ save_pd_qpa_overall.method
          'I/Ic'.
 
          Quantitative phase analysis was undertaken following the Reference
-         Intensity Ratio methodology [1-3].
+         Intensity Ratio methodology [1].
 
          The method of determining the RIR value, and the particular standard
          against which it was calculated should be given in the
@@ -8585,19 +8585,12 @@ save_pd_qpa_overall.method
          _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.RIR,
          respectively.
 
-         [1] Hubbard, C. R., Evans, E. H. & Smith, D. K. (1976). J. Appl.
-         Crystallogr. 9, 169-174.
-
-         [2] Hubbard, C. R. & Snyder, R. L. (1988). Powder Diffr. 3, 74-77.
-
-         [3] Snyder, R. L. & Bish, D. L. (1989). In Modern Powder Diffraction,
-         edited by D. L. Bish & J. E. Post, pp. 101-142. Washington DC:
-         Mineralogical Society of America.
+         [1] Snyder, R. L. (1992). Powder Diffr. 7, 186-192.
 ;
          ZMV
 ;
          Quantitative phase analysis was undertaken following the ZMV
-         algorithm [1] in conjunction with Rietveld [2] refinements.
+         algorithm [1-2] in conjunction with Rietveld [3] refinements.
 
          The relative weight fraction of phase p, W~p~, is given by
 
@@ -8616,6 +8609,7 @@ save_pd_qpa_overall.method
          respectively.
 
          [1] Hill,R.J. & Howard, C.J. (1987). J. Appl. Crystallogr. 20, 467-474.
+         [1] Bish,D.L. & Howard, S.A. (1988). J. Appl. Crystallogr. 21, 86-91.
          [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
 ;
          other

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8424,20 +8424,22 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the
          absorption-diffraction methodology methodology [1].
 
-         _pd_qpa_calib_factor.absorption_diffraction, which corresponds to C~p~,
-         below should be defined for each phase. _pd_qpa_intensity_factor.value,
-         which corresponds to I~p~, below, should be defined for each
-         diffractogram the phase appears in. In addition,
-         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
-         must be given for the specimen in each diffractogram.
-
          The absolute weight fraction of phase p, W~p~, is given by
 
              W~p~ = [I~p~ / C~p~] * \mu^*^~m~
 
          where I~p~ is the intensity of the analyte peak, \mu^*^~m~ is the mass
          absorption coefficient of the entire specimen, and C~p~ is a previously
-         determined calibration constant.
+         determined calibration constant. Intensities from unknown specimens
+         must be collected under the same conditions as the calibration was
+         determined, or normalised to match.
+
+         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
+         must be given for the specimen in each diffractogram.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and
+         _pd_qpa_calib_factor.absorption_diffraction, respectively.
 
          [1] Klug, H.P. & Alexander, L.E. (1974). X-Ray Diffraction Procedures:
          For Polycrystalline and Amorphous Materials. New York: Wiley.
@@ -8446,9 +8448,6 @@ save_pd_qpa_overall.method
 ;
          Quantitative phase analysis was undertaken following the Direct
          Derivation Method [1-6].
-
-         _pd_qpa_calib_factor.DDM should be defined for each phase, which
-         corresponds to C~p~, below.
 
          The relative weight fraction of phase p, W~p~, is given by
 
@@ -8464,6 +8463,10 @@ save_pd_qpa_overall.method
          number of electrons belonging to the i^th^ atom of phase p, and N~p~ is
          the number of atoms in the formula unit of phase p.
 
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.DDM,
+         respectively.
+
          [1] Toraya, H. (2016). J. Appl. Crystallogr. 49, 1508-1516.
          [2] Toraya, H. (2017). J. Appl. Crystallogr. 50, 820-829.
          [3] Toraya, H. (2017). J. Appl. Crystallogr. 50, 665-665.
@@ -8476,12 +8479,6 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the external
          standard methodology [1] to quantify absolute phase fractions taken
          from Rietveld [2] refinements.
-
-         _pd_qpa_calib_factor.external_standard can be defined for each phase,
-         but data items from the PD_QPA_EXTERNAL_STANDARD category should be
-         preferentially used. In addition, _pd_char.mass_atten_coef_mu_calc or
-         _pd_char.mass_atten_coef_mu_obs must be given for the specimen in each
-         diffractogram.
 
          The absolute weight fraction of phase p, W~p~, is given by
 
@@ -8497,6 +8494,15 @@ save_pd_qpa_overall.method
          where Z is the number of formula units per unit cell, M is the chemical
          formula weight, and V is the volume of the unit cell, all of phase p.
 
+         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
+         must be given for the specimen in each diffractogram.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and
+         _pd_qpa_calib_factor.external_standard, respectively, however, data
+         items from the PD_QPA_EXTERNAL_STANDARD category should be
+         preferentially used.
+
          [1] O'Connor, B. H. & Raven, M. D. (1988). Powder Diffr. 3, 2-6.
          [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
 ;
@@ -8506,18 +8512,16 @@ save_pd_qpa_overall.method
          value was determined using corundum (\a-alumina) as the standard, and
          the mass ratio of the standard and analyte phases was 50:50.
 
-         _pd_qpa_calib_factor.I_over_Ic should be defined for each phase, which
-         corresponds to C~p~.
-
          For a description of the RIR methodology, see the entry for the 'RIR'.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.I_over_Ic,
+         respectively.
 ;
          PONKCS
 ;
          Quantitative phase analysis was undertaken following the Partial Or No
          Known Crystal Structure methodology [1].
-
-         _pd_qpa_calib_factor.PONKCS should be defined for each phase. Its value
-         corresponds to the value C~p~, below.
 
          The relative weight fraction of phase p, W~p~, is given by
 
@@ -8544,6 +8548,10 @@ save_pd_qpa_overall.method
          approach, the entire quantification is to be marked as 'PONKCS', and
          all phases should define _pd_qpa_calib_factor.value.
 
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.PONKCS,
+         respectively.
+
          [1] Scarlett, N.V.Y. & Madsen, I.C. (2006). Powder Diffr. 21, 278-284.
 ;
          RIR
@@ -8553,9 +8561,6 @@ save_pd_qpa_overall.method
 
          Quantitative phase analysis was undertaken following the Reference
          Intensity Ratio methodology [1-3].
-
-         _pd_qpa_calib_factor.RIR should be defined for each phase. Its value
-         corresponds to the value C~p~, below.
 
          The method of determining the RIR value, and the particular standard
          against which it was calculated should be given in the
@@ -8574,6 +8579,10 @@ save_pd_qpa_overall.method
 
              C~p~ = (W~s~/W~p~) * (I~p~^'^/I~s~^'^) * (I~s,rel~/(I~p,rel~)
 
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.RIR,
+         respectively.
+
          [1] Hubbard, C. R., Evans, E. H. & Smith, D. K. (1976). J. Appl.
          Crystallogr. 9, 169-174.
 
@@ -8588,10 +8597,6 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the ZMV
          algorithm [1] in conjunction with Rietveld [2] refinements.
 
-         _pd_qpa_calib_factor.ZMV can be defined, if desired, for each phase,
-         but can be otherwise be calculated from the phase's crystal structure
-         details. Its value corresponds to the value C~p~, below.
-
          The relative weight fraction of phase p, W~p~, is given by
 
              W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
@@ -8603,6 +8608,10 @@ save_pd_qpa_overall.method
 
          where Z is the number of formula units per unit cell, M is the chemical
          formula weight, and V is the volume of the unit cell, all of phase p.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.ZMV,
+         respectively.
 
          [1] Hill,R.J. & Howard, C.J. (1987). J. Appl. Crystallogr. 20, 467-474.
          [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7933,24 +7933,6 @@ save_pd_qpa_overall.diffractogram_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_pd_qpa_overall.special_details
-
-    _definition.id                '_pd_qpa_overall.special_details'
-    _definition.update            2023-01-16
-    _description.text
-;
-    Description of overall QPA details that require additional detail,
-    or cannot otherwise be recorded using other PD_QPA_OVERALL data items.
-;
-    _name.category_id             pd_qpa_overall
-    _name.object_id               special_details
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
     _type.contents                Text
 
 save_
@@ -8162,6 +8144,24 @@ save_pd_qpa_overall.method
 ;
          Please give details in _pd_qpa_overall.special_details.
 ;
+
+save_
+
+save_pd_qpa_overall.special_details
+
+    _definition.id                '_pd_qpa_overall.special_details'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Description of overall QPA details that require additional detail,
+    or cannot otherwise be recorded using other PD_QPA_OVERALL data items.
+;
+    _name.category_id             pd_qpa_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7661,7 +7661,7 @@ save_
 
 save_pd_qpa_calib_factor.other
 
-    _definition.id                '_pd_qpa_calib_factor.other
+    _definition.id                '_pd_qpa_calib_factor.other'
     _definition.update            2023-01-24
     _description.text
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-18
+    _dictionary.date              2023-01-22
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -7482,11 +7482,8 @@ save_PD_QPA_CALIB_FACTOR
 ;
     This category gives the value of the calibration constant by which the
     calculated intensity or scale factor associated with the given phase is
-    divided in order to allow quantitative phase analysis to be undertaken.
+    divided by in order to allow quantitative phase analysis to be undertaken.
     Further normalisation may be necessary, and can be indicated.
-
-    For example, if quantification was undertaken using RIR values, those
-    values can be recorded with _pd_qpa_calib_factor.value
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_CALIB_FACTOR
@@ -7907,7 +7904,7 @@ save_
 save_pd_qpa_overall.method
 
     _definition.id                '_pd_qpa_overall.method'
-    _definition.update            2023-01-16
+    _definition.update            2023-01-22
     _description.text
 ;
     The type of quantification method applied to the given diffractogram.
@@ -7932,6 +7929,126 @@ save_pd_qpa_overall.method
     loop_
       _enumeration_set.state
       _enumeration_set.detail
+         absorption_diffraction
+;
+         Quantitative phase analysis was undertaken following the
+         absorption-diffraction methodology methodology [1].
+
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below. In addition,
+         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
+         must be given for the specimen in each diffractogram.
+
+         The absolute weight fraction of phase p, W_p, is given by
+
+             W~p~ = [I~p~ / C~p~] * \mu^*^~m~
+
+         where I~p~ is the intensity of the analyte peak, \mu^*^~m~ is the mass
+         absorption coefficient of the entire specimen, and C~p~ is a previously
+         determined calibration constant.
+
+         [1] Klug, H.P. & Alexander, L.E. (1974). X-Ray Diffraction Procedures:
+         For Polycrystalline and Amorphous Materials. New York: Wiley.
+;
+         DDM
+;
+         Quantitative phase analysis was undertaken following the Direct
+         Derivation Method [1-6].
+
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below.
+
+         The relative weight fraction of phase p, W_p, is given by
+
+             W~p~ = (I~p~ / C~p~) / Sum(I~k~ / C~k~, k=1:P)
+
+         where I~p~ is the integrated, Lp-normalised intensity of the analyte
+         phase over the entire diffractogram. The sum is taken over all phases
+         present. C~p~ is given by
+
+             C~p~ = (1/M~p~) * Sum(n~i,p~^2^, i=1:N~p~)
+
+         where M~p~ is the chemical formula weight of phase p, n~i,p~ is the
+         number of electrons belonging to the i^th^ atom of phase p, and N~p~ is
+         the number of atoms in the formula unit of phase p.
+
+         [1] Toraya, H. (2016). J. Appl. Crystallogr. 49, 1508-1516.
+         [2] Toraya, H. (2017). J. Appl. Crystallogr. 50, 820-829.
+         [3] Toraya, H. (2017). J. Appl. Crystallogr. 50, 665-665.
+         [4] Toraya, H. (2018). J. Appl. Crystallogr. 51, 446-455.
+         [5] Toraya, H. (2019). J. Appl. Crystallogr. 52, 520-531.
+         [6] Toraya, H. & Omote, K. (2019). J. Appl. Crystallogr. 52, 13-22.
+;
+         external_standard
+;
+         Quantitative phase analysis was undertaken following the external
+         standard methodology [1] to quantify absolute phase fractions taken
+         from Rietveld [2] refinements.
+
+         _pd_qpa_calib_factor.value can be defined for each phase, but data
+         items from the PD_QPA_EXTERNAL_STANDARD category should preferentially
+         used. In addition, _pd_char.mass_atten_coef_mu_calc or
+         _pd_char.mass_atten_coef_mu_obs must be given for the specimen in each
+         diffractogram.
+
+         The absolute weight fraction of phase p, W~p~, is given by
+
+             W~p~ = [S~p~ / C~p~] * \mu^*^~m~
+
+         where S~p~ is the Rietveld scale factor of the analyte phase, and
+         \mu^*^~m~ is the mass absorption coefficient of the entire specimen.
+         C~p~ is given as
+
+             C~p~ = K /(Z * M * V)~p~
+
+         where Z is the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell, all of phase p,
+         and K is the previously determined diffractometer constant.
+
+         [1] O'Connor, B. H. & Raven, M. D. (1988). Powder Diffr. 3, 2-6.
+         [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
+;
+         I/Ic
+;
+         A Reference Intensity Ratio (RIR) in the specific case where the RIR
+         value was determined using corundum (\a-alumina) as the standard, and
+         the mass ratio of the standard and analyte phases was 50:50.
+
+         For a description of the RIR methodology, see the entry for the 'RIR'.
+;
+         PONKCS
+;
+         Quantitative phase analysis was undertaken following the Partial Or No
+         Known Crystal Structure methodology [1].
+
+         _pd_qpa_calib_factor.value should be defined for each phase. Its value
+         corresponds to the value C~p~, below.
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
+
+         where S~p~ is the Rietveld scale factor of the analyte phase. The sum
+         is taken over all phases present, and
+
+             C~p~ = (W~s~/W~p~) * (S~p~/S~s~) * (1/(ZMV)~s~)
+
+         where W is the weight fraction, S is the Rietveld scale factor, Z is
+         the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell. The subscript p
+         denotes the analyte phase, and s denotes the standard phase.
+
+         Once a particular phase has been calibrated, it's value of C~p~ is
+         consistent with ZMV values and can be used in conjunction with the ZMV
+         algorithm with normal, crystalline phases to quantify relative phase
+         fractions in mixtures containing this phase.
+
+         If any phase in an analysis of a diffractogram uses the PONKCS
+         approach, the entire quantification is to be marked as 'PONKCS', and
+         all phases should define _pd_qpa_calib_factor.value.
+
+         [1] Scarlett, N.V.Y. & Madsen, I.C. (2006). Powder Diffr. 21, 278-284.
+;
          RIR
 ;
          For an RIR value made with reference to corundum, see the state
@@ -7965,41 +8082,6 @@ save_pd_qpa_overall.method
          edited by D. L. Bish & J. E. Post, pp. 101-142. Washington DC:
          Mineralogical Society of America.
 ;
-         I/Ic
-;
-         A Reference Intensity Ratio in the specific case where the RIR value
-         was determined using corundum (\a-alumina) as the standard, and the
-         mass ratio of the standard and analyte phases was 50:50.
-;
-         DDM
-;
-         Quantitative phase analysis was undertaken following the Direct
-         Derivation Method [1-6].
-
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
-         corresponds to the value C~p~, below.
-
-         The relative weight fraction of phase p, W_p, is given by
-
-             W~p~ = (I~p~ / C~p~) / Sum(I~k~ / C~k~, k=1:P)
-
-         where I~p~ is the integrated, Lp-normalised intensity of the analyte
-         phase over the entire diffractogram. The sum is taken over all phases
-         present. C~p~ is given by
-
-             C~p~ = (1/M~p~) * Sum(n~i,p~^2^, i=1:N~p~)
-
-         where M~p~ is the chemical formula weight of phase p, n~i,p~ is the
-         number of electrons belonging to the i^th^ atom of phase p, and N~p~ is
-         the number of atoms in the formula unit of phase p.
-
-         [1] Toraya, H. (2016). J. Appl. Crystallogr. 49, 1508-1516.
-         [2] Toraya, H. (2017). J. Appl. Crystallogr. 50, 820-829.
-         [3] Toraya, H. (2017). J. Appl. Crystallogr. 50, 665-665.
-         [4] Toraya, H. (2018). J. Appl. Crystallogr. 51, 446-455.
-         [5] Toraya, H. (2019). J. Appl. Crystallogr. 52, 520-531.
-         [6] Toraya, H. & Omote, K. (2019). J. Appl. Crystallogr. 52, 13-22.
-;
          ZMV
 ;
          Quantitative phase analysis was undertaken following the ZMV
@@ -8022,89 +8104,6 @@ save_pd_qpa_overall.method
          formula weight, and V is the volume of the unit cell, all of phase p.
 
          [1] Hill,R.J. & Howard, C.J. (1987). J. Appl. Crystallogr. 20, 467-474.
-         [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
-;
-         PONKCS
-;
-         Quantitative phase analysis was undertaken following the Partial Or No
-         Known Crystal Structure methodology [1].
-
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
-         corresponds to the value C~p~, below.
-
-         The relative weight fraction of phase p, W~p~, is given by
-
-             W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
-
-         where S~p~ is the Rietveld scale factor of the analyte phase. The sum
-         is taken over all phases present, and
-
-             C~p~ = (W~s~/W~p~) * (S~p~/S~s~) * (1/(ZMV)~s~)
-
-         where W is the weight fraction, S is the Rietveld scale factor, Z is
-         the number of formula units per unit cell, M is the chemical
-         formula weight, and V is the volume of the unit cell. The subscript p
-         denotes the analyte phase, and s denotes the standard phase.
-
-         Once a particular phase has been calibrated, it's value of C~p~ is
-         consistent with ZMV valuesand can be used in conjunction with the ZMV
-         algorithm with normal, crystalline phases to quantify relative phase
-         fractions in mixtures containing this phase.
-
-         If any phase in an analysis of a diffractogram uses the PONKCS
-         approach, the entire quantification is to be marked as 'PONKCS', and
-         all phases should define _pd_qpa_calib_factor.value.
-
-         [1] Scarlett, N.V.Y. & Madsen, I.C. (2006). Powder Diffr. 21, 278-284.
-;
-         absorption_diffraction
-;
-         Quantitative phase analysis was undertaken following the
-         absorption-diffraction methodology methodology [1].
-
-         _pd_qpa_calib_factor.value should be defined for each phase. Its value
-         corresponds to the value C~p~, below. In addition,
-         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
-         must be given for the specimen in each diffractogram.
-
-         The absolute weight fraction of phase p, W_p, is given by
-
-             W~p~ = [I~p~ / C~p~] * \mu^*^~m~
-
-         where I~p~ is the intensity of the analyte peak, \mu^*^~m~ is the mass
-         absorption coefficient of the entire specimen, and C~p~ is a previously
-         determined calibration constant.
-
-         [1] Klug, H.P. & Alexander, L.E. (1974). X-Ray Diffraction Procedures:
-         For Polycrystalline and Amorphous Materials. New York: Wiley.
-;
-         external_standard
-;
-         Quantitative phase analysis was undertaken following the external
-         standard methodology [1] to quantify absolute phase fractions taken
-         from Rietveld [2] refinements.
-
-         _pd_qpa_calib_factor.value can be defined for each phase, but data
-         items from the PD_QPA_EXTERNAL_STANDARD category should preferentially
-         used. In addition, _pd_char.mass_atten_coef_mu_calc or
-         _pd_char.mass_atten_coef_mu_obs must be given for the specimen in each
-         diffractogram.
-
-         The absolute weight fraction of phase p, W~p~, is given by
-
-             W~p~ = [S~p~ / C~p~] * \mu^*^~m~
-
-         where S~p~ is the Rietveld scale factor of the analyte phase, and
-         \mu^*^~m~ is the mass absorption coefficient of the entire specimen.
-         C~p~ is given as
-
-             C~p~ = K /(Z * M * V)~p~
-
-         where Z is the number of formula units per unit cell, M is the chemical
-         formula weight, and V is the volume of the unit cell, all of phase p,
-         and K is the previously determined diffractometer constant.
-
-         [1] O'Connor, B. H. & Raven, M. D. (1988). Powder Diffr. 3, 2-6.
          [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
 ;
          other
@@ -8599,7 +8598,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-18
+         2.5.0                    2023-01-22
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7701,25 +7701,6 @@ save_pd_qpa_external_std.phase_id
 
 save_
 
-save_pd_qpa_external_std.phase_name
-
-    _definition.id                '_pd_qpa_external_std.phase_name'
-    _definition.update            2023-01-07
-    _description.text
-;
-    Identifies the name of the material used as an external standard for
-    quantitative phase analysis. This should match the value given in
-    _pd_phase.name in the data block containing the calibration diffractogram.
-;
-    _name.category_id             pd_qpa_external_std
-    _name.object_id               phase_name
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_qpa_external_std.special_details
 
     _definition.id                '_pd_qpa_external_std.special_details'
@@ -7807,9 +7788,8 @@ save_pd_qpa_internal_std.mass_percent
     _definition.update            2023-01-16
     _description.text
 ;
-    Per cent presence of the internal standard specified by the data item
-    _pd_qpa_internal_std.phase_name expressed as 100 times the mass of
-    standard added divided by the sum of the mass of standard added and the
+    Per cent presence of the internal standard expressed as 100 times the mass
+    of standard added divided by the sum of the mass of standard added and the
     original sample mass.
 
     This value does not take into account the crystallinity of the internal
@@ -7856,25 +7836,6 @@ save_pd_qpa_internal_std.phase_id
     _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Link
     _type.source                  Related
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_qpa_internal_std.phase_name
-
-    _definition.id                '_pd_qpa_internal_std.phase_name'
-    _definition.update            2023-01-16
-    _description.text
-;
-    Identifies the name of the material used as an internal standard for
-    quantitative phase analysis. This should match the value given in
-    _pd_phase.name in the data block containing the calibration diffractogram.
-;
-    _name.category_id             pd_qpa_internal_std
-    _name.object_id               phase_name
-    _type.purpose                 Describe
-    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
 
@@ -8679,8 +8640,7 @@ save_
        Changed _pd_meas.step_count_time and _pd_meas.time_of_flight from
        Integer to Real.
 
-       Update definitions of _pd_phase.name, _pd_qpa_external_std.phase_name,
-       and _pd_qpa_internal_std.phase_name to better represent their contents.
+       Update definitions of _pd_phase.name to better represent their contents.
 
        Created PD_AMORPHOUS.
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7980,6 +7980,118 @@ save_pd_qpa_external_std.special_details
 
 save_
 
+save_PD_QPA_INTENSITY_FACTOR
+
+    _definition.id                PD_QPA_INTENSITY_FACTOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-22
+    _description.text
+;
+    This category gives the value of the intensity or scale factor which is
+    divided by the corresponding calibration factor in order to allow
+    quantitative phase analysis to be undertaken. Further normalisation may be
+    necessary, and can be indicated.
+
+    The supported methodologies are enumerated in _pd_qpa_overall.method.
+
+    For a review on quantitative phase analysis, see Chapter 3.9 of
+    International Tables, Vol. H, and references therein.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_INTENSITY_FACTOR
+
+    loop_
+      _category_key.name
+         '_pd_qpa_intensity_factor.diffractogram_id'
+         '_pd_qpa_intensity_factor.phase_id'
+
+save_
+
+save_pd_qpa_intensity_factor.diffractogram_id
+
+    _definition.id                '_pd_qpa_intensity_factor.diffractogram_id'
+    _definition.update            2023-01-15
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the intensity factor
+    relates.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_intensity_factor.phase_id
+
+    _definition.id                '_pd_qpa_intensity_factor.phase_id'
+    _definition.update            2023-01-22
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the intensity factor applies.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_intensity_factor.value
+
+    _definition.id                '_pd_qpa_intensity_factor.value'
+    _definition.update            2023-01-22
+    _description.text
+;
+    An intensity or scale factor value associated with the given phase and
+    diffractogram, which, when divided by the appropriate calibration value
+    defined in _pd_qpa_calib_factor.*, allows quantitative phase analysis to be
+    undertaken.
+
+    This value is not, in general, transferable between different program types
+    and versions, as each software package may incorporate different constants
+    or normalisations into their calculations. However, if all values for a
+    given diffractogram, or CIF container, are self-consistent, then
+    quantification is able to be undertaken.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               value
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_intensity_factor.value_su
+
+    _definition.id                '_pd_qpa_intensity_factor.value_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_intensity_factor.value.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               value_su
+    _name.linked_item_id          '_pd_qpa_intensity_factor.value'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
 save_PD_QPA_INTERNAL_STD
 
     _definition.id                PD_QPA_INTERNAL_STD
@@ -8930,5 +9042,7 @@ save_
        Renamed _pd_char.mass_atten_coef_mu_obs to
        _pd_char.mass_atten_coef_mu_meas.
 
-       Updated _pd_phase.name
+       Updated _pd_phase.name.
+
+       Created PD_QPA_INTENSITY_FACTOR.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -7659,6 +7659,52 @@ save_pd_qpa_calib_factor.I_over_Ic_su
 
 save_
 
+save_pd_qpa_calib_factor.other
+
+    _definition.id                '_pd_qpa_calib_factor.other
+    _definition.update            2023-01-24
+    _description.text
+;
+    A calibration value associated with the given phase which allows
+    quantitative phase analysis to be undertaken.
+
+    The type of data this value represents must be given in
+    _pd_qpa_calib_factor.special_details.
+
+    A description of the associated quantification procedure must be given in
+    _pd_qpa_overall.method.
+
+    When this data item is used in many phases present in the same
+    diffractogram, the person creating the CIF file must ensure that they are
+    have consistent definitions.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               other
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.other_su
+
+    _definition.id                '_pd_qpa_calib_factor.other_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.other.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               other_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.other'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
 save_pd_qpa_calib_factor.phase_id
 
     _definition.id                '_pd_qpa_calib_factor.phase_id'
@@ -7792,9 +7838,9 @@ save_pd_qpa_calib_factor.ZMV
     A ZMV calibration value associated with the given phase which allows
     quantitative phase analysis to be undertaken.
 
-    If the ZMV value used in the quantification can be derived from the
-    structural information present with the phase, then this value
-    does not need to be given.
+    If this value is not given, please ensure the atoms in the unit cell are
+    given in an ATOM_TYPE list to allow for the correct calculation of
+    _cell.atomic_mass.
 
     A description of the associated quantification procedure can be found in
     the equivalent enumeration in _pd_qpa_overall.method.
@@ -8179,6 +8225,7 @@ save_pd_qpa_internal_std.crystallinity_percent
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
+    _enumeration.default          100.0
     _enumeration.range            0.0:100.0
     _units.code                   none
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8400,8 +8400,10 @@ save_pd_qpa_overall.method
          Quantitative phase analysis was undertaken following the
          absorption-diffraction methodology methodology [1].
 
-         _pd_qpa_calib_factor.absorption_diffraction should be defined for each
-         phase, which corresponds to C~p~, below. In addition,
+         _pd_qpa_calib_factor.absorption_diffraction, which corresponds to C~p~,
+         below should be defined for each phase. _pd_qpa_intensity_factor.value,
+         which corresponds to I~p~, below, should be defined for each
+         diffractogram the phase appears in. In addition,
          _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_obs
          must be given for the specimen in each diffractogram.
 


### PR DESCRIPTION
I started writing up how to report QPA, and realised I had overthought things.

Key changes:

- Removed `PD_QPA_RIR`.
   -  I think this category was too narrowly focussed, and only served to specify that you did QPA by RIR. This was the only sort of QPA that was given it's own category
- Created `PD_QPA_CALIB_FACTOR` (`Set`, keyed on `_pd_qpa_calib_factor.phase_id`)
   - This category takes over from `PD_QPA_RIR` inasmuch as it allows a phase to be given a `_pd_qpa_calib_factor.value`. For RIR, this data value is the RIR.
   - In general, this category allows a phase to be given a calibration constant that allows the calculated intensities or scale factor of that phase (for any diffractogram) to be converted into a mass percentage via the appropriate algorithm, whatever that may be.
- Created `PD_QPA_OVERALL` (`Set`, keyed on `_pd_qpa_overall.diffractogram_id`)
   - The main data item here is `_pd_qpa_overall.method`, which is an enumerated list of how the diffractogram was quantified. It can be used just as an information item, but can also be used to provide context to any value associated with `_pd_qpa_calib_factor.value`. The enumerations were taken from Chapter 3.9 of ITC H.
- Renamed `PD_QPA_EXT_STD` and `PD_QPA_INT_STD` to `PD_QPA_EXTERNAL_STD` and `PD_QPA_INTERNAL_STD` to remove one level of abbreviation.
- Rewrote category description of `PD_QPA_INTERNAL_STD` to say that internal std can be used with a variety of quantification methods in order to give absolute phase quantification (not just Rietveld).

.

Possible other considerations for the future:
- Create `PD_QPA_INTENSITY_FACTOR` (`Loop`, keyed on `_pd_qpa_intensity_factor.phase_id` and `_pd_qpa_intensity_factor.diffractogram_id`)
   - Contains `_pd_qpa_intensity_factor.value`. This is the value which is divided by `_pd_qpa_calib_factor.value` in order to give the value which is used in quantification.
      - eg: this would be the Rietveld scale factor for the ZMV method, or a peak intensity for the RIR method.
   - This would allow for a verifiable phase quantification, which currently isn't possible for any technique.
