### PR TITLE
rejig PD_CALIB_DETECTED_INTENSITY

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3103,7 +3103,7 @@ save_pd_calib.2theta_off_point
     _definition.id                '_pd_calib.2theta_off_point'
 
     _definition_replaced.id       1
-    _definition_replaced.by       '_pd_calib_xcoord.nominal_2theta'
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_nominal'
 
     _alias.definition_id          '_pd_calib_2theta_off_point'
     _definition.update            2023-06-05
@@ -3306,10 +3306,10 @@ save_pd_calib_std.external_block_id
     loop_
       _definition_replaced.id
       _definition_replaced.by
-         1                      '_pd_calib_detected_intensity_overall.diffractogram_id'
-         2                      '_pd_calib_incident_intensity.diffractogram_id'
-         3                      '_pd_calib_wavelength.diffractogram_id'
-         4                      '_pd_calib_xcoord_overall.diffractogram_id'
+         1              '_pd_calib_detected_intensity_overall.diffractogram_id'
+         2              '_pd_calib_incident_intensity.diffractogram_id'
+         3              '_pd_calib_wavelength.diffractogram_id'
+         4              '_pd_calib_xcoord_overall.diffractogram_id'
 
     _alias.definition_id          '_pd_calib_std_external_block_id'
     _definition.update            2023-06-05

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2592,6 +2592,66 @@ save_PD_CALIB_DETECTED_INTENSITY
       _category_key.name
          '_pd_calib_detected_intensity.detector_id'
          '_pd_calib_detected_intensity.overall_id'
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _pd_calib_detected_intensity_overall.id                calid_det_int
+         _pd_calib_detected_intensity_overall.diffractogram_id  DIFFRACTOGRAM_A
+         _pd_calib_detected_intensity_overall.special_details
+             'flood field calibration'
+
+         loop_
+         _pd_calib_detected_intensity.detector_id
+         _pd_calib_detected_intensity.detector_response
+         _pd_calib_detected_intensity.detector_response_su
+         A   1       .
+         B   1.035   0.013
+
+         _pd_diffractogram.id         DIFFRACTOGRAM_A
+         _pd_diffractogram.instr_id   INSTRUMENT_1234
+
+         loop_
+         _pd_meas.detector_id
+         _pd_meas.2theta_scan
+         _pd_meas.counts_total
+         A   10.04   1021
+         B   10.04   1056
+         A   10.06   1022
+         B   10.06   1058
+         #...
+;
+;
+         The two detectors, A and B, have responses of 1 and 1.035,
+         respectively, meaning that their measured intensities must be divided
+         by these values to retreive their true values. These response values
+         were derived from an analysis of the diffractogram DIFFRACTOGRAM_A,
+         which is given after the calibration. The diffractogram
+         DIFFRACTOGRAM_A is the result of a flood-field calibration collected
+         on an instrument designated INSTRUMENT_1234.
+;
+;
+         _pd_diffractogram.id         UNKNOWN_SAMPLE
+         _pd_diffractogram.instr_id   INSTRUMENT_1234
+
+         loop_
+         _pd_meas.detector_id
+         _pd_meas.2theta_scan
+         _pd_meas.counts_total
+         A   12.12   13545
+         B   12.12   14022
+         A   12.16   13698
+         B   12.16   14167
+         #...
+;
+;
+         This shows the case where the calibration can be applied to a
+         diffractogram collected from an unknown specimen. We know the
+         instrument and detectors used to collect the data, so we can
+         find the appropriate calibration values for the detectors
+         from the PD_CALIB_DETECTED_INTENSITY category via the
+         PD_CALIB_DETECTED_INTENSITY_OVERALL category.
+;
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2705,7 +2705,8 @@ save_
 
 save_pd_calib_detected_intensity_overall.diffractogram_id
 
-    _definition.id                '_pd_calib_detected_intensity_overall.diffractogram_id'
+    _definition.id
+        '_pd_calib_detected_intensity_overall.diffractogram_id'
     _definition.update            2025-06-20
     _description.text
 ;
@@ -2742,7 +2743,8 @@ save_
 
 save_pd_calib_detected_intensity_overall.phase_id
 
-    _definition.id                '_pd_calib_detected_intensity_overall.phase_id'
+    _definition.id
+        '_pd_calib_detected_intensity_overall.phase_id'
     _definition.update            2025-06-20
     _description.text
 ;
