### PR TITLE
removed PD_CALIB_WAVELENGTH , add DIFFRN_WAVELENGTH_RADIATION .difractogram_id and .phase_id

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -298,8 +298,7 @@ save_
 
 save_diffrn_radiation_wavelength.special_details
 
-    _definition.id
-        '_diffrn_radiation_wavelength.special_details'
+    _definition.id                '_diffrn_radiation_wavelength.special_details'
     _definition.update            2025-06-23
     _description.text
 ;
@@ -12803,7 +12802,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-20
+         2.5.0                    2025-06-23
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
as per https://github.com/COMCIFS/Powder_Dictionary/issues/189#issuecomment-2990068746

Remove PD_CALIB_WAVELENGTH all together, add .diffractogram_id and .phase_id to DIFFRN_WAVELENGTH_RADIATION to allow for recording the source of a refined wavelength.