### PR TITLE
harmonised description of _pd_proc.info_excluded_region

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -11063,6 +11063,9 @@ save_pd_proc.info_excluded_regions
     Description of regions in the diffractogram excluded
     from processing along with a justification of why the
     data points were not used.
+
+    To indicate excluded regions in a machine-readble manner,
+    set the requisite values in _pd_proc.ls_weight to 0.
 ;
     _name.category_id             pd_proc_overall
     _name.object_id               info_excluded_regions


### PR DESCRIPTION
While reading Vol G things.

`_pd_proc.info_excluded_region` is a human-readable description of excluded regions in the associated diffractogram analysis.

`_pd_proc.ls_weight`'s description says to set its value to 0 if that point is excluded.

I added a sentence in the description of `_pd_proc.info_excluded_region` which reference `_pd_proc.ls_weight`