### PR TITLE
Deprecate calibration categories

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1953,13 +1953,6 @@ save_PD_CALIB
     _definition.id                PD_CALIB
     _definition.scope             Category
     _definition.class             Loop
-
-    loop_
-      _definition_replaced.id
-      _definition_replaced.by
-         1                        PD_CALIB_DETECTED_INTENSITY
-         2                        PD_QPA_INTERNAL_STD
-
     _definition.update            2023-06-05
     _description.text
 ;
@@ -2713,13 +2706,6 @@ save_PD_CALIB_OFFSET
     _definition.id                PD_CALIB_OFFSET
     _definition.scope             Category
     _definition.class             Loop
-
-    loop_
-      _definition_replaced.id
-      _definition_replaced.by
-         1                        PD_CALIB_XCOORD
-         2                        PD_CALIB_XCOORD_OVERALL
-
     _definition.update            2023-06-05
     _description.text
 ;
@@ -2946,15 +2932,6 @@ save_PD_CALIB_STD
     _definition.id                PD_CALIB_STD
     _definition.scope             Category
     _definition.class             Loop
-
-    loop_
-      _definition_replaced.id
-      _definition_replaced.by
-         1                        PD_CALIB_DETECTED_INTENSITY
-         2                        PD_CALIB_INCIDENT_INTENSITY
-         3                        PD_CALIB_WAVELENGTH
-         4                        PD_CALIB_XCOORD_OVERALL
-
     _definition.update            2023-06-05
     _description.text
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3023,14 +3023,14 @@ save_pd_calib_std.external_block_id
     loop_
       _definition_replaced.id
       _definition_replaced.by
-         1                       '_pd_calib_detected_intensity.block_id'
-         2                       '_pd_calib_detected_intensity.diffractogram_id'
-         3                       '_pd_calib_incident_intensity.block_id'
-         4                       '_pd_calib_incident_intensity.diffractogram_id'
-         5                       '_pd_calib_wavelength.block_id'
-         6                       '_pd_calib_wavelength.diffractogram_id'
-         7                       '_pd_calib_xcoord_overall.block_id'
-         8                       '_pd_calib_xcoord_overall.diffractogram_id'
+         1                      '_pd_calib_detected_intensity.block_id'
+         2                      '_pd_calib_detected_intensity.diffractogram_id'
+         3                      '_pd_calib_incident_intensity.block_id'
+         4                      '_pd_calib_incident_intensity.diffractogram_id'
+         5                      '_pd_calib_wavelength.block_id'
+         6                      '_pd_calib_wavelength.diffractogram_id'
+         7                      '_pd_calib_xcoord_overall.block_id'
+         8                      '_pd_calib_xcoord_overall.diffractogram_id'
 
     _alias.definition_id          '_pd_calib_std_external_block_id'
     _definition.update            2023-06-05

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2710,7 +2710,14 @@ save_PD_CALIB_OFFSET
     _definition.id                PD_CALIB_OFFSET
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-11-12
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        PD_CALIB_XCOORD
+         2                        PD_CALIB_XCOORD_OVERALL
+
+    _definition.update            2023-06-05
     _description.text
 ;
     Data items in this category define an offset angle (in degrees)
@@ -2740,10 +2747,18 @@ save_
 save_pd_calib.2theta_off_max
 
     _definition.id                '_pd_calib.2theta_off_max'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+
     _alias.definition_id          '_pd_calib_2theta_off_max'
-    _definition.update            2014-06-20
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see PD_CALIB_XCOORD. In general,
+    calibrations are now carried out over the given range, removing the need
+    to explicitly provide minima and maxima.
+
     The maximum nominal 2\q value to which the offset given by
     _pd_calib.2theta_offset applies.
 ;
@@ -2761,10 +2776,18 @@ save_
 save_pd_calib.2theta_off_min
 
     _definition.id                '_pd_calib.2theta_off_min'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+
     _alias.definition_id          '_pd_calib_2theta_off_min'
-    _definition.update            2014-06-20
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see PD_CALIB_XCOORD. In general,
+    calibrations are now carried out over the given range, removing the need
+    to explicitly provide minima and maxima.
+
     The minimum nominal 2\q value to which the offset given by
     _pd_calib.2theta_offset applies.
 ;
@@ -2782,10 +2805,16 @@ save_
 save_pd_calib.2theta_off_point
 
     _definition.id                '_pd_calib.2theta_off_point'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_nominal'
+
     _alias.definition_id          '_pd_calib_2theta_off_point'
-    _definition.update            2014-06-20
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see _pd_calib_xcoord.2theta_nominal.
+
     The nominal 2\q value to which the offset given in
     _pd_calib.2theta_offset applies.
 ;
@@ -2803,10 +2832,16 @@ save_
 save_pd_calib.2theta_offset
 
     _definition.id                '_pd_calib.2theta_offset'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_offset'
+
     _alias.definition_id          '_pd_calib_2theta_offset'
