### PR TITLE
update `PD_CALIBRATION`

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-23
+    _dictionary.date              2025-06-28
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -3940,7 +3940,7 @@ save_PD_CALIBRATION
     _definition.id                PD_CALIBRATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-06-06
+    _definition.update            2025-06-28
     _description.text
 ;
     This category details the equations used to convert a channel number
@@ -3950,10 +3950,12 @@ save_PD_CALIBRATION
 
     This information is not designed to be machine-readable, but should be
     written in an explicit manner to enable reimplementation.
+
+    For a machine-readable implementation, please see PD_CALIB_XCOORD.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIBRATION
-    _category_key.name            '_pd_calibration.diffractogram_id'
+    _category_key.name            '_pd_calibration.id'
     _description_example.case
 ;
          _pd_diffractogram.id   EDD_DP
@@ -4019,11 +4021,11 @@ save_
 save_pd_calibration.diffractogram_id
 
     _definition.id                '_pd_calibration.diffractogram_id'
-    _definition.update            2023-06-06
+    _definition.update            2025-06-28
     _description.text
 ;
-    A code which identifies the diffractogram to which this calibration equation
-    has been applied.
+    A code which identifies the diffractogram from which this
+    calibration equation was derived.
 ;
     _name.category_id             pd_calibration
     _name.object_id               diffractogram_id
@@ -4035,22 +4037,20 @@ save_pd_calibration.diffractogram_id
 
 save_
 
-save_pd_calibration.ref_diffractogram_id
+save_pd_calibration.id
 
-    _definition.id                '_pd_calibration.ref_diffractogram_id'
-    _definition.update            2023-06-06
+    _definition.id                '_pd_calibration.id'
+    _definition.update            2025-06-28
     _description.text
 ;
-    A code which identifies the reference diffractogram from which this
-    calibration equation was derived.
+    Arbitrary label identifying a calibration.
 ;
     _name.category_id             pd_calibration
-    _name.object_id               ref_diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
+    _name.object_id               id
+    _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -13202,7 +13202,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-23
+         2.5.0                    2025-06-28
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -13312,9 +13312,6 @@ save_
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
        PD_BACKGROUND, and REFLN.
 
-       Update PD_CALIBRATION with _pd_calibration.ref_diffractogram_id and new
-       category key _pd_calibration.diffractogram_id.
-
        Created category keys for PD_CHAR and PD_PREP. Added link keys to join
        PD_CHAR to PD_PREP, and PD_PREP to PD_SPEC.
 
@@ -13391,4 +13388,7 @@ save_
        information about the wavelength.
 
        Added _pd_meas_overall.step_count_time
+
+       Update PD_CALIBRATION with _pd_calibration.diffractogram_id and new
+       key, _pd_calibration.id.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-28
+    _dictionary.date              2025-07-08
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -3940,11 +3940,11 @@ save_PD_CALIBRATION
     _definition.id                PD_CALIBRATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-06-28
+    _definition.update            2025-07-08
     _description.text
 ;
     This category details the equations used to convert a channel number
-    supplied in _pd_meas.detector_id for a position-sensitive or
+    supplied in _pd_meas.channel for a position-sensitive or
     energy-dispersive detector or the distance supplied in _pd_meas.position
     to Q, energy, angle etc.
 
@@ -3958,7 +3958,7 @@ save_PD_CALIBRATION
     _category_key.name            '_pd_calibration.id'
     _description_example.case
 ;
-         _pd_diffractogram.id   EDD_DP
+         _pd_diffractogram.id   EDD_STANDARD
 
          _pd_calibration.conversion_eqn
        ;
@@ -3976,11 +3976,11 @@ save_PD_CALIBRATION
             linear response. This value was fixed for all data
             collection, including the standards.
        ;
-         _pd_calibration.ref_diffractogram_id   EDD_STANDARD
+         _pd_calibration.diffractogram_id   EDD_STANDARD
 
          loop_
          _pd_data.id
-         _pd_meas.detector_id
+         _pd_meas.channel
          _pd_proc.energy_detection
          _pd_proc.energy_detection_su
          _pd_meas.counts_total
@@ -3988,6 +3988,15 @@ save_PD_CALIBRATION
          b   2    20139.1   4.2    1434
          c   3    20226.7   4.3    1457
          #...
+;
+    _description_example.detail
+;
+    The calibration equation is a human-readable method of determining the
+    conversion of, in this case, channel to energy. The channel number is
+    calibrated from the diffractogram EDD_STANDARD to give the energy of the
+    detected X-rays in electron volts. The quadratic formula given allows
+    the calibration to be applied to other diffractograms collected
+    on the same instrument.
 ;
 
 save_
@@ -13395,7 +13404,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-28
+         2.5.0                    2025-07-08
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -13754,7 +13754,7 @@ save_
        the source of a refined wavelength value.
        _diffrn_radiation_wavelength.special_details added to record
        information about the wavelength.
-       
+
        Added _pd_meas_overall.step_count_time
 
        Update PD_CALIBRATION with _pd_calibration.diffractogram_id and new

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-04
+    _dictionary.date              2023-06-06
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -3669,14 +3669,20 @@ save_PD_CALIBRATION
     _definition.id                PD_CALIBRATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2016-10-17
+    _definition.update            2023-06-06
     _description.text
 ;
