### PR TITLE
Deprecate pd block id again

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1499,10 +1499,9 @@ save_pd_block.id
     loop_
        _definition_replaced.id
        _definition_replaced.by
-      _category_key.name
-         1 '_pd_phase.id'
-         2 '_pd_diffractogram.id'
-         3 '_audit.block_code'
+         1                        '_pd_phase.id'
+         2                        '_pd_diffractogram.id'
+         3                        '_audit.block_code'
     _alias.definition_id          '_pd_block_id'
     _definition.update            2025-04-18
     _description.text
@@ -8584,16 +8583,13 @@ save_PD_PHASE
     _definition.id                PD_PHASE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-08
+    _definition.update            2025-04-18
     _description.text
 ;
-    This section contains a description of the phases contributing to the powder
+    This category allows for the description of the phases contributing to the powder
     diffraction data set. Note that if multiple-phase Rietveld or other
     structural analysis is performed, the structural results will be placed in
     different data blocks, using CIF entries from the core CIF dictionary.
-
-    The _pd_phase_block.id or _pd_phase.id entry points to the CIF block with
-    structural parameters for each crystalline phase.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PHASE
@@ -8604,10 +8600,10 @@ save_
 save_pd_phase.id
 
     _definition.id                '_pd_phase.id'
-    _definition.update            2022-12-03
+    _definition.update            2025-04-18
     _description.text
 ;
-    Arbitrary label uniquely identifying a phase.
+    Unique label identifying a phase.
 ;
     _name.category_id             pd_phase
     _name.object_id               id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1676,32 +1676,6 @@ save_PD_CALC_COMPONENT
 
 save_
 
-save_pd_calc_component.block_id
-
-    _definition.id                '_pd_calc_component.block_id'
-    _definition.update            2023-01-09
-    _description.text
-;
-    A block ID code (see _pd_block.id) that identifies
-    calculated component diffraction data contained in a
-    data block other than the current block. The data
-    block containing the crystallographic information
-    for this phase will be identified with a _pd_block.id
-    code matching the code in _pd_phase_block.id. The data
-    block containing the diffractogram to which this component
-    belongs will be identified with a _pd_block.id
-    code matching the code in _pd_block_diffractogram.id.
-;
-    _name.category_id             pd_calc_component
-    _name.object_id               block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_calc_component.diffractogram_id
 
     _definition.id                '_pd_calc_component.diffractogram_id'
@@ -2351,28 +2325,6 @@ save_PD_CALIB_DETECTED_INTENSITY
 
 save_
 
-save_pd_calib_detected_intensity.block_id
-
-    _definition.id                '_pd_calib_detected_intensity.block_id'
-    _definition.update            2023-01-21
-    _description.text
-;
-    A block ID code identifying the diffractogram from which the intensity
-    calibration was taken, if it was calibrated by a specimen.
-
-    The data block containing the diffraction pattern will be identified with a
-    _pd_block.id code matching the code given as the value of this data item.
-;
-    _name.category_id             pd_calib_detected_intensity
-    _name.object_id               block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_calib_detected_intensity.detector_id
 
     _definition.id                '_pd_calib_detected_intensity.detector_id'
@@ -2541,29 +2493,6 @@ save_PD_CALIB_INCIDENT_INTENSITY
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_INCIDENT_INTENSITY
     _category_key.name            '_pd_calib_incident_intensity.instr_id'
-
-save_
-
-save_pd_calib_incident_intensity.block_id
-
-    _definition.id                '_pd_calib_incident_intensity.block_id'
-    _definition.update            2023-01-21
-    _description.text
-;
-    A block ID code identifying the diffractogram from which the intensity
-    calibration was taken, if it was calibrated by a specimen.
-
-    The data block containing the diffraction pattern will be identified with a
-    _pd_block.id code matching the code in
-    _pd_calib_incident_intensity.block_id.
-;
-    _name.category_id             pd_calib_incident_intensity
-    _name.object_id               block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -3014,27 +2943,19 @@ save_pd_calib_std.external_block_id
     loop_
       _definition_replaced.id
       _definition_replaced.by
