### PR TITLE
add _diffrn.instr_id

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -275,7 +275,7 @@ save_
 
 save_diffrn.instr_id
 
-    _definition.id                '_chemical_formula.phase_id'
+    _definition.id                '_diffrn.instr_id'
     _definition.update            2025-06-17
     _description.text
 ;


### PR DESCRIPTION
As discussed at the end of #185 

Adding `_diffrn.instr_id` allows an instrument to be linked to a `_diffrn.id`. This means that a `_pd_diffractogram.id`, via `_pd_diffractogram.diffrn_id` can be linked to an instrument.

In the particular example of an external std, this allows `_pd_qpa_extrnal_std.diffractogram_id` to be linked to an instrument, which allows the `_pd_qpa_external_std.k_factor` to be fixed to an instrument.

I think it should all work out.