### PR TITLE
Created PD_CALIB_XCOORD

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-17
+    _dictionary.date              2023-05-06
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3390,10 +3390,8 @@ save_PD_CALIB_XCOORD_OVERALL
     _definition.update            2023-05-06
     _description.text
 ;
-
-
-
-
+    This category gives the overall information about the x-coordinate
+    calibration applied to a given diffractogram.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_XCOORD_OVERALL
@@ -3511,7 +3509,7 @@ save_
 
 save_pd_calib_xcoord_overall.special_details
 
-    _definition.id                '_pd_calib_xcoord.special_details'
+    _definition.id                '_pd_calib_xcoord_overall.special_details'
     _definition.update            2023-05-06
     _description.text
 ;
@@ -12072,7 +12070,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-17
+         2.5.0                    2023-05-06
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3203,14 +3203,14 @@ save_PD_CALIB_XCOORD
          value for each data point.
 ;
 ;
-			loop_
-			_pd_calib_xcoord_overall.id
-			_pd_calib_xcoord_overall.detector_id
-			_pd_calib_xcoord_overall.diffractogram_id
-			_pd_calib_xcoord_overall.phase_id
-			_pd_calib_xcoord_overall.special_details
-			A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
-			B   det2   .   .   "Scanned through direct beam with fine slit."
+            loop_
+            _pd_calib_xcoord_overall.id
+            _pd_calib_xcoord_overall.detector_id
+            _pd_calib_xcoord_overall.diffractogram_id
+            _pd_calib_xcoord_overall.phase_id
+            _pd_calib_xcoord_overall.special_details
+            A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
+            B   det2   .   .   "Scanned through direct beam with fine slit."
 
           loop_
           _pd_calib_xcoord.id
@@ -3492,25 +3492,25 @@ save_PD_CALIB_XCOORD_OVERALL
       _description_example.case
       _description_example.detail
 ;
-			loop_
-			_pd_calib_xcoord_overall.id
-			_pd_calib_xcoord_overall.detector_id
-			d1   det1
-			d2   det2
+         loop_
+         _pd_calib_xcoord_overall.id
+         _pd_calib_xcoord_overall.detector_id
+         d1   det1
+         d2   det2
 ;
 ;
          Calibration offsets given using PD_CALIB_XCOORD category data items
          will correspond to calibrations carried out on the given two detectors.
 ;
 ;
-			loop_
-			_pd_calib_xcoord_overall.id
-			_pd_calib_xcoord_overall.detector_id
-			_pd_calib_xcoord_overall.diffractogram_id
-			_pd_calib_xcoord_overall.phase_id
-			1   A   CALIBRATION_DIFFRACTOGRAM_A   NIST_SRM640E
-			2   B   CALIBRATION_DIFFRACTOGRAM_B   NIST_SRM640E
-			3   C   CALIBRATION_DIFFRACTOGRAM_C   NIST_SRM640E
+         loop_
+         _pd_calib_xcoord_overall.id
+         _pd_calib_xcoord_overall.detector_id
+         _pd_calib_xcoord_overall.diffractogram_id
+         _pd_calib_xcoord_overall.phase_id
+         1   A   CALIBRATION_DIFFRACTOGRAM_A   NIST_SRM640E
+         2   B   CALIBRATION_DIFFRACTOGRAM_B   NIST_SRM640E
+         3   C   CALIBRATION_DIFFRACTOGRAM_C   NIST_SRM640E
 ;
 ;
          Calibration offsets given using PD_CALIB_XCOORD category data items
@@ -3521,14 +3521,14 @@ save_PD_CALIB_XCOORD_OVERALL
          items.
 ;
 ;
-			loop_
-			_pd_calib_xcoord_overall.id
-			_pd_calib_xcoord_overall.detector_id
-			_pd_calib_xcoord_overall.diffractogram_id
-			_pd_calib_xcoord_overall.phase_id
-			_pd_calib_xcoord_overall.special_details
-			A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
-			B   det2   .   .   "Scanned through direct beam with fine slit."
+         loop_
+         _pd_calib_xcoord_overall.id
+         _pd_calib_xcoord_overall.detector_id
+         _pd_calib_xcoord_overall.diffractogram_id
+         _pd_calib_xcoord_overall.phase_id
+         _pd_calib_xcoord_overall.special_details
+         A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
+         B   det2   .   .   "Scanned through direct beam with fine slit."
 ;
 ;
          Different detectors can be calibrated through different means. Here,

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3133,9 +3133,6 @@ save_PD_CALIB_XCOORD
     _pd_calib_xcoord.*_nominal. These values may need to be interpolated to
     be applied to their respective diffractograms.
 
