### PR TITLE
add diffrn_id to _pd_diffractogram and _pd_phase

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5988,24 +5988,6 @@ save_PD_DIFFRACTOGRAM
 
 save_
 
-save_pd_diffractogram.id
-
-    _definition.id                '_pd_diffractogram.id'
-    _definition.update            2022-01-06
-    _description.text
-;
-    Arbitrary label identifying a powder diffraction measurement.
-    If missing, _pd_block.id is used.
-;
-    _name.category_id             pd_diffractogram
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_diffractogram.diffrn_id
 
     _definition.id                '_pd_diffractogram.diffrn_id'
@@ -6022,6 +6004,24 @@ save_pd_diffractogram.diffrn_id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
+
+save_
+
+save_pd_diffractogram.id
+
+    _definition.id                '_pd_diffractogram.id'
+    _definition.update            2022-01-06
+    _description.text
+;
+    Arbitrary label identifying a powder diffraction measurement.
+    If missing, _pd_block.id is used.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8618,25 +8618,6 @@ save_PD_PHASE
 
 save_
 
-save_pd_phase.diffrn_id
-
-    _definition.id                '_pd_phase.diffrn_id'
-    _definition.update            2023-10-16
-    _description.text
-;
-    A code which identifies the diffraction conditions to which this phase
-    pertains.
-;
-    _name.category_id             pd_phase
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_pd_phase.id
 
     _definition.id                '_pd_phase.id'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-07-11
+    _dictionary.date              2023-10-16
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -6006,6 +6006,25 @@ save_pd_diffractogram.id
 
 save_
 
+save_pd_diffractogram.diffrn_id
+
+    _definition.id                '_pd_diffractogram.diffrn_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code which identifies the diffraction conditions under which this
+    diffractogram was collected.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_pd_diffractogram.spec_id
 
     _definition.id                '_pd_diffractogram.spec_id'
@@ -8699,6 +8718,25 @@ save_PD_PHASE
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE
     _category_key.name            '_pd_phase.id'
+
+save_
+
+save_pd_phase.diffrn_id
+
+    _definition.id                '_pd_phase.diffrn_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code which identifies the diffraction conditions to which this phase
+    pertains.
+;
+    _name.category_id             pd_phase
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -12563,7 +12601,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-07-11
+         2.5.0                    2023-10-16
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12699,4 +12737,6 @@ save_
        Clarified description of _pd_meas.rocking_angle.
 
        Changed the _type.source attribute of all SU data items to 'Related'.
+
+       Added _pd_diffractogram.diffrn_id and _pd_phase.diffrn_id.
 ;


### PR DESCRIPTION
From https://github.com/COMCIFS/cif_core/issues/344#issuecomment-1763640090

Can now link a diffractogram and phases to the conditions under which the data were collected.