### PR TITLE
Convert all `Array` and `Matrix`-type data items to be `List`

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-10
+    _dictionary.date              2023-06-13
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -409,7 +409,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_1
 
     _definition.id
         '_pd_background.air_or_thermal_diffuse_coefs_1'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of the first coefficients used in an equation representing the
@@ -426,7 +426,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_1
     _name.object_id               air_or_thermal_diffuse_coefs_1
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -437,7 +437,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_1_su
 
     _definition.id
         '_pd_background.air_or_thermal_diffuse_coefs_1_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.air_or_thermal_diffuse_coefs_1.
@@ -448,7 +448,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_1_su
         '_pd_background.air_or_thermal_diffuse_coefs_1'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -459,7 +459,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_2
 
     _definition.id
         '_pd_background.air_or_thermal_diffuse_coefs_2'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of the second coefficients used in an equation representing the
@@ -476,7 +476,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_2
     _name.object_id               air_or_thermal_diffuse_coefs_2
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -487,7 +487,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_2_su
 
     _definition.id
         '_pd_background.air_or_thermal_diffuse_coefs_2_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.air_or_thermal_diffuse_coefs_2.
@@ -498,7 +498,7 @@ save_pd_background.air_or_thermal_diffuse_coefs_2_su
         '_pd_background.air_or_thermal_diffuse_coefs_2'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -595,7 +595,7 @@ save_
 save_pd_background.chebyshev_coefs
 
     _definition.id                '_pd_background.Chebyshev_coefs'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of coefficients used in a Chebyshev equation representing the
@@ -611,7 +611,7 @@ save_pd_background.chebyshev_coefs
     _name.object_id               Chebyshev_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -621,7 +621,7 @@ save_
 save_pd_background.chebyshev_coefs_su
 
     _definition.id                '_pd_background.Chebyshev_coefs_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.Chebyshev_coefs.
@@ -631,7 +631,7 @@ save_pd_background.chebyshev_coefs_su
     _name.linked_item_id          '_pd_background.Chebyshev_coefs'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -722,7 +722,7 @@ save_
 save_pd_background.cosine_fourier_series_coefs
 
     _definition.id                '_pd_background.cosine_Fourier_series_coefs'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     The value of a coefficient used in a cosine Fourier series equation
@@ -738,7 +738,7 @@ save_pd_background.cosine_fourier_series_coefs
     _name.object_id               cosine_Fourier_series_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -749,7 +749,7 @@ save_pd_background.cosine_fourier_series_coefs_su
 
     _definition.id
         '_pd_background.cosine_Fourier_series_coefs_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.cosine_Fourier_series_coefs.
@@ -759,7 +759,7 @@ save_pd_background.cosine_fourier_series_coefs_su
     _name.linked_item_id          '_pd_background.cosine_Fourier_series_coefs'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -987,7 +987,7 @@ save_
 save_pd_background.line_segment_intensities
 
     _definition.id                '_pd_background.line_segment_intensities'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of intensities used to create many straight-line segments representing
@@ -1002,7 +1002,7 @@ save_pd_background.line_segment_intensities
     _name.object_id               line_segment_intensities
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -1012,7 +1012,7 @@ save_
 save_pd_background.line_segment_intensities_su
 
     _definition.id                '_pd_background.line_segment_intensities_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.line_segment_intensities.
@@ -1022,7 +1022,7 @@ save_pd_background.line_segment_intensities_su
     _name.linked_item_id          '_pd_background.line_segment_intensities'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -1122,7 +1122,7 @@ save_
 save_pd_background.line_segment_xs
 
     _definition.id                '_pd_background.line_segment_Xs'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of X-coordinates used to create many straight-line segments
@@ -1137,7 +1137,7 @@ save_pd_background.line_segment_xs
     _name.object_id               line_segment_Xs
     _type.purpose                 Number
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -1234,7 +1234,7 @@ save_
 save_pd_background.polynomial_coefs
 
     _definition.id                '_pd_background.polynomial_coefs'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of coefficients used in a polynomial equation representing the
@@ -1250,7 +1250,7 @@ save_pd_background.polynomial_coefs
     _name.object_id               polynomial_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   arbitrary
