### PR TITLE
Make `_pd_instr_detector.id` the primary source of detector id values

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1974,7 +1974,6 @@ save_pd_calib.detector_id
     _type.container               Single
     _type.contents                Code
 
-
 save_
 
 save_pd_calib.detector_response
@@ -2386,7 +2385,6 @@ save_pd_calib_detected_intensity.detector_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1957,21 +1957,23 @@ save_pd_calib.detector_id
 
     _definition.id                '_pd_calib.detector_id'
     _alias.definition_id          '_pd_calib_detector_id'
-    _definition.update            2014-06-20
+    _definition.update            2023-06-09
     _description.text
 ;
     A code which identifies the detector or channel number in a
     position-sensitive, energy-dispersive or other multiple-detector
-    instrument. Note that this code should match the code name used
-    for _pd_meas.detector_id.
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
 ;
     _name.category_id             pd_calib
     _name.object_id               detector_id
-    _name.linked_item_id          '_pd_meas.detector_id'
+    _name.linked_item_id          '_pd_instr_detector.id'
     _type.purpose                 Link
-    _type.source                  Assigned
+    _type.source                  Related
     _type.container               Single
     _type.contents                Code
+
 
 save_
 
@@ -2368,21 +2370,23 @@ save_
 save_pd_calib_detected_intensity.detector_id
 
     _definition.id                '_pd_calib_detected_intensity.detector_id'
-    _definition.update            2023-01-21
+    _definition.update            2023-06-09
     _description.text
 ;
     A code which identifies the detector or channel number in a
-    position-sensitive, energy-dispersive or other multiple-detector instrument.
-    Note that this code should match the code name used for
-    _pd_meas.detector_id.
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
 ;
     _name.category_id             pd_calib_detected_intensity
     _name.object_id               detector_id
-    _name.linked_item_id          '_pd_meas.detector_id'
+    _name.linked_item_id          '_pd_instr_detector.id'
     _type.purpose                 Link
-    _type.source                  Assigned
+    _type.source                  Related
     _type.container               Single
     _type.contents                Code
+
 
 save_
 
@@ -2973,24 +2977,26 @@ save_pd_calib_std.detector_id
          1                        '_pd_calib_detected_intensity.detector_id'
          2                        '_pd_calib_xcoord_overall.detector_id'
 
-    _definition.update            2023-06-05
+    _definition.update            2023-06-09
     _description.text
 ;
     This item is deprecated. Please see _pd_calib_detected_intensity.detector_id
     or _pd_calib_xcoord_overall.detector_id, as necessary.
 
-    A code which identifies the detector or channel number that the
-    calibration data applies to. Note that this code should match a
-    detector from _pd_meas.detector_id and may be omitted if only
-    one detector is used.
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
 ;
     _name.category_id             pd_calib_std
     _name.object_id               detector_id
-    _name.linked_item_id          '_pd_meas.detector_id'
+    _name.linked_item_id          '_pd_instr_detector.id'
     _type.purpose                 Link
-    _type.source                  Assigned
+    _type.source                  Related
     _type.container               Single
     _type.contents                Code
+
     _enumeration.default          .
 
 save_
@@ -3686,25 +3692,22 @@ save_
 save_pd_calib_xcoord_overall.detector_id
 
     _definition.id                '_pd_calib_xcoord_overall.detector_id'
-    _definition.update            2023-05-06
+    _definition.update            2023-06-09
     _description.text
 ;
-    A code which identifies the detector or channel number, in a
-    position-sensitive, energy-dispersive or other multiple-detector instrument,
-    to which the calibration applies.
-
-    Note that this code should match the code name used for
-    _pd_meas.detector_id. As a default value is defined, the detector id may be
-    omitted if only a single detector is present.
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
 ;
     _name.category_id             pd_calib_xcoord_overall
     _name.object_id               detector_id
-    _name.linked_item_id          '_pd_meas.detector_id'
+    _name.linked_item_id          '_pd_instr_detector.id'
     _type.purpose                 Link
-    _type.source                  Assigned
+    _type.source                  Related
     _type.container               Single
     _type.contents                Code
-    _enumeration.default          .
 
 save_
 
@@ -4878,24 +4881,27 @@ save_pd_meas.detector_id
 
     _definition.id                '_pd_meas.detector_id'
     _alias.definition_id          '_pd_meas_detector_id'
