### PR TITLE
Drop _pd_peak_overall.diffractogram_id

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8744,10 +8744,7 @@ save_PD_PEAK_OVERALL
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_PEAK_OVERALL
-
-    loop_
-      _category_key.name
-         '_pd_peak_overall.id'
+    _category_key.name            '_pd_peak_overall.id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-17
+    _dictionary.date              2025-06-18
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -8747,7 +8747,6 @@ save_PD_PEAK_OVERALL
 
     loop_
       _category_key.name
-         '_pd_peak_overall.diffractogram_id'
          '_pd_peak_overall.id'
 
 save_
@@ -8767,25 +8766,6 @@ save_pd_peak.special_details
     _name.object_id               special_details
     _type.purpose                 Describe
     _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_pd_peak_overall.diffractogram_id
-
-    _definition.id                '_pd_peak_overall.diffractogram_id'
-    _definition.update            2023-06-10
-    _description.text
-;
-    The diffractogram (see _pd_diffractogram.id) to which the overall peak
-    information relates.
-;
-    _name.category_id             pd_peak_overall
-    _name.object_id               diffractogram_id
-    _name.linked_item_id          '_pd_diffractogram.id'
-    _type.purpose                 Link
-    _type.source                  Related
     _type.container               Single
     _type.contents                Text
 
@@ -12678,7 +12658,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-17
+         2.5.0                    2025-06-18
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -12798,7 +12778,7 @@ save_
 
        Add _pd_calib_xcoord.diffractogram_id.
 
-       Add _pd_peak.diffractogram_id and _pd_peak_overall.diffractogram_id.
+       Add _pd_peak.diffractogram_id.
 
        Altered PD_CALIB_INCIDENT_INTENSITY to be a Set category.
 


### PR DESCRIPTION
This is unnecessary as peak extraction procedure can be described independent of a particular diffractogram. Fixes #192. 