-    This category should be used to specify corrections relating to specimen
-    displacement, and other such specimen-related corrections.
-
     Alternatively, if the offset has been determined at each measurement
     point in the diffractogram, _pd_calib_xcoord.point_id may be used to
     specify the offset on a per-point basis.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-04-13
+    _dictionary.date              2023-01-17
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3115,7 +3115,7 @@ save_PD_CALIB_XCOORD
     _definition.id                PD_CALIB_XCOORD
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-01-17
+    _definition.update            2023-05-06
     _description.text
 ;
     This section defines the parameters used for the calibration of the
@@ -3133,17 +3133,16 @@ save_PD_CALIB_XCOORD
     _pd_calib_xcoord.*_nominal. These values may need to be interpolated to
     be applied to their respective diffractograms.
 
+    This category should be used to specify corrections relating to specimen
+    displacement, and other such specimen-related corrections.
+
     Alternatively, if the offset has been determined at each measurement
     point in the diffractogram, _pd_calib_xcoord.point_id may be used to
     specify the offset on a per-point basis.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_XCOORD
-
-    loop_
-      _category_key.name
-         '_pd_calib_xcoord.detector_id'
-         '_pd_calib_xcoord.id'
+    _category_key.name            '_pd_calib_xcoord.id'
 
 save_
 
@@ -3207,70 +3206,6 @@ save_pd_calib_xcoord.2theta_offset_su
 
 save_
 
-save_pd_calib_xcoord.block_id
-
-    _definition.id                '_pd_calib_xcoord.block_id'
-    _definition.update            2023-01-17
-    _description.text
-;
-    A block ID code identifying the diffractogram from which the X-coordinate
-    calibration was taken, if it was calibrated by a specimen.
-
-    The data block containing the diffraction pattern will be identified with a
-    _pd_block.id code matching the code in _pd_calib_xcoord.block_id.
-;
-    _name.category_id             pd_calib_xcoord
-    _name.object_id               block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_calib_xcoord.detector_id
-
-    _definition.id                '_pd_calib_xcoord.detector_id'
-    _definition.update            2023-01-17
-    _description.text
-;
-    A code which identifies the detector or channel number in a
-    position-sensitive, energy-dispersive or other multiple-detector
-    instrument. Note that this code should match the code name used
-    for _pd_meas.detector_id. As a default value is defined, the detector
-    id may be omitted if only a single detector is present.
-;
-    _name.category_id             pd_calib_xcoord
-    _name.object_id               detector_id
-    _name.linked_item_id          '_pd_meas.detector_id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Code
-    _enumeration.default          .
-
-save_
-
-save_pd_calib_xcoord.diffractogram_id
-
-    _definition.id                '_pd_calib_xcoord.diffractogram_id'
-    _definition.update            2023-01-17
-    _description.text
-;
-    A code which identifies the particular diffractogram from which this
-    X-coordinate calibration was taken, if it was calibrated by a specimen.
-;
-    _name.category_id             pd_calib_xcoord
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_calib_xcoord.id
 
     _definition.id                '_pd_calib_xcoord.id'
@@ -3292,19 +3227,18 @@ save_pd_calib_xcoord.id
 ;
 save_
 
-save_pd_calib_xcoord.phase_id
+save_pd_calib_xcoord.overall_id
 
-    _definition.id                '_pd_calib_xcoord.phase_id'
-    _definition.update            2023-01-17
+    _definition.id                '_pd_calib_xcoord.overall_id'
+    _definition.update            2023-05-06
     _description.text
 ;
-    A code which identifies the particular phase used in calibrating the
-    X-coordinate, if it was calibrated by a specimen. The phase can be
-    an internal or external standard.
+    A code which identifies the particular set of overall calibration conditions
+    under which the calibration was calculated.
 ;
     _name.category_id             pd_calib_xcoord