-    _definition.update            2014-06-20
+    _definition.update            2023-06-09
     _description.text
 ;
-    A code or number which identifies the measuring detector or
-    channel number in a position-sensitive, energy-dispersive
-    or other multiple-detector instrument.
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
 
-    Calibration information, such as angle offsets or
-    a calibration function to convert channel numbers
-    to Q, energy, wavelength, angle etc. should
-    be described with PD_CALIB values. If
-    _pd_calibration.conversion_eqn is used, the detector ID's
-    should be the number to be used in the equation.
+    Calibration information, such as angle offsets or a calibration
+    function to convert channel numbers to Q, energy, wavelength,
+    angle etc. should be described using PD_CALIB_XCOORD and/or
+    PD_CALIBRATION data items. If _pd_calibration.conversion_eqn is
+    used, the detector IDs should be the number to be used in the
+    equation.
 ;
     _name.category_id             pd_meas
     _name.object_id               detector_id
-    _type.purpose                 Encode
-    _type.source                  Assigned
+    _name.linked_item_id          '_pd_instr_detector.id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Code
 
@@ -12498,5 +12504,6 @@ save_
        Deprecated PD_MEAS_INFO_AUTHOR and PD_PROC_INFO_AUTHOR in favour of
        AUDIT_AUTHOR and AUDIT_AUTHOR_ROLE.
 
-       Redefined _pd_meas.detector_id in terms of _pd_instr_detector.id.
+       Redefined _pd_meas.detector_id in terms of _pd_instr_detector.id. Linked
+       all _pd_*.detector_id data names to _pd_instr_detector.id.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1595,26 +1595,6 @@ save_PD_BLOCK_DIFFRACTOGRAM
 
 save_
 
-save_pd_block_diffractogram.diffractogram_id
-
-    _definition.id                '_pd_block_diffractogram.diffractogram_id'
-    _definition.update            2022-12-03
-    _description.text
-;
-    A diffractogram id code (see _pd_diffractogram.id) that
-    identifies the diffraction data contained in the data block
-    pointed to by _pd_block_diffractogram.id.
-;
-    _name.category_id             pd_block_diffractogram
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_block_diffractogram.id
 
     _definition.id                '_pd_block_diffractogram.id'
@@ -8705,27 +8685,6 @@ save_pd_phase_block.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-
-save_
-
-save_pd_phase_block.phase_id
-
-    _definition.id                '_pd_phase_block.phase_id'
-    _alias.definition_id          '_pd_phase_id'
-    _definition.update            2022-12-03
-    _description.text
-;
-    A phase id code (see _pd_phase.id) that identifies the phase
-    contained in the data block pointed to by _pd_phase_block.id
-;
-    _name.category_id             pd_phase_block
-    _name.object_id               phase_id
-    _name.linked_item_id          '_pd_phase.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _enumeration.default          .
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-05
+    _dictionary.date              2023-06-09
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -7527,20 +7527,17 @@ save_
 save_pd_instr_detector.id
 
     _definition.id                '_pd_instr_detector.id'
-    _definition.update            2023-01-06
+    _definition.update            2023-06-09
     _description.text
 ;
     A code which identifies the detector or channel number in a
     position-sensitive, energy-dispersive or other multiple-detector
-    instrument for which individual instrument geometry is being
-    defined. Note that this code should match the code name used for
-    _pd_meas.detector_id. Where a single detector is used, this
-    may be omitted.
+    instrument for which the individual instrument geometry is being
+    defined. Where a single detector is used, this may be omitted.
 ;
     _name.category_id             pd_instr_detector
     _name.object_id               id
-    _name.linked_item_id          '_pd_meas.detector_id'
-    _type.purpose                 Link
+    _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
@@ -12386,7 +12383,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-05
+         2.5.0                    2023-06-09
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12500,4 +12497,6 @@ save_
 
        Deprecated PD_MEAS_INFO_AUTHOR and PD_PROC_INFO_AUTHOR in favour of
        AUDIT_AUTHOR and AUDIT_AUTHOR_ROLE.
+
+       Redefined _pd_meas.detector_id in terms of _pd_instr_detector.id.
 ;


### PR DESCRIPTION
Will close #138. See also #56