@@ -1260,7 +1260,7 @@ save_
 save_pd_background.polynomial_coefs_su
 
     _definition.id                '_pd_background.polynomial_coefs_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.polynomial_coefs.
@@ -1270,7 +1270,7 @@ save_pd_background.polynomial_coefs_su
     _name.linked_item_id          '_pd_background.polynomial_coefs'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   arbitrary
@@ -1324,7 +1324,7 @@ save_
 save_pd_background.polynomial_powers
 
     _definition.id                '_pd_background.polynomial_powers'
-    _definition.update            2023-02-02
+    _definition.update            2023-06-13
     _description.text
 ;
     List of powers used in a polynomial equation representing the background
@@ -1340,7 +1340,7 @@ save_pd_background.polynomial_powers
     _name.object_id               polynomial_powers
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -1350,7 +1350,7 @@ save_
 save_pd_background.polynomial_powers_su
 
     _definition.id                '_pd_background.polynomial_powers_su'
-    _definition.update            2023-06-04
+    _definition.update            2023-06-13
     _description.text
 ;
     Standard uncertainty of _pd_background.polynomial_powers.
@@ -1360,7 +1360,7 @@ save_pd_background.polynomial_powers_su
     _name.linked_item_id          '_pd_background.polynomial_powers'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -1892,7 +1892,7 @@ save_pd_calc_overall.component_presentation_order
 
     _definition.id
         '_pd_calc_overall.component_presentation_order'
-    _definition.update            2022-11-17
+    _definition.update            2023-06-13
     _description.text
 ;
     List of _pd_phase.ids specifying the order in which
@@ -1903,7 +1903,7 @@ save_pd_calc_overall.component_presentation_order
     _name.object_id               component_presentation_order
     _type.purpose                 Encode
     _type.source                  Assigned
-    _type.container               Array
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Code
 
@@ -4344,7 +4344,7 @@ save_
 save_pd_calc.component_intensity_net_list
 
     _definition.id                '_pd_calc.component_intensity_net_list'
-    _definition.update            2022-12-04
+    _definition.update            2023-06-13
     _description.text
 ;
     List of intensity values for the contributions of an
@@ -4372,7 +4372,7 @@ save_pd_calc.component_intensity_net_list
     _name.object_id               component_intensity_net_list
     _type.purpose                 Number
     _type.source                  Derived
-    _type.container               Array
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _enumeration.range            0.0:
@@ -4383,7 +4383,7 @@ save_
 save_pd_calc.component_intensity_total_list
 
     _definition.id                '_pd_calc.component_intensity_total_list'
-    _definition.update            2022-10-12
+    _definition.update            2023-06-13
     _description.text
 ;
     List of intensity values for the contributions of an
@@ -4411,7 +4411,7 @@ save_pd_calc.component_intensity_total_list
     _name.object_id               component_intensity_total_list
     _type.purpose                 Number
     _type.source                  Derived
-    _type.container               Array
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _enumeration.range            0.0:
@@ -9773,7 +9773,7 @@ save_
 save_pd_pref_orient_spherical_harmonics.y_ij
 
     _definition.id                '_pd_pref_orient_spherical_harmonics.y_ij'
-    _definition.update            2023-01-06
+    _definition.update            2023-06-13
     _description.text
 ;
     The order (i) and  term (j) of the spherical harmonic
@@ -9799,7 +9799,7 @@ save_pd_pref_orient_spherical_harmonics.y_ij
     _name.object_id               y_ij
     _type.purpose                 Number
     _type.source                  Assigned
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[2]'
     _type.contents                Integer
     _units.code                   none
@@ -12438,7 +12438,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-10
+         2.5.0                    2023-06-13
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12559,4 +12559,7 @@ save_
 
        Redefined _pd_meas.detector_id in terms of _pd_instr_detector.id. Linked
        all _pd_*.detector_id data names to _pd_instr_detector.id.
+
+       Converted all 'Array' and 'Matrix'-type data items to be 'List', except
+       _pd_pref_orient_march_dollase.hkl.
 ;


### PR DESCRIPTION
will close #148

except `_pd_pref_orient_march_dollase.hkl`.