### PR TITLE
Set DDL conformance to version 4.2.0

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,10 +14,10 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-04-18
+    _dictionary.date              2025-05-21
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
-    _dictionary.ddl_conformance   3.11.10
+    _dictionary.ddl_conformance   4.2.0
     _dictionary.namespace         CifPow
     _description.text
 ;
@@ -12350,7 +12350,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-04-18
+         2.5.0                    2025-05-21
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12496,4 +12496,6 @@ save_
 
        Deprecated PD_BLOCK, PD_BLOCK_DIFFRACTOGRAM, PD_PHASE_BLOCK, and all
        related data items in favour of PD_PHASE and PD_DIFFRACTOGRAM.
+
+       Set DDL conformance to version 4.2.0.
 ;


### PR DESCRIPTION
The repository check already validate it against the latest revision of the DDLm reference dictionary. This change makes it formal.