### PR TITLE
Fixed update dates of PD_CHAR and PD_PREP

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-05-14
+    _dictionary.date              2023-06-03
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -11655,7 +11655,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-05-14
+         2.5.0                    2023-06-03
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3185,7 +3185,7 @@ save_PD_CHAR
     _definition.id                PD_CHAR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2014-06-20
+    _definition.update            2023-02-22
     _description.text
 ;
     This section contains experimental (non-diffraction) information relevant to
@@ -9115,7 +9115,7 @@ save_PD_PREP
     _definition.id                PD_PREP
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2014-06-20
+    _definition.update            2023-02-22
     _description.text
 ;
     This section contains descriptive information about how the sample, from


### PR DESCRIPTION
Date taken from https://github.com/COMCIFS/Powder_Dictionary/commit/ecb7d10bc27acc1a8d8a66cdb7da6c216470d0f0

PD_SPEC was already changed. The revision sentence at the end was already correct.