-    _name.object_id               phase_id
-    _name.linked_item_id          '_pd_phase.id'
+    _name.object_id               overall_id
+    _name.linked_item_id          '_pd_calib_xcoord_overall.id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
@@ -3389,23 +3323,6 @@ save_pd_calib_xcoord.position_offset_su
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
-save_pd_calib_xcoord.special_details
-
-    _definition.id                '_pd_calib_xcoord.special_details'
-    _definition.update            2023-01-17
-    _description.text
-;
-    Description of X-coordinate calibration details that cannot otherwise
-    be recorded using other PD_CALIB_XCOORD data items
-;
-    _name.category_id             pd_calib_xcoord
-    _name.object_id               special_details
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
 
 save_pd_calib_xcoord.time_of_flight_nominal
 
@@ -3462,6 +3379,151 @@ save_pd_calib_xcoord.time_of_flight_offset_su
     _units.code                   microseconds
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_CALIB_XCOORD_OVERALL
+
+    _definition.id                PD_CALIB_XCOORD_OVERALL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-05-06
+    _description.text
+;
+
+
+
+
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_XCOORD_OVERALL
+
+    loop_
+      _category_key.name
+         '_pd_calib_xcoord_overall.detector_id'
+         '_pd_calib_xcoord_overall.id'
+
+save_
+
+save_pd_calib_xcoord_overall.block_id
+
+    _definition.id                '_pd_calib_xcoord_overall.block_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A block ID code identifying the diffractogram from which the X-coordinate
+    calibration was taken, if it was calibrated by a specimen.
+
+    The data block containing the diffraction pattern will be identified with a
+    _pd_block.id code matching the code in _pd_calib_xcoord_overall.block_id.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               block_id
+    _name.linked_item_id          '_pd_block.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.detector_id
+
+    _definition.id                '_pd_calib_xcoord_overall.detector_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code which identifies the detector or channel number, in a
+    position-sensitive, energy-dispersive or other multiple-detector instrument,
+    to which the calibration applies.
+
+    Note that this code should match the code name used for
+    _pd_meas.detector_id. As a default value is defined, the detector id may be
+    omitted if only a single detector is present.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_meas.detector_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          .
+
+save_
+
+save_pd_calib_xcoord_overall.diffractogram_id
+
+    _definition.id                '_pd_calib_xcoord_overall.diffractogram_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code which identifies the particular diffractogram from which this
+    X-coordinate calibration was taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.id
+
+    _definition.id                '_pd_calib_xcoord_overall.id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code to uniquely identify the overall values associated with a group of
+    calibration points.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.phase_id
+
+    _definition.id                '_pd_calib_xcoord_overall.phase_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code which identifies the particular phase used in calibrating the
+    X-coordinate, if it was calibrated by a specimen. The phase can be
+    an internal or external standard.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.special_details
+
+    _definition.id                '_pd_calib_xcoord.special_details'
+    _definition.update            2023-05-06
+    _description.text
+;
+    Description of X-coordinate calibration details that cannot otherwise
+    be recorded using other PD_CALIB_XCOORD_OVERALL data items.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -12010,7 +12072,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-04-13
+         2.5.0                    2023-01-17
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12087,7 +12149,7 @@ save_
        Renamed _pd_char.mass_atten_coef_mu_obs to
        _pd_char.mass_atten_coef_mu_meas.
 
-       Created PD_CALIB_XCOORD
+       Created PD_CALIB_XCOORD and PD_CALIB_XCOORD_OVERALL
 
        Updated _pd_phase.name
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-05-14
+    _dictionary.date              2023-05-22
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -12202,7 +12202,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-05-14
+         2.5.0                    2023-05-22
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1344,28 +1344,6 @@ save_pd_calib_xcoord.phase_id
 
 save_
 
