### PR TITLE
Switch to using multiblock dictionary

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2023-06-09
+    _dictionary.date              2024-12-13
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -32,7 +32,7 @@ save_PD_GROUP
     _definition.id                PD_GROUP
     _definition.scope             Category
     _definition.class             Head
-    _definition.update            2014-06-20
+    _definition.update            2024-12-13
     _description.text
 ;
     Groups all of the categories of definitions in the powder
@@ -12396,7 +12396,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2023-06-09
+         2.5.0                    2024-12-13
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12513,4 +12513,6 @@ save_
 
        Redefined _pd_meas.detector_id in terms of _pd_instr_detector.id. Linked
        all _pd_*.detector_id data names to _pd_instr_detector.id.
+
+       Switch to using multiblock dictionary as base dictionary.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -42,7 +42,11 @@ save_PD_GROUP
     _name.object_id               PD_GROUP
 
     _import.get
-        [{'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE}]
+        [
+          {'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
+           'save':MULTIBLOCK_CORE
+          }
+        ]
 
 save_
 


### PR DESCRIPTION
As powder CIF will need to spread datasets over multiple data blocks, it needs to use the definitions provided in the multiblock dictionary (which itself imports the core dictionary).