### PR TITLE
Explicitly deprecate several _refln.wavelength_id aliases

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-04-18
+    _dictionary.date              2025-05-21
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   3.11.10
@@ -12281,11 +12281,12 @@ save_refln.wavelength_id
 
     loop_
       _alias.definition_id
-         '_refln_wavelength_id'
-         '_pd_refln.wavelength_id'
-         '_pd_refln_wavelength_id'
+      _alias.deprecation_date
+         '_refln_wavelength_id'                                      .
+         '_pd_refln.wavelength_id'                                   2021-12-06
+         '_pd_refln_wavelength_id'                                   2021-12-06
 
-    _definition.update            2021-12-06
+    _definition.update            2025-05-21
     _description.text
 ;
     _pd_refln.wavelength_id is DEPRECATED. _refln.wavelength_id should
@@ -12350,7 +12351,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-04-18
+         2.5.0                    2025-05-21
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12496,4 +12497,7 @@ save_
 
        Deprecated PD_BLOCK, PD_BLOCK_DIFFRACTOGRAM, PD_PHASE_BLOCK, and all
        related data items in favour of PD_PHASE and PD_DIFFRACTOGRAM.
+
+       Explicitly deprecated the _pd_refln.wavelength_id and
+       _pd_refln_wavelength_id aliases.
 ;


### PR DESCRIPTION
In the embedded revision description for version 2.4.1 it is stated that the `_pd_refln.wavelength_id` was deprecated after consultation with PDDMG. I assume that the same applies to `_pd_refln_wavelength_id`. These items are already declared as deprecated in the human-readable description of `_refln.wavelength_id`, the suggested change expresses it in a machine-readable way.