-         1                      '_pd_calib_detected_intensity.block_id'
-         2                      '_pd_calib_detected_intensity.diffractogram_id'
-         3                      '_pd_calib_incident_intensity.block_id'
-         4                      '_pd_calib_incident_intensity.diffractogram_id'
-         5                      '_pd_calib_wavelength.block_id'
-         6                      '_pd_calib_wavelength.diffractogram_id'
-         7                      '_pd_calib_xcoord_overall.block_id'
-         8                      '_pd_calib_xcoord_overall.diffractogram_id'
+         1                      '_pd_calib_detected_intensity.diffractogram_id'
+         2                      '_pd_calib_incident_intensity.diffractogram_id'
+         3                      '_pd_calib_wavelength.diffractogram_id'
+         4                      '_pd_calib_xcoord_overall.diffractogram_id'
 
     _alias.definition_id          '_pd_calib_std_external_block_id'
     _definition.update            2023-06-05
     _description.text
 ;
     This item is deprecated. Please see:
-      - _pd_calib_detected_intensity.block_id
       - _pd_calib_detected_intensity.diffractogram_id
-      - _pd_calib_incident_intensity.block_id
       - _pd_calib_incident_intensity.diffractogram_id
-      - _pd_calib_wavelength.block_id
       - _pd_calib_wavelength.diffractogram_id
-      - _pd_calib_xcoord_overall.block_id
       - _pd_calib_xcoord_overall.diffractogram_id
     as necessary.
 
@@ -3149,27 +3070,6 @@ save_PD_CALIB_WAVELENGTH
        was used to calibrate the wavelength against known unit cell
        parameters.
 ;
-
-save_
-
-save_pd_calib_wavelength.block_id
-
-    _definition.id                '_pd_calib_wavelength.block_id'
-    _definition.update            2023-01-17
-    _description.text
-;
-    A block ID code for a block containing a diffractogram used to calibrate
-    the wavelength.
-
-    The data block containing the diffraction pattern will be identified with a
-    _pd_block.id code matching the code in _pd_calib_wavelength.block_id.
-;
-    _name.category_id             pd_calib_wavelength
-    _name.object_id               block_id
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -3693,28 +3593,6 @@ save_PD_CALIB_XCOORD_OVERALL
          Calibration values will be given using PD_CALIB_XCOORD category data
          items.
 ;
-
-save_
-
-save_pd_calib_xcoord_overall.block_id
-
-    _definition.id                '_pd_calib_xcoord_overall.block_id'
-    _definition.update            2023-05-06
-    _description.text
-;
-    A block ID code identifying the diffractogram from which the X-coordinate
-    calibration was taken, if it was calibrated by a specimen.
-
-    The data block containing the diffraction pattern will be identified with a
-    _pd_block.id code matching the code in _pd_calib_xcoord_overall.block_id.
-;
-    _name.category_id             pd_calib_xcoord_overall
-    _name.object_id               block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -9138,30 +9016,6 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
 
 save_
 
-save_pd_pref_orient_march_dollase.diffractogram_block_id
-
-    _definition.id
-        '_pd_pref_orient_March_Dollase.diffractogram_block_id'
-    _definition.update            2023-01-09
-    _description.text
-;
-    A block ID code identifying the diffractogram to
-    which the preferred-orientation correction applies.
-    The data block containing the diffraction pattern
-    for this phase will be identified with a _pd_block.id
-    code matching the code in
-    _pd_pref_orient_March_Dollase.diffractogram_block_id.
-;
-    _name.category_id             pd_pref_orient_March_Dollase
-    _name.object_id               diffractogram_block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_pref_orient_march_dollase.diffractogram_id
 
     _definition.id
@@ -9362,28 +9216,6 @@ save_pd_pref_orient_march_dollase.index_l
     _type.container               Single
     _type.contents                Integer
     _units.code                   none
-
-save_
-
-save_pd_pref_orient_march_dollase.phase_block_id
-
-    _definition.id                '_pd_pref_orient_March_Dollase.phase_block_id'
-    _definition.update            2023-01-09
-    _description.text
-;
-    A code identifying the phase to which the
-    preferred-orientation correction applies. The data
-    block containing the crystallographic information
-    for this phase will be identified with the corresponding
-    _pd_block.id code.
-;
-    _name.category_id             pd_pref_orient_March_Dollase
-    _name.object_id               phase_block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -9596,30 +9428,6 @@ save_pd_pref_orient_spherical_harmonics.c_ij_su
 
 save_
 