-    This section contains calibration information that is
-    not looped
+    This section details the equations used to convert a channel number
+    supplied in _pd_meas.detector_id for a position-sensitive or
+    energy-dispersive detector or the distance supplied in _pd_meas.position
+    to Q, energy, angle etc.
+
+    This information is not designed to be machine-readable, but should be
+    written in an explicit manner to enable reimplementation.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIBRATION
+    _category_key.name            '_pd_calibration.diffractogram_id'
 
 save_
 
@@ -3684,17 +3690,13 @@ save_pd_calibration.conversion_eqn
 
     _definition.id                '_pd_calibration.conversion_eqn'
     _alias.definition_id          '_pd_calibration_conversion_eqn'
-    _definition.update            2023-01-21
+    _definition.update            2023-06-06
     _description.text
 ;
-    The calibration function for converting a channel number
+    The calibration equation for converting a channel number
     supplied in _pd_meas.detector_id for a position-sensitive
     or energy-dispersive detector or the distance supplied in
     _pd_meas.position to Q, energy, angle etc.
-
-    Use _pd_calib_std.external_block_id to define a pointer to
-    the data block containing the data used to determine the
-    parameter values in this function.
 ;
     _name.category_id             pd_calibration
     _name.object_id               conversion_eqn
@@ -3710,20 +3712,56 @@ save_pd_calibration.conversion_eqn
 
 save_
 
+save_pd_calibration.diffractogram_id
+
+    _definition.id                '_pd_calibration.diffractogram_id'
+    _definition.update            2023-06-06
+    _description.text
+;
+    A code which identifies the diffractogram to which this calibration equation
+    has been applied.
+;
+    _name.category_id             pd_calibration
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calibration.ref_diffractogram_id
+
+    _definition.id                '_pd_calibration.ref_diffractogram_id'
+    _definition.update            2023-06-06
+    _description.text
+;
+    A code which identifies the reference diffractogram from which this
+    calibration equation was derived.
+;
+    _name.category_id             pd_calibration
+    _name.object_id               ref_diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_pd_calibration.special_details
 
     _definition.id                '_pd_calibration.special_details'
     _alias.definition_id          '_pd_calibration_special_details'
-    _definition.update            2016-10-17
+    _definition.update            2023-06-06
     _description.text
 ;
-    Description of how the instrument was
-    calibrated, particularly for instruments where
-    calibration information is used to make hardware
-    settings that would otherwise be invisible once data
-    collection is completed. Do not use this item to specify
-    information that can be specified using other
-    PD_CALIBRATION or PD_CALIB items.
+    Description of how the instrument was calibrated, particularly for
+    instruments where calibration information is used to make hardware
+    settings that would otherwise be invisible once data collection is
+    completed. Do not use this item to specify information that can be
+    specified using other PD_CALIBRATION items.
 ;
     _name.category_id             pd_calibration
     _name.object_id               special_details
@@ -12249,7 +12287,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-04
+         2.5.0                    2023-06-06
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12357,5 +12395,8 @@ save_
        Added _pd_peak_overall.id.
 
        Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
-       PD_BACKGROUND, and REFLN
+       PD_BACKGROUND, and REFLN.
+
+       Update PD_CALIBRATION with _pd_calibration.ref_diffractogram_id and new
+       category key _pd_calibration.diffractogram_id.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3672,7 +3672,7 @@ save_PD_CALIBRATION
     _definition.update            2023-06-06
     _description.text
 ;
-    This section details the equations used to convert a channel number
+    This category details the equations used to convert a channel number
     supplied in _pd_meas.detector_id for a position-sensitive or
     energy-dispersive detector or the distance supplied in _pd_meas.position
     to Q, energy, angle etc.
@@ -3683,6 +3683,39 @@ save_PD_CALIBRATION
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIBRATION
     _category_key.name            '_pd_calibration.diffractogram_id'
+    _description_example.case
+;
+         _pd_diffractogram.id   EDD_DP
+
+         _pd_calibration.conversion_eqn
+       ;
+            E = A~0~ + A~1~ * channel + A~2~ * channel^2^
+
+            Values refined from the reference pattern and then kept fixed.
+            A~0~ = 19964(2)      eV
+            A~1~ =    87.51(4)   eV / channel
+            A~2~ =     0.0156(6) eV / channel^2^
+       ;
+         _pd_calibration.special_details
+       ;
+            Gain settings slight affected the detector linearity.
+            The gain was fixed at 4.2 as this produced the most
+            linear response. This value was fixed for all data
+            collection, including the standards.
+       ;
+         _pd_calibration.ref_diffractogram_id   EDD_STANDARD
+
+         loop_
+         _pd_data.id
+         _pd_meas.detector_id
+         _pd_proc.energy_detection
+         _pd_proc.energy_detection_su
+         _pd_meas.counts_total
+         a   1    20051.5   4.1    1234
+         b   2    20139.1   4.2    1434
+         c   3    20226.7   4.3    1457
+         #...
+;
 
 save_
 


### PR DESCRIPTION
EDIT: Lots of things have changed. Jump to the bottom for the current version.


.

Will close #133. Also applicable to #132.

This PR enhances `PD_CALIBRATION` by providing a category key based on the diffractogram_id to which the calibration applies, and a dataitem to record the diffractogram_id of the reference diffraction pattern from which the calibration was made.