@@ -2762,7 +2764,8 @@ save_
 
 save_pd_calib_detected_intensity_overall.special_details
 
-    _definition.id                '_pd_calib_detected_intensity_overall.special_details'
+    _definition.id
+        '_pd_calib_detected_intensity_overall.special_details'
     _definition.update            2025-06-20
     _description.text
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3103,7 +3103,7 @@ save_pd_calib.2theta_off_point
     _definition.id                '_pd_calib.2theta_off_point'
 
     _definition_replaced.id       1
-    _definition_replaced.by       '_pd_calib_detected_intensity.2theta_nominal'
+    _definition_replaced.by       '_pd_calib_xcoord.nominal_2theta'
 
     _alias.definition_id          '_pd_calib_2theta_off_point'
     _definition.update            2023-06-05
@@ -3306,7 +3306,7 @@ save_pd_calib_std.external_block_id
     loop_
       _definition_replaced.id
       _definition_replaced.by
-         1                      '_pd_calib_detected_intensity.diffractogram_id'
+         1                      '_pd_calib_detected_intensity_overall.diffractogram_id'
          2                      '_pd_calib_incident_intensity.diffractogram_id'
          3                      '_pd_calib_wavelength.diffractogram_id'
          4                      '_pd_calib_xcoord_overall.diffractogram_id'
@@ -3316,7 +3316,7 @@ save_pd_calib_std.external_block_id
     _description.text
 ;
     This item is deprecated. Please see:
-      - _pd_calib_detected_intensity.diffractogram_id
+      - _pd_calib_detected_intensity_overall.diffractogram_id
       - _pd_calib_incident_intensity.diffractogram_id
       - _pd_calib_wavelength.diffractogram_id
       - _pd_calib_xcoord_overall.diffractogram_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-19
+    _dictionary.date              2025-06-20
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -2562,7 +2562,7 @@ save_PD_CALIB_DETECTED_INTENSITY
     _definition.id                PD_CALIB_DETECTED_INTENSITY
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-01-21
+    _definition.update            2025-06-20
     _description.text
 ;
     This section defines the parameters used for the intensity calibration of
@@ -2591,7 +2591,7 @@ save_PD_CALIB_DETECTED_INTENSITY
     loop_
       _category_key.name
          '_pd_calib_detected_intensity.detector_id'
-         '_pd_calib_detected_intensity.id'
+         '_pd_calib_detected_intensity.overall_id'
 
 save_
 
@@ -2665,17 +2665,54 @@ save_pd_calib_detected_intensity.detector_response_su
 
 save_
 
-save_pd_calib_detected_intensity.diffractogram_id
+save_pd_calib_detected_intensity.overall_id
 
-    _definition.id
-        '_pd_calib_detected_intensity.diffractogram_id'
-    _definition.update            2023-01-21
+    _definition.id                '_pd_calib_detected_intensity.overall_id'
+    _definition.update            2025-06-20
+    _description.text
+;
+    A code which identifies the particular set of overall calibration
+    conditions under which the calibration was calculated.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               overall_id
+    _name.linked_item_id          '_pd_calib_detected_intensity_overall.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIB_DETECTED_INTENSITY_OVERALL
+
+    _definition.id                PD_CALIB_DETECTED_INTENSITY_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-06-19
+    _description.text
+;
+    This category gives the overall information about the detected
+    intensity calibration applied to a given diffractogram.
+
+    See PD_CALIB_DETECTED_INTENSITY.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_DETECTED_INTENSITY_OVERALL
+    _category_key.name            '_pd_calib_detected_intensity_overall.id'
+
+save_
+
+save_pd_calib_detected_intensity_overall.diffractogram_id
+
+    _definition.id                '_pd_calib_detected_intensity_overall.diffractogram_id'
+    _definition.update            2025-06-20
     _description.text
 ;
     A code which identifies the particular diffractogram from which this
     intensity calibration was taken, if it was calibrated by a specimen.
 ;
-    _name.category_id             pd_calib_detected_intensity
+    _name.category_id             pd_calib_detected_intensity_overall
     _name.object_id               diffractogram_id
     _name.linked_item_id          '_pd_diffractogram.id'
     _type.purpose                 Link