-save_pd_pref_orient_spherical_harmonics.diffractogram_block_id
-
-    _definition.id
-        '_pd_pref_orient_spherical_harmonics.diffractogram_block_id'
-    _definition.update            2023-01-09
-    _description.text
-;
-    A block ID code identifying the diffractogram to
-    which the preferred-orientation correction applies.
-    The data block containing the diffraction pattern
-    for this phase will be identified with a _pd_block.id
-    code matching the code in
-    _pd_pref_orient_spherical_harmonics.diffractogram_block_id.
-;
-    _name.category_id             pd_pref_orient_spherical_harmonics
-    _name.object_id               diffractogram_block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_pref_orient_spherical_harmonics.diffractogram_id
 
     _definition.id
@@ -9694,29 +9502,6 @@ save_pd_pref_orient_spherical_harmonics.id
     _type.container               Single
     _type.contents                Code
     _enumeration.default          .
-
-save_
-
-save_pd_pref_orient_spherical_harmonics.phase_block_id
-
-    _definition.id
-        '_pd_pref_orient_spherical_harmonics.phase_block_id'
-    _definition.update            2023-01-09
-    _description.text
-;
-    A code identifying the phase to which the
-    preferred-orientation correction applies. The data
-    block containing the crystallographic information
-    for this phase will be identified with the corresponding
-    _pd_block.id code.
-;
-    _name.category_id             pd_pref_orient_spherical_harmonics
-    _name.object_id               phase_block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 
@@ -11250,29 +11035,6 @@ save_PD_QPA_EXTERNAL_STD
 
 save_
 
-save_pd_qpa_external_std.diffractogram_block_id
-
-    _definition.id                '_pd_qpa_external_std.diffractogram_block_id'
-    _definition.update            2023-01-09
-    _description.text
-;
-    Identifies the _pd_block.id of the diffractogram of the phase
-    used as an external standard for the determination of
-    the diffractometer constant.
-
-    Further references to additional phases present are given in
-    that data block.
-;
-    _name.category_id             pd_qpa_external_std
-    _name.object_id               diffractogram_block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_qpa_external_std.diffractogram_id
 
     _definition.id                '_pd_qpa_external_std.diffractogram_id'
@@ -11530,30 +11292,6 @@ save_PD_QPA_INTERNAL_STD
       _category_key.name
          '_pd_qpa_internal_std.diffractogram_id'
          '_pd_qpa_internal_std.phase_id'
-
-save_
-
-save_pd_qpa_internal_std.block_id
-
-    _definition.id                '_pd_qpa_internal_std.block_id'
-    _definition.update            2023-01-16
-    _description.text
-;
-    Identifies the _pd_block.id of the phase used as an internal
-    standard for the determination of absolute quantitative phase
-    analysis.
-
-    The data block containing the crystallographic information for this
-    phase will be identified with a _pd_block.id code matching the
-    code in _pd_qpa_internal_std.block_id
-;
-    _name.category_id             pd_qpa_internal_std
-    _name.object_id               block_id
-    _name.linked_item_id          '_pd_block.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1459,9 +1459,13 @@ save_PD_BLOCK
     _definition.id                PD_BLOCK
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-10-21
+    _definition.update            2025-04-18
     _description.text
 ;