-    _definition.update            2022-10-11
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see _pd_calib_xcoord.2theta_offset.
+
     _pd_calib.2theta_offset defines an offset angle (in degrees)
     used to calibrate 2\q (as defined in _pd_meas.2theta_*).
     Calibration is done by adding the offset:
@@ -2827,9 +2862,15 @@ save_
 save_pd_calib.2theta_offset_su
 
     _definition.id                '_pd_calib.2theta_offset_su'
-    _definition.update            2022-10-27
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_offset_su'
+
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see _pd_calib_xcoord.2theta_offset_su.
+
     Standard uncertainty of _pd_calib.2theta_offset.
 ;
     _name.category_id             pd_calib_offset
@@ -2844,9 +2885,15 @@ save_
 save_pd_calib_offset.detector_id
 
     _definition.id                '_pd_calib_offset.detector_id'
-    _definition.update            2016-11-12
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord_overall.detector_id'
+
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see _pd_calib_xcoord_overall.detector_id.
+
     The detector to which the offset values relate.
     As a default value is defined, the detector id may be
     omitted if only a single detector is present.
@@ -2865,9 +2912,15 @@ save_
 save_pd_calib_offset.id
 
     _definition.id                '_pd_calib_offset.id'
-    _definition.update            2023-01-06
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.id'
+
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see _pd_calib_xcoord.id.
+
     An arbitrary code which identifies a particular 2\q offset
     description. As a default value is defined, this may be
     omitted if only a single offset is provided.
@@ -12383,5 +12436,5 @@ save_
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
        PD_BACKGROUND, and REFLN
 
-       Deprecate PD_CALIB.
+       Deprecated PD_CALIB, PD_CALIB_OFFSET.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1953,7 +1953,14 @@ save_PD_CALIB
     _definition.id                PD_CALIB
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-10-17
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        PD_CALIB_DETECTED_INTENSITY
+         2                        PD_QPA_INTERNAL_STD
+
+    _definition.update            2023-06-05
     _description.text
 ;
     This section defines the parameters used for the calibration
@@ -1995,10 +2002,16 @@ save_
 save_pd_calib.detector_response
 
     _definition.id                '_pd_calib.detector_response'
+    _definition_replaced.id       1
+    _definition_replaced.by
+        '_pd_calib_detected_intensity.detector_response'
     _alias.definition_id          '_pd_calib_detector_response'
-    _definition.update            2022-10-11
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see
+    _pd_calib_detected_intensity.detector_response.
+
     A value that indicates the relative sensitivity of each
     detector. This can compensate for differences in electronics,
     size and collimation. Usually, one detector or the mean for
@@ -2018,9 +2031,15 @@ save_
 save_pd_calib.detector_response_su
 
     _definition.id                '_pd_calib.detector_response_su'
-    _definition.update            2022-10-27
+    _definition_replaced.id       1
+    _definition_replaced.by
+        '_pd_calib_detected_intensity.detector_response_su'
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see
+    _pd_calib_detected_intensity.detector_response_su.
+
     Standard uncertainty of _pd_calib.detector_response.
 ;
     _name.category_id             pd_calib
@@ -2082,10 +2101,15 @@ save_
 save_pd_calib.std_internal_name
 
     _definition.id                '_pd_calib.std_internal_name'
+    _definition_replaced.id       1
+    _definition_replaced.by       .
     _alias.definition_id          '_pd_calib_std_internal_name'
-    _definition.update            2022-12-01
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see PD_QPA_INTERNAL_STD for alternate
+    methods of identifying an internal standard.
+
     Identity of material(s) used as an internal intensity standard.
 ;
     _name.category_id             pd_calib

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2940,7 +2940,16 @@ save_PD_CALIB_STD
     _definition.id                PD_CALIB_STD
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-10-18
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        PD_CALIB_DETECTED_INTENSITY
+         2                        PD_CALIB_INCIDENT_INTENSITY
+         3                        PD_CALIB_WAVELENGTH
+         4                        PD_CALIB_XCOORD_OVERALL
+
+    _definition.update            2023-06-05
     _description.text
 ;
     This category identifies the external standards used for the calibration
@@ -2953,7 +2962,7 @@ save_PD_CALIB_STD
     used (for example, separately for angular and gain calibration).
 
     For quantitative phase analysis by the external standard approach,
-    please see PD_QPA_EXT_STD.
+    please see PD_QPA_EXTERNAL_STD.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_STD
@@ -2968,9 +2977,19 @@ save_
 save_pd_calib_std.detector_id
 
     _definition.id                '_pd_calib_std.detector_id'
-    _definition.update            2016-10-18
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_pd_calib_detected_intensity.detector_id'
+         2                        '_pd_calib_xcoord_overall.detector_id'
+
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see _pd_calib_detected_intensity.detector_id
+    or _pd_calib_xcoord_overall.detector_id, as necessary.
+
     A code which identifies the detector or channel number that the
     calibration data applies to. Note that this code should match a
     detector from _pd_meas.detector_id and may be omitted if only
