### PR TITLE
Replace old data names with their newer variants in data item descriptions

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-01-29
+    _dictionary.date              2023-02-06
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3218,22 +3218,22 @@ save_PD_INSTR
 
     Note that several definitions in the core CIF dictionary
     are relevant here. For example, use:
-      _diffrn_radiation_wavelength for the source wavelength,
-      _diffrn_radiation_type for the X-ray wavelength type,
-      _diffrn_source for the radiation source,
-      _diffrn_radiation_polarisn_ratio for the source polarization,
-      _diffrn_radiation_probe for the radiation type.
+      _diffrn_radiation_wavelength.value for the source wavelength,
+      _diffrn_radiation_wavelength.type for the X-ray wavelength type,
+      _diffrn_source.device and _diffrn_source.details for the radiation source,
+      _diffrn_radiation.polarisn_ratio for the source polarization,
+      _diffrn_radiation.probe for the radiation type.
     For data sets measured with partially monochromatized radiation,
     for example, where both K\a~1~ and K\a~2~ are present, it is
     important that all wavelengths present are included in a
-    loop_ using _diffrn_radiation_wavelength to define the
-    wavelength and _diffrn_radiation_wavelength_wt to define the
+    loop_ using _diffrn_radiation_wavelength.value to define the
+    wavelength and _diffrn_radiation_wavelength.wt to define the
     relative intensity of that wavelength. It is required that
-    _diffrn_radiation_wavelength_id also be present in the
+    _diffrn_radiation_wavelength.id also be present in the
     wavelength loop. It may also be useful to
     create a "dummy" ID to use for labelling
     peaks/reflections where the K\a~1~ and K\a~2~ wavelengths are
-    not resolved. Set _diffrn_radiation_wavelength_wt to be 0 for
+    not resolved. Set _diffrn_radiation_wavelength.wt to be 0 for
     such a dummy ID.
 
     In the PD_INSTR definitions, the term monochromator refers
@@ -3243,7 +3243,7 @@ save_PD_INSTR
     wavelength or may be capable of being scanned.
 
     It is strongly recommended that the core dictionary term
-    _diffrn_radiation_probe (specifying the nature of the radiation
+    _diffrn_radiation.probe (specifying the nature of the radiation
     used) is employed for all data sets.
 ;
     _name.category_id             PD_GROUP
@@ -5575,7 +5575,7 @@ save_pd_peak.wavelength_id
 ;
     Code identifying the wavelength appropriate for this peak
     from the wavelengths in the _diffrn_radiation_ list.
-    (See _diffrn_radiation_wavelength_id.) Most commonly used
+    (See _diffrn_radiation_wavelength.id.) Most commonly used
     to distinguish K\a~1~ peaks from K\a~2~ or to designate
     where K\a~1~ and K\a~2~ peaks cannot be resolved. For
     complex peak tables with multiple superimposed peaks,
@@ -9112,7 +9112,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-01-29
+         2.5.0                    2023-02-06
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
This PR replaces several dotless data names from the `CIF_CORE` dictionary with their newer variants. Note that some of the referenced data items had been completely deprecated in the `CIF_CORE` dictionary and were therefore substituted by their replacement items (e.g. `_diffrn_radiation_type` was changed to `_diffrn_radiation_wavelength.type `). On the first glace the semantics seem to remain mostly the same, but it would be great if someone could double check.