-save_pd_calib_xcoord.phase_name
-
-    _definition.id                '_pd_calib_xcoord.phase_name'
-    _definition.update            2023-01-17
-    _description.text
-;
-    Identity of material(s) used as an X-coordinate standard.
-;
-    _name.category_id             pd_calib_xcoord
-    _name.object_id               phase_name
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         'NIST 640a Silicon standard'
-         'Al2O3'
-
-save_
-
 save_pd_calib_xcoord.point_id
 
     _definition.id                '_pd_calib_xcoord.point_id'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3144,6 +3144,93 @@ save_PD_CALIB_XCOORD
     _name.object_id               PD_CALIB_XCOORD
     _category_key.name            '_pd_calib_xcoord.id'
 
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+          _pd_calib_xcoord.point_id
+          _pd_calib_xcoord.2theta_offset
+          1   0.01
+          2   0.01
+          3   0.02
+          4   0.02
+          ...
+
+          loop_
+          _pd_data.point_id
+          _pd_meas.2theta_scan
+          _pd_meas.counts_total
+          _pd_calc.intensity_total
+          1   10.01   1234    1234.1
+          2   10.03   1235    1235.3
+          3   10.05   1352    1236.5
+          4   10.07   1324    1237.7
+          ...
+;
+;
+         Calibration offset values are provided for each data point in the
+         diffractogram.
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+          _pd_calib_xcoord.id
+          _pd_calib_xcoord.2theta_nominal
+          _pd_calib_xcoord.2theta_offset
+          a   10.00   0.01
+          b   12.00   0.02
+          c   14.00   0.03
+          d   16.00   0.04
+          ...
+
+          loop_
+          _pd_data.point_id
+          _pd_meas.2theta_scan
+          _pd_meas.counts_total
+          _pd_calc.intensity_total
+          1   10.01   1234    1234.1
+          2   10.03   1235    1235.3
+          3   10.05   1352    1236.5
+          4   10.07   1324    1237.7
+          ...
+;
+;
+         Calibration offsets and the nominal 2\q values to which they apply are
+         listed, along with the diffraction pattern to which they apply. With
+         the given calibration data, an interpolation must be made to obtain a
+         value for each data point.
+;
+;
+			loop_
+			_pd_calib_xcoord_overall.id
+			_pd_calib_xcoord_overall.detector_id
+			_pd_calib_xcoord_overall.diffractogram_id
+			_pd_calib_xcoord_overall.phase_id
+			_pd_calib_xcoord_overall.special_details
+			A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
+			B   det2   .   .   "Scanned through direct beam with fine slit."
+
+          loop_
+          _pd_calib_xcoord.id
+          _pd_calib_xcoord.position_nominal
+          _pd_calib_xcoord.position_offset
+          _pd_calib_xcoord.overall_id
+          a   10.00   0.01   A
+          b   10.00   0.02   B
+          c   12.00   0.03   A
+          d   12.00   0.03   B
+          ...
+;
+;
+         Calibration offsets and the nominal position values to which they apply
+         are listed. The given _pd_calib_xcoord.overall_id refers to the
+         PD_CALIB_XCOORD_OVERALL category items given above.
+
+         An interpolation must be made to obtain a value for each data point.
+;
+
 save_
 
 save_pd_calib_xcoord.2theta_nominal
@@ -3400,6 +3487,58 @@ save_PD_CALIB_XCOORD_OVERALL
       _category_key.name
          '_pd_calib_xcoord_overall.detector_id'
          '_pd_calib_xcoord_overall.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+			loop_