@@ -2990,10 +3009,34 @@ save_
 save_pd_calib_std.external_block_id
 
     _definition.id                '_pd_calib_std.external_block_id'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                       '_pd_calib_detected_intensity.block_id'
+         2                       '_pd_calib_detected_intensity.diffractogram_id'
+         3                       '_pd_calib_incident_intensity.block_id'
+         4                       '_pd_calib_incident_intensity.diffractogram_id'
+         5                       '_pd_calib_wavelength.block_id'
+         6                       '_pd_calib_wavelength.diffractogram_id'
+         7                       '_pd_calib_xcoord_overall.block_id'
+         8                       '_pd_calib_xcoord_overall.diffractogram_id'
+
     _alias.definition_id          '_pd_calib_std_external_block_id'
-    _definition.update            2023-01-09
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see:
+      - _pd_calib_detected_intensity.block_id
+      - _pd_calib_detected_intensity.diffractogram_id
+      - _pd_calib_incident_intensity.block_id
+      - _pd_calib_incident_intensity.diffractogram_id
+      - _pd_calib_wavelength.block_id
+      - _pd_calib_wavelength.diffractogram_id
+      - _pd_calib_xcoord_overall.block_id
+      - _pd_calib_xcoord_overall.diffractogram_id
+    as necessary.
+
     Identifies the _pd_block.id used as an external standard for the
     diffraction angle or the intensity calibrations.
 
@@ -3013,10 +3056,20 @@ save_
 save_pd_calib_std.external_name
 
     _definition.id                '_pd_calib_std.external_name'
+    _definition_replaced.id       1
+    _definition_replaced.by       .
     _alias.definition_id          '_pd_calib_std_external_name'
-    _definition.update            2023-01-07
+    _definition.update            2023-06-05
     _description.text
 ;
+    This item is deprecated. Please see:
+      - PD_CALIB_DETECTED_INTENSITY
+      - PD_CALIB_INCIDENT_INTENSITY
+      - PD_CALIB_WAVELENGTH
+      - PD_CALIB_XCOORD
+      - PD_CALIB_XCOORD_OVERALL
+    as necessary, for information on how to identify the external standard used.
+
     Identifies the name of the material used as an external standard for
     the diffraction angle or the intensity calibrations.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-04
+    _dictionary.date              2023-06-05
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -12273,7 +12273,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-04
+         2.5.0                    2023-06-05
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12382,4 +12382,6 @@ save_
 
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
        PD_BACKGROUND, and REFLN
+
+       Deprecate PD_CALIB.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1963,6 +1963,9 @@ save_PD_CALIB
     _definition.update            2023-06-05
     _description.text
 ;
+    This category is deprecated. Please see PD_CALIB_DETECTED_INTENSITY and
+    PD_QPA_INTERNAL_STD.
+
     This section defines the parameters used for the calibration
     of the instrument that are used directly or indirectly in the
     interpretation of this data set. The information in this
@@ -2720,6 +2723,9 @@ save_PD_CALIB_OFFSET
     _definition.update            2023-06-05
     _description.text
 ;
+    This category is deprecated. Please see PD_CALIB_XCOORD and
+    PD_CALIB_XCOORD_OVERALL.
+
     Data items in this category define an offset angle (in degrees)
     used to calibrate 2\q (as defined in _pd_meas.2theta_*).
     Calibration is done by adding the offset:
@@ -2952,6 +2958,10 @@ save_PD_CALIB_STD
     _definition.update            2023-06-05
     _description.text
 ;
+    This category is deprecated. Please see PD_CALIB_DETECTED_INTENSITY,
+    PD_CALIB_INCIDENT_INTENSITY, PD_CALIB_WAVELENGTH, and
+    PD_CALIB_XCOORD_OVERALL.
+
     This category identifies the external standards used for the calibration
     of the instrument that are used directly or indirectly in the
     interpretation of this data set. The information in this
@@ -12489,5 +12499,5 @@ save_
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
        PD_BACKGROUND, and REFLN
 
-       Deprecated PD_CALIB, PD_CALIB_OFFSET.
+       Deprecated PD_CALIB, PD_CALIB_OFFSET, and PD_CALIB_STD.
 ;


### PR DESCRIPTION
Originally talked about in #53 and implemented in #89, #91, #92, and #93

The new categories 

- `PD_CALIB_DETECTED_INTENSITY`
- `PD_CALIB_INCIDENT_INTENSITY`
- `PD_CALIB_WAVELENGTH`
- `PD_CALIB_XCOORD`
- `PD_QPA_INTERNAL_STD` 

take up the functionality previously facilitated by

- `PD_CALIB `
- `PD_CALIB_OFFSET`
- `PD_CALIB_STD`

This PR is to deprecate redundant data items and categories.

.

I'm not deprecating `PD_CALIBRATION` yet, as I need to convince myself how I can calibrate a (for instance) energy-sensitive detector based on detector_id to energy (or position, or 2th or whatever...)