### PR TITLE
Category keys and links for `PD_CHAR`, `PD_PREP`, and `PD_SPEC`

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -11853,6 +11853,6 @@ save_
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
        PD_BACKGROUND, and REFLN
 
-       Created category keys for PD_CHAR and PD_PREP. Added link keys between
-       PD_CHAR and PD_PREP, and PD_PREP and PD_SPEC.
+       Created category keys for PD_CHAR and PD_PREP. Added link keys to join
+       PD_CHAR to PD_PREP, and PD_PREP to PD_SPEC.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-05-14
+    _dictionary.date              2023-06-04
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -11220,7 +11220,7 @@ save_PD_SPEC
     _definition.id                PD_SPEC
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-22
+    _definition.update            2023-03-25
     _description.text
 ;
     This section contains information about the specimen used for measurement of
@@ -11745,7 +11745,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-05-14
+         2.5.0                    2023-06-04
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -11852,4 +11852,7 @@ save_
 
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
        PD_BACKGROUND, and REFLN
+
+       Created category keys for PD_CHAR and PD_PREP. Added link keys between
+       PD_CHAR and PD_PREP, and PD_PREP and PD_SPEC.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3341,6 +3341,23 @@ save_pd_char.colour
 
 save_
 
+save_pd_char.id
+
+    _definition.id                '_pd_char.id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    Arbitrary label identifying a material.
+;
+    _name.category_id             pd_char
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_char.mass_atten_coef_mu_calc
 
     _definition.id                '_pd_char.mass_atten_coef_mu_calc'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -9198,6 +9198,23 @@ save_pd_prep.cool_rate_su
 
 save_
 
+save_pd_prep.id
+
+    _definition.id                '_pd_prep.id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    Arbitrary label identifying a sample.
+;
+    _name.category_id             pd_prep
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_prep.pressure
 
     _definition.id                '_pd_prep.pressure'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -9237,6 +9237,24 @@ save_pd_prep.pressure_su
 
 save_
 
+save_pd_prep.special_details
+
+    _definition.id                '_pd_prep.special_details'
+    _definition.update            2023-06-04
+    _description.text
+;
+    Descriptive information about the sample that cannot be included in other
+    data items.
+;
+    _name.category_id             pd_prep
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_prep.temperature
 
     _definition.id                '_pd_prep.temperature'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -9156,6 +9156,24 @@ save_PD_PREP
 
 save_
 
+save_pd_prep.char_id
+
+    _definition.id                '_pd_prep.char_id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    A char id, representing a material, to which this sample relates.
+;
+    _name.category_id             pd_prep
+    _name.object_id               char_id
+    _name.linked_item_id          '_pd_char.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_prep.conditions
 
     _definition.id                '_pd_prep.conditions'
@@ -11340,6 +11358,24 @@ save_pd_spec.orientation
          horizontal
          vertical
          both
+
+save_
+
+save_pd_spec.prep_id
+
+    _definition.id                '_pd_spec.prep_id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    A prep id, representing a sample, to which this specimen relates.
+;
+    _name.category_id             pd_spec
+    _name.object_id               prep_id
+    _name.linked_item_id          '_pd_prep.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3185,7 +3185,7 @@ save_PD_CHAR
     _definition.id                PD_CHAR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2014-06-20
+    _definition.update            2023-06-04
     _description.text
 ;
     This section contains experimental (non-diffraction) information relevant to
@@ -3205,6 +3205,7 @@ save_PD_CHAR
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CHAR
+    _category_key.name            '_pd_spec.id'
 
 save_
 
@@ -9132,7 +9133,7 @@ save_PD_PREP
     _definition.id                PD_PREP
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2014-06-20
+    _definition.update            2023-06-04
     _description.text
 ;
     This section contains descriptive information about how the sample, from
@@ -9153,6 +9154,7 @@ save_PD_PREP
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PREP
+    _category_key.name            '_pd_prep.id'
 
 save_
 


### PR DESCRIPTION
Set in motion by #114

Added category keys for the `Set` categories `PD_CHAR`, `PD_PREP`, and `PD_SPEC`

Added linking keys to join `PD_CHAR` to `PD_PREP` and `PD_PREP` to `PD_SPEC`.

There is now:

- `_pd_char.id`
- `_pd_prep.id`
- `_pd_prep.char_id`
- `_pd_spec.prep_id`

to compliment the existing

- `_pd_spec.id`, and
- `_pd_diffractogram.spec_id`

Now you can have one material (`PD_CHAR`) making multiple samples (`PD_PREP`) and each sample making multiple specimens (`PD_SPEC`), and it should all link together.