@@ -2685,34 +2722,35 @@ save_pd_calib_detected_intensity.diffractogram_id
 
 save_
 
-save_pd_calib_detected_intensity.id
+save_pd_calib_detected_intensity_overall.id
 
-    _definition.id                '_pd_calib_detected_intensity.id'
-    _definition.update            2023-01-21
+    _definition.id                '_pd_calib_detected_intensity_overall.id'
+    _definition.update            2025-06-20
     _description.text
 ;
-    A code to uniquely identify each intensity calibration.
+    A code to uniquely identify the overall values associated with a group of
+    calibration points.
 ;
-    _name.category_id             pd_calib_detected_intensity
+    _name.category_id             pd_calib_detected_intensity_overall
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _enumeration.default          .
 
 save_
 
-save_pd_calib_detected_intensity.phase_id
+save_pd_calib_detected_intensity_overall.phase_id
 
-    _definition.id                '_pd_calib_detected_intensity.phase_id'
-    _definition.update            2023-01-21
+    _definition.id                '_pd_calib_detected_intensity_overall.phase_id'
+    _definition.update            2025-06-20
     _description.text
 ;
-    A code which identifies the particular phase from which this intensity was
-    taken, if it was calibrated by a specimen.
+    A code which identifies the particular phase used in calibrating the
+    intensity, if it was calibrated by a specimen. The phase can be
+    an internal or external standard.
 ;
-    _name.category_id             pd_calib_detected_intensity
+    _name.category_id             pd_calib_detected_intensity_overall
     _name.object_id               phase_id
     _name.linked_item_id          '_pd_phase.id'
     _type.purpose                 Link
@@ -2722,16 +2760,16 @@ save_pd_calib_detected_intensity.phase_id
 
 save_
 
-save_pd_calib_detected_intensity.special_details
+save_pd_calib_detected_intensity_overall.special_details
 
-    _definition.id                '_pd_calib_detected_intensity.special_details'
-    _definition.update            2023-01-21
+    _definition.id                '_pd_calib_detected_intensity_overall.special_details'
+    _definition.update            2025-06-20
     _description.text
 ;
-    Description of detected intensity calibration details that cannot otherwise
-    be recorded using other PD_CALIB_DETECTED_INTENSITY data items
+    Description of intensity calibration details that cannot otherwise
+    be recorded using other PD_CALIB_DETECTED_INTENSITY_OVERALL data items.
 ;
-    _name.category_id             pd_calib_detected_intensity
+    _name.category_id             pd_calib_detected_intensity_overall
     _name.object_id               special_details
     _type.purpose                 Describe
     _type.source                  Recorded
@@ -3062,7 +3100,7 @@ save_pd_calib.2theta_off_point
     _definition.id                '_pd_calib.2theta_off_point'
 
     _definition_replaced.id       1
-    _definition_replaced.by       '_pd_calib_xcoord.2theta_nominal'
+    _definition_replaced.by       '_pd_calib_detected_intensity.2theta_nominal'
 
     _alias.definition_id          '_pd_calib_2theta_off_point'
     _definition.update            2023-06-05
@@ -12870,7 +12908,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-19
+         2.5.0                    2025-06-20
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -13040,4 +13078,7 @@ save_
 
        Added examples to PD_CALC_OVERALL, PD_CALIB_INCIDENT_INTENSITY, PD_CHAR,
        _pd_diffractogram.id, PD_PHASE_MASS, PD_PROC_LS, PD_SPEC.
+
+       Updated PD_CALIB_DETECTED_INTENSITY and created
+       PD_CALIB_DETECTED_INTENSITY_OVERALL
 ;


### PR DESCRIPTION
Revise along the lines on CALIB_XCOORD

.

`PD_CALIB_DETECTED_INTENSITY`
- `_pd_calib_detected_intensity.detector_id`: key
- `_pd_calib_detected_intensity.detector_response`
- `_pd_calib_detected_intensity.overall_id`: key

`PD_CALIB_DETECTED_INTENSITY_OVERALL`
- `_pd_calib_detected_intensity_overall.id`: key
- `_pd_calib_detected_intensity_overall.diffractogram_id`
- `_pd_calib_detected_intensity_overall.phase_id`
- `_pd_calib_detected_intensity_overall.special_details`