+			_pd_calib_xcoord_overall.id
+			_pd_calib_xcoord_overall.detector_id
+			d1   det1
+			d2   det2
+;
+;
+         Calibration offsets given using PD_CALIB_XCOORD category data items
+         will correspond to calibrations carried out on the given two detectors.
+;
+;
+			loop_
+			_pd_calib_xcoord_overall.id
+			_pd_calib_xcoord_overall.detector_id
+			_pd_calib_xcoord_overall.diffractogram_id
+			_pd_calib_xcoord_overall.phase_id
+			1   A   CALIBRATION_DIFFRACTOGRAM_A   NIST_SRM640E
+			2   B   CALIBRATION_DIFFRACTOGRAM_B   NIST_SRM640E
+			3   C   CALIBRATION_DIFFRACTOGRAM_C   NIST_SRM640E
+;
+;
+         Calibration offsets given using PD_CALIB_XCOORD category data items
+         will correspond to calibrations carried out on the given three
+         detectors derived from analysis of the given diffractograms and phase.
+
+         Calibration values will be given using PD_CALIB_XCOORD category data
+         items.
+;
+;
+			loop_
+			_pd_calib_xcoord_overall.id
+			_pd_calib_xcoord_overall.detector_id
+			_pd_calib_xcoord_overall.diffractogram_id
+			_pd_calib_xcoord_overall.phase_id
+			_pd_calib_xcoord_overall.special_details
+			A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
+			B   det2   .   .   "Scanned through direct beam with fine slit."
+;
+;
+         Different detectors can be calibrated through different means. Here,
+         det1 was calibrated through the analysis of a diffractogram and a
+         known reference material, whereas det2 was calibrated by scanning the
+         detector through the direct beam.
+
+         Calibration values will be given using PD_CALIB_XCOORD category data
+         items.
+;
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3304,11 +3304,7 @@ save_pd_calib_xcoord.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default = _pd_calib_xcoord.point_id
-;
+
 save_
 
 save_pd_calib_xcoord.overall_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-16
