### PR TITLE
remove `_pd_block_diffractogram.diffractogram_id` and `_pd_phase_block.phase_id`

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1595,26 +1595,6 @@ save_PD_BLOCK_DIFFRACTOGRAM
 
 save_
 
-save_pd_block_diffractogram.diffractogram_id
-
-    _definition.id                '_pd_block_diffractogram.diffractogram_id'
-    _definition.update            2022-12-03
-    _description.text
-;
-    A diffractogram id code (see _pd_diffractogram.id) that
-    identifies the diffraction data contained in the data block
-    pointed to by _pd_block_diffractogram.id.
-;
-    _name.category_id             pd_block_diffractogram
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_block_diffractogram.id
 
     _definition.id                '_pd_block_diffractogram.id'
@@ -8705,27 +8685,6 @@ save_pd_phase_block.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-
-save_
-
-save_pd_phase_block.phase_id
-
-    _definition.id                '_pd_phase_block.phase_id'
-    _alias.definition_id          '_pd_phase_id'
-    _definition.update            2022-12-03
-    _description.text
-;
-    A phase id code (see _pd_phase.id) that identifies the phase
-    contained in the data block pointed to by _pd_phase_block.id
-;
-    _name.category_id             pd_phase_block
-    _name.object_id               phase_id
-    _name.linked_item_id          '_pd_phase.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _enumeration.default          .
 
 save_
 


### PR DESCRIPTION
When we made `PD_PHASE` a `Set` caetgory, and `PD_BLOCK` a `Loop` category, we moved things around and we also added `_pd_phase.id` and `_pd_diffractogram.id` as the principle methods of identifying phases and patterns.

As in the old way, we could loop block IDs, we wanted to keep that same possibility, so we added `_pd_block_diffractogram.diffractogram_id` and `_pd_phase_block.phase_id` to keep that ability, however that requirement has been subsumed by individual `phase` and `diffractogram_id` tags in different categories.

Also, it conflates the block id methodology with the `phase` and `diffractogram.id` methodology of identifying things.

Straight up deletion, as they're new and not in any other previously released dictionary.

See also https://github.com/COMCIFS/Powder_Dictionary/pull/117#issuecomment-1493713618