+    **DEPRECATED**
+    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code' as 
+    necessary.
+
     _pd_block.id is used to assign a unique ID code to a data block.
     This code is then used for references between different blocks
     (see _pd_block_diffractogram.id, _pd_phase_block.id and
@@ -2035,7 +2039,8 @@ save_pd_calib.std_internal_mass_percent
     _definition.update            2023-01-06
     _description.text
 ;
-    This item is deprecated. Please see _pd_qpa_internal_std.mass_percent.
+    **DEPRECATED**
+    Please see _pd_qpa_internal_std.mass_percent.
 
     Per cent presence of the internal standard specified by the
     data item _pd_calib.std_internal_name expressed as 100 times
@@ -2061,7 +2066,8 @@ save_pd_calib.std_internal_mass_percent_su
     _definition.update            2023-01-06
     _description.text
 ;
-    This item is deprecated. Please see _pd_qpa_internal_std.mass_percent_su.
+    **DEPRECATED**
+    Please see _pd_qpa_internal_std.mass_percent_su.
 
     Standard uncertainty of _pd_calib.std_internal_mass_percent.
 ;
@@ -4494,14 +4500,13 @@ save_PD_MEAS
     _definition.id                PD_MEAS
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-10-11
+    _definition.update            2025-04-18
     _description.text
 ;
     This section contains the measured diffractogram prior to
     processing and application of correction terms. While additional
     information may be added to the CIF as data are processed and
-    transported between laboratories (possibly with the addition of
-    a new _pd_block.id entry), the information in this section of
+    transported between laboratories, the information in this section of
     the CIF will rarely be changed once data collection is complete.
 
     Where possible, measurements in this section should have no
@@ -5242,13 +5247,12 @@ save_PD_PROC
     _definition.id                PD_PROC
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-10-11
+    _definition.update            2025-04-18
     _description.text
 ;
     This section contains the diffraction data set after processing
     and application of correction terms. If the data set is
-    reprocessed, this section may be replaced (with the addition of
-    a new _pd_block.id entry).
+    reprocessed, this section may be replaced.
 ;
     _name.category_id             PD_DATA
     _name.object_id               PD_PROC
@@ -5889,11 +5893,10 @@ save_
 save_pd_diffractogram.id
 
     _definition.id                '_pd_diffractogram.id'
-    _definition.update            2022-01-06
+    _definition.update            2025-04-18
     _description.text
 ;
     Arbitrary label identifying a powder diffraction measurement.
-    If missing, _pd_block.id is used.
 ;
     _name.category_id             pd_diffractogram
     _name.object_id               id
@@ -7672,15 +7675,14 @@ save_PD_MEAS_OVERALL
     _definition.id                PD_MEAS_OVERALL
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-12
+    _definition.update            2025-04-18
     _description.text
 ;
     This section contains information about the conditions used for
     the measurement of the diffraction data set, prior to processing
     and application of correction terms. While additional
     information may be added to the CIF as data are processed and
-    transported between laboratories (possibly with the addition of
-    a new _pd_block.id entry), the information in this section of
+    transported between laboratories, the information in this section of
     the CIF will rarely be changed once data collection is complete.
 ;
     _name.category_id             PD_GROUP
@@ -10418,13 +10420,13 @@ save_PD_PROC_OVERALL
     _definition.id                PD_PROC_OVERALL
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-12
+    _definition.update            2025-04-18
     _description.text
 ;
     This section contains overall information about the diffraction
     data set after processing and application of correction
     terms. If the data set is reprocessed, this section may be
-    replaced (with the addition of a new _pd_block.id entry).
+    replaced.
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PROC_OVERALL
@@ -12326,7 +12328,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2024-05-15
+         2.5.0                    2025-04-18
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12465,4 +12467,8 @@ save_
 
        Updated the CIF_CORE dictionary import statement with the new Head
        category name.
+
+       Deprecated PD_BLOCK, PD_BLOCK_DIFFRACTOGRAM, PD_PHASE_BLOCK, and all
+       related data items in favour of PD_PHASE and PD_DIFFRACTOGRAM.
+
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1501,8 +1501,8 @@ save_pd_block.id
 
     _definition.id                '_pd_block.id'
     loop_
-       _definition_replaced.id
-       _definition_replaced.by
+      _definition_replaced.id
+      _definition_replaced.by
          1                        '_pd_phase.id'
          2                        '_pd_diffractogram.id'
          3                        '_audit.block_code'

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2024-05-15
+    _dictionary.date              2025-04-18
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -1496,10 +1496,21 @@ save_
 save_pd_block.id
 
     _definition.id                '_pd_block.id'
+    loop_
+       _definition_replaced.id
+       _definition_replaced.by
+      _category_key.name
+         1 '_pd_phase.id'
+         2 '_pd_diffractogram.id'
+         3 '_audit.block_code'
     _alias.definition_id          '_pd_block_id'
-    _definition.update            2023-01-06
+    _definition.update            2025-04-18
     _description.text
 ;
+    **DEPRECATED**
+    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code, 
+    as necessary.
+
     Used to assign a unique character string to a block.
     Note that this code is not intended to be parsed; the
     concatenation of several strings is used in order to
@@ -1583,9 +1594,12 @@ save_PD_BLOCK_DIFFRACTOGRAM
     _definition.id                PD_BLOCK_DIFFRACTOGRAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-12-03
+    _definition.update            2025-04-18
     _description.text
 ;
+     **DEPRECATED**
+    Use _pd_diffractogram.id, as necessary.
+    
     A number of diffractograms may contribute to the
     determination of the structure of a single phase.
     The _pd_block.ids of those diffractograms should
@@ -1600,10 +1614,15 @@ save_
 save_pd_block_diffractogram.id
 
     _definition.id                '_pd_block_diffractogram.id'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_diffractogram.id'
     _alias.definition_id          '_pd_block_diffractogram_id'
-    _definition.update            2022-10-11
+    _definition.update            2025-04-18
     _description.text
 ;
+    **DEPRECATED**
+    Use _pd_diffractogram.id, as necessary.
+
     A block ID code (see _pd_block.id) that identifies
     diffraction data contained in a data block other
     than the current block. This will occur most frequently
@@ -8634,6 +8653,9 @@ save_PD_PHASE_BLOCK
     _definition.update            2022-12-03
     _description.text
 ;
+    **DEPRECATED**
+    Use _pd_phase.id, as necessary.
+
     A table of phases relevant to the current data
     block. Each phase is identified by the block identifier
     of the data block containing the phase information,
@@ -8649,10 +8671,15 @@ save_
 save_pd_phase_block.id
 
     _definition.id                '_pd_phase_block.id'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_phase.id'
     _alias.definition_id          '_pd_phase_block_id'
-    _definition.update            2023-01-09
+    _definition.update            2025-04-18
     _description.text
 ;
+    **DEPRECATED**
+    Use _pd_phase.id, as necessary.
+
     A block ID code identifying a block containing phase information.
 ;
     _name.category_id             pd_phase_block

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1463,7 +1463,7 @@ save_PD_BLOCK
     _description.text
 ;
     **DEPRECATED**
-    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code' as 
+    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code' as
     necessary.
 
     _pd_block.id is used to assign a unique ID code to a data block.
@@ -1511,7 +1511,7 @@ save_pd_block.id
     _description.text
 ;
     **DEPRECATED**
-    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code, 
+    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code,
     as necessary.
 
     Used to assign a unique character string to a block.
@@ -1602,7 +1602,7 @@ save_PD_BLOCK_DIFFRACTOGRAM
 ;
      **DEPRECATED**
     Use _pd_diffractogram.id, as necessary.
-    
+
     A number of diffractograms may contribute to the
     determination of the structure of a single phase.
     The _pd_block.ids of those diffractograms should
@@ -8588,8 +8588,8 @@ save_PD_PHASE
     _definition.update            2025-04-18
     _description.text
 ;
-    This category allows for the description of the phases contributing to the powder
-    diffraction data set. Note that if multiple-phase Rietveld or other
+    This category allows for the description of the phases contributing to the
+    powder diffraction data set. Note that if multiple-phase Rietveld or other
     structural analysis is performed, the structural results will be placed in
     different data blocks, using CIF entries from the core CIF dictionary.
 ;


### PR DESCRIPTION
A restart of #120 

There have been a bunch of changes in parallel to the block ID deprecation and changes have been lost through the various merging against master, so I started again.

Anyhoo...

The idea is that now we have `_pd_phase.id` and `_pd_diffractogram.id`, the vast majority of use cases for the block codes go away. Additionally, the new id values are machine readable. Furthermore, with the potential addition of `_audit_dataset.id`, the last vestiges of `_pd_block.id` are not needed.

What say you?

PS I still think that this change should alter the version number to 3.0.0