+    _dictionary.date              2023-01-17
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -1139,6 +1139,383 @@ save_pd_calib_std.external_name
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_PD_CALIB_XCOORD
+
+    _definition.id                PD_CALIB_XCOORD
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-17
+    _description.text
+;
+    This section defines the parameters used for the calibration of the
+    X-coordinate axis of the instrument used directly or indirectly in the
+    interpretation of this data set; that is, 2\q, time-of-flight, or
+    position.
+
+    Calibration is carried out be adding the offset value:
+
+        X-coord~calibrated~ = X-coord~meas~ + X-coord~offset~
+
+    For cases where the offset value is not a constant, but rather varies
+    with X-coordinate, a set of offset values is supplied in a loop. In this
+    case, the value where the offset has been determined can be specified as
+    _pd_calib_xcoord.*_nominal. These values may need to be interpolated to
+    be applied to their respective diffractograms.
+
+    Alternatively, if the offset has been determined at each measurement
+    point in the diffractogram, _pd_calib_xcoord.point_id may be used to
+    specify the offset on a per-point basis.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_XCOORD
+
+    loop_
+      _category_key.name
+         '_pd_calib_xcoord.detector_id'
+         '_pd_calib_xcoord.id'
+
+save_
+
+save_pd_calib_xcoord.2theta_nominal
+
+    _definition.id                '_pd_calib_xcoord.2theta_nominal'
+    _definition.update            2023-01-17
+    _description.text
+;
+    The nominal 2\q value to which the offset given in
+    _pd_calib_xcoord.2theta_offset applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               2theta_nominal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib_xcoord.2theta_offset
+
+    _definition.id                '_pd_calib_xcoord.2theta_offset'
+    _definition.update            2023-01-17
+    _description.text
+;
+    _pd_calib_xcoord.2theta_offset defines an offset angle (in degrees) used
+    to calibrate 2\q (as defined in _pd_meas.2theta_). Calibration is done
+    by adding the offset:
+
+         2\q~calibrated~ = 2\q~measured~ + 2\q~offset~
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               2theta_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib_xcoord.2theta_offset_su
+
+    _definition.id                '_pd_calib_xcoord.2theta_offset_su'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_xcoord.2theta_offset.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               2theta_offset_su
+    _name.linked_item_id          '_pd_calib_xcoord.2theta_offset'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_xcoord.block_id
+
+    _definition.id                '_pd_calib_xcoord.block_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A block ID code identifying the diffractogram from which the X-coordinate
+    calibration was taken, if it was calibrated by a specimen.
+
+    The data block containing the diffraction pattern will be identified with a
+    _pd_block.id code matching the code in _pd_calib_xcoord.block_id.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               block_id
+    _name.linked_item_id          '_pd_block.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.detector_id
+
+    _definition.id                '_pd_calib_xcoord.detector_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument. Note that this code should match the code name used
+    for _pd_meas.detector_id. As a default value is defined, the detector
+    id may be omitted if only a single detector is present.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_meas.detector_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          .
+
+save_
+
+save_pd_calib_xcoord.diffractogram_id
+
+    _definition.id                '_pd_calib_xcoord.diffractogram_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the particular diffractogram from which this
+    X-coordinate calibration was taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.id
+
+    _definition.id                '_pd_calib_xcoord.id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code to uniquely identify each X-coordinate calibration.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = _pd_calib_xcoord.point_id
+;
+save_
+
+save_pd_calib_xcoord.phase_id
+
+    _definition.id                '_pd_calib_xcoord.phase_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the particular phase used in calibrating the
+    X-coordinate, if it was calibrated by a specimen. The phase can be
+    an internal or external standard.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.phase_name
+
+    _definition.id                '_pd_calib_xcoord.phase_name'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Identity of material(s) used as an X-coordinate standard.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               phase_name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'NIST 640a Silicon standard'
+         'Al2O3'
+
+save_
+
+save_pd_calib_xcoord.point_id
+
+    _definition.id                '_pd_calib_xcoord.point_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Arbitrary label identifying a data point in a diffractogram. Used to
+    identify a specific entry in a list of values forming the diffractogram
+    to which the X-coordinate calibration applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_xcoord.position_nominal
+
+    _definition.id                '_pd_calib_xcoord.position_nominal'
+    _definition.update            2023-01-17
+    _description.text
+;
+    The nominal position value to which the offset given in
+    _pd_calib_xcoord.position_offset applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               position_nominal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
+save_pd_calib_xcoord.position_offset
+
+    _definition.id                '_pd_calib_xcoord.position_offset'
+    _definition.update            2023-01-17
+    _description.text
+;
+    _pd_calib_xcoord.position_offset defines an offset position (in
+    millimetres) used to calibrate position (as defined in
+    _pd_meas.position). Calibration is done by adding the offset:
+
+         position~calibrated~ = position~measured~ + position~offset~
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               position_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
+save_pd_calib_xcoord.position_offset_su
+
+    _definition.id                '_pd_calib_xcoord.position_offset_su'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_xcoord.position_offset.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               position_offset_su
+    _name.linked_item_id          '_pd_calib_xcoord.position_offset'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+save_pd_calib_xcoord.special_details
+
+    _definition.id                '_pd_calib_xcoord.special_details'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Description of X-coordinate calibration details that cannot otherwise
+    be recorded using other PD_CALIB_XCOORD data items
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.time_of_flight_nominal
+
+    _definition.id                '_pd_calib_xcoord.time_of_flight_nominal'
+    _definition.update            2023-01-17
+    _description.text
+;
+    The nominal time-of-flight value to which the offset given in
+    _pd_calib_xcoord.time_of_flight_offset applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               time_of_flight_nominal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   microseconds
+
+save_
+
+save_pd_calib_xcoord.time_of_flight_offset
+
+    _definition.id                '_pd_calib_xcoord.time_of_flight_offset'
+    _definition.update            2023-01-17
+    _description.text
+;
+    _pd_calib_xcoord.time_of_flight_offset defines an offset time (in
+    microseconds) used to calibrate time-of-flight (TOF) (as defined in
+    _pd_meas.time_of_flight). Calibration is done by adding the offset:
+
+    TOF~calibrated~ = TOF~measured~ + TOF~offset~
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               time_of_flight_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   microseconds
+
+save_
+
+save_pd_calib_xcoord.time_of_flight_offset_su
+
+    _definition.id                '_pd_calib_xcoord.time_of_flight_offset_su'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_xcoord.time_of_flight_offset.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               time_of_flight_offset_su
+    _name.linked_item_id          '_pd_calib_xcoord.time_of_flight_offset'
+    _units.code                   microseconds
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -8424,7 +8801,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-16
+         2.5.0                    2023-01-17
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -8493,4 +8870,6 @@ save_
 
        Renamed _pd_char.mass_atten_coef_mu_obs to
        _pd_char.mass_atten_coef_mu_meas.
+
+       Created PD_CALIB_XCOORD
 ;


### PR DESCRIPTION
This category holds information on the corrections in X-coordinate used to calibrate detector_ids. It is trying to be a single category that can cover all of the different types of measured x-coordinate; 2Th, TOF, position, wavelength, detector_id (aka channel).

