### PR TITLE
Add mirrors to `pd instr(_detector)`

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6569,6 +6569,29 @@ save_pd_instr.monochr_pre_spec
 
 save_
 
+save_pd_instr.mirror_pre
+
+    _definition.id                '_pd_instr.mirror_pre'
+    _definition.update            2023-06-26
+    _description.text
+;
+    The focal length of a pre-specimen mirror. A value of '0.0' indicates
+    a parallel/parabolic mirror. A non-zero value indicates the focal length
+    of a focussing/elliptical mirror. If this value is equal to twice the
+    detector radius (see _pd_instr.detector_circle_radius), then the beam is
+    focussed on the detector when 2\q = 0.0\%.
+;
+    _name.category_id             pd_instr
+    _name.object_id               mirror_pre
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
 save_pd_instr.slit_ax_mono_spec
 
     _definition.id                '_pd_instr.slit_ax_mono_spec'
@@ -7266,6 +7289,27 @@ save_pd_instr.monochr_post_spec
          'none'
          'equatorial mounted graphite (0001)'
          'Si (111), antiparallel'
+
+save_
+
+save_pd_instr.mirror_post
+
+    _definition.id                '_pd_instr.mirror_post'
+    _definition.update            2023-06-26
+    _description.text
+;
+    The focal length of a post-specimen mirror. A value of '0.0' indicates
+    a parallel/parabolic mirror. A non-zero value indicates the focal length
+    of a focussing/elliptical mirror.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               mirror_post
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-23
+    _dictionary.date              2023-06-26
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -12607,7 +12607,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-23
+         2.5.0                    2023-06-26
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12741,4 +12741,7 @@ save_
        counts_per_second and per_second.
 
        Clarified description of _pd_meas.rocking_angle.
+
+       Added _pd_instr.mirror_pre and *_post to allow for mirror placement to
+       be specified.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6580,6 +6580,10 @@ save_pd_instr.mirror_pre
     of a focussing/elliptical mirror. If this value is equal to twice the
     detector radius (see _pd_instr.detector_circle_radius), then the beam is
     focussed on the detector when 2\q = 0.0\%.
+
+    As a mirror will normally take the place of a monochromator, the use of
+    PD_INSTR data items referring to 'mono' (such as
+    _pd_instr.soller_ax_src_mono) will be taken as referring to the mirror.
 ;
     _name.category_id             pd_instr
     _name.object_id               mirror_pre
@@ -7301,6 +7305,10 @@ save_pd_instr.mirror_post
     The focal length of a post-specimen mirror. A value of '0.0' indicates
     a parallel/parabolic mirror. A non-zero value indicates the focal length
     of a focussing/elliptical mirror.
+
+    As a mirror will normally take the place of a monochromator, use of
+    PD_INSTR_DETECTOR data items referring to 'anal' (such as
+    _pd_instr.dist_anal_detc) will be taken as referring to the mirror.
 ;
     _name.category_id             pd_instr_detector
     _name.object_id               mirror_post

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6523,6 +6523,36 @@ save_pd_instr.location
 
 save_
 
+save_pd_instr.mirror_pre
+
+    _definition.id                '_pd_instr.mirror_pre'
+    _definition.update            2023-06-26
+    _description.text
+;
+    The focal length of a pre-specimen mirror. A value of '0.0' indicates
+    a parallel/parabolic mirror. A non-zero value indicates the focal length
+    of a focussing/elliptical mirror. If this value is equal to twice the
+    detector radius (see _pd_instr.detector_circle_radius), then the beam is
+    focussed on the detector when 2\q = 0.0\%.
+
+    As a mirror will normally take the place of a monochromator, the use of
+    PD_INSTR data items referring to 'mono' (such as
+    _pd_instr.soller_ax_src_mono) will be taken as referring to the mirror.
+
+    Further details can be given in _pd_instr.monochr_pre_spec, as a mirror is
+    a way to obtain a monochromatised beam.
+;
+    _name.category_id             pd_instr
+    _name.object_id               mirror_pre
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
 save_pd_instr.monochr_pre_spec
 
     _definition.id                '_pd_instr.monochr_pre_spec'
@@ -6566,33 +6596,7 @@ save_pd_instr.monochr_pre_spec
          'none'
          'equatorial mounted graphite (0001)'
          'Si (111), antiparallel'
-
-save_
-
-save_pd_instr.mirror_pre
-
-    _definition.id                '_pd_instr.mirror_pre'
-    _definition.update            2023-06-26
-    _description.text
-;
-    The focal length of a pre-specimen mirror. A value of '0.0' indicates
-    a parallel/parabolic mirror. A non-zero value indicates the focal length
-    of a focussing/elliptical mirror. If this value is equal to twice the
-    detector radius (see _pd_instr.detector_circle_radius), then the beam is
-    focussed on the detector when 2\q = 0.0\%.
-
-    As a mirror will normally take the place of a monochromator, the use of
-    PD_INSTR data items referring to 'mono' (such as
-    _pd_instr.soller_ax_src_mono) will be taken as referring to the mirror.
-;
-    _name.category_id             pd_instr
-    _name.object_id               mirror_pre
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   millimetres
+         'W/C multilayer mirror'
 
 save_
 
@@ -7250,6 +7254,34 @@ save_pd_instr.divg_eq_spec_detc
 
 save_
 
+save_pd_instr.mirror_post
+
+    _definition.id                '_pd_instr.mirror_post'
+    _definition.update            2023-06-26
+    _description.text
+;
+    The focal length of a post-specimen mirror. A value of '0.0' indicates
+    a parallel/parabolic mirror. A non-zero value indicates the focal length
+    of a focussing/elliptical mirror.
+
+    As a mirror will normally take the place of a monochromator, use of
+    PD_INSTR_DETECTOR data items referring to 'anal' (such as
+    _pd_instr.dist_anal_detc) will be taken as referring to the mirror.
+
+    Further details can be given in _pd_instr.monochr_post_spec, as a mirror is
+    a way to obtain a monochromatised beam.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               mirror_post
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
 save_pd_instr.monochr_post_spec
 
     _definition.id                '_pd_instr.monochr_post_spec'
@@ -7293,31 +7325,7 @@ save_pd_instr.monochr_post_spec
          'none'
          'equatorial mounted graphite (0001)'
          'Si (111), antiparallel'
-
-save_
-
-save_pd_instr.mirror_post
-
-    _definition.id                '_pd_instr.mirror_post'
-    _definition.update            2023-06-26
-    _description.text
-;
-    The focal length of a post-specimen mirror. A value of '0.0' indicates
-    a parallel/parabolic mirror. A non-zero value indicates the focal length
-    of a focussing/elliptical mirror.
-
-    As a mirror will normally take the place of a monochromator, use of
-    PD_INSTR_DETECTOR data items referring to 'anal' (such as
-    _pd_instr.dist_anal_detc) will be taken as referring to the mirror.
-;
-    _name.category_id             pd_instr_detector
-    _name.object_id               mirror_post
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   millimetres
+         'W/C multilayer mirror'
 
 save_
 


### PR DESCRIPTION
From #157

Add the ability to record mirrors as incident or diffracted optics.