### PR TITLE
update description of _pd_proc.wavelength

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-21
+    _dictionary.date              2023-01-22
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3113,16 +3113,20 @@ save_pd_proc.wavelength
 
     _definition.id                '_pd_proc.wavelength'
     _alias.definition_id          '_pd_proc_wavelength'
-    _definition.update            2022-10-11
+    _definition.update            2023-01-22
     _description.text
 ;
     Wavelength in angstroms for the incident radiation as
     computed from secondary calibration information. This will
-    be most appropriate for time-of-flight and synchrotron
-    measurements. This will be a single value for
-    continuous-wavelength methods or may vary for each data point
-    and be looped with the intensity values for energy-dispersive
-    measurements.
+    be most appropriate for measurements where the wavelength varies
+    for each data point and must be looped with the intensity values,
+    such as time-of-flight, or energy-dispersive measurements.
+
+    For measurements where the incident radiation can be considered to
+    be monochromatic and has been estimated or refined, for instance,
+    from instrumental parameters or a reference material, please record
+    the wavelength with _diffrn_radiation_wavelength.value and
+    _diffrn_radiation_wavelength.determination.
 ;
     _name.category_id             pd_proc
     _name.object_id               wavelength
@@ -8496,7 +8500,6 @@ save_
        PD_PREF_ORIENT_SPHERICAL_HARMONICS.
 
        Updated data items to hold block ID values to be of type Link, and to
-
        link them formally to _pd_block.id
 
        Update description of _pd_proc.info_datetime to maintain consistency
@@ -8508,4 +8511,6 @@ save_
        Updated _pd_phase.name.
 
        Updated description of _pd_calibration.conversion_eqn.
+
+       Updated description of _pd_proc.wavelength.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8439,7 +8439,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-21
+         2.5.0                    2023-01-22
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
will close #95 

Is this part OK?
> the incident radiation can be considered to be monochromatic

I'm thinking about a case like having a tube source and a Johannson mono, where the emission profile is some funky thing that still requires multiple wavelengths to model properly, but is "monochromatic". or even a curved graphite mono where there is still some residual kB radiation; i'd still call that "monochromatic", but it has been refined.


![image](https://user-images.githubusercontent.com/14921460/213899225-166bd395-4a9a-4dcb-9f4f-87a03f6f5747.png)
![image](https://user-images.githubusercontent.com/14921460/213899255-527193fd-e16c-4a47-98b1-c4ccb9fc2c54.png)
