### PR TITLE
Change the linked item of several items to _pd_data.diffractogram_id.

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-17
+    _dictionary.date              2023-06-23
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -4464,7 +4464,7 @@ save_
 save_pd_calc.diffractogram_id
 
     _definition.id                '_pd_calc.diffractogram_id'
-    _definition.update            2022-10-11
+    _definition.update            2023-06-23
     _description.text
 ;
     Label identifying the calculated diffractogram that the
@@ -4473,7 +4473,7 @@ save_pd_calc.diffractogram_id
 ;
     _name.category_id             pd_calc
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
+    _name.linked_item_id          '_pd_data.diffractogram_id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -4955,7 +4955,7 @@ save_
 save_pd_meas.diffractogram_id
 
     _definition.id                '_pd_meas.diffractogram_id'
-    _definition.update            2022-10-11
+    _definition.update            2023-06-23
     _description.text
 ;
     Label identifying the diffraction measurement that the
@@ -4965,7 +4965,7 @@ save_pd_meas.diffractogram_id
 ;
     _name.category_id             pd_meas
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
+    _name.linked_item_id          '_pd_data.diffractogram_id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -5447,7 +5447,7 @@ save_
 save_pd_proc.diffractogram_id
 
     _definition.id                '_pd_proc.diffractogram_id'
-    _definition.update            2022-10-11
+    _definition.update            2023-06-23
     _description.text
 ;
     Label identifying the diffraction measurement that the
@@ -5457,7 +5457,7 @@ save_pd_proc.diffractogram_id
 ;
     _name.category_id             pd_proc
     _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
+    _name.linked_item_id          '_pd_data.diffractogram_id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -12563,7 +12563,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-17
+         2.5.0                    2023-06-23
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
This PR addresses the issue discussed in PR #159.

Semantically, nothing should really change except it will be easier for software to properly handle the parent-child relationship of looped categories.