### PR TITLE
update description of PD_BACKGROUND

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -368,8 +368,10 @@ save_PD_BACKGROUND
     _pd_proc.intensity_bkg_calc.
 
     The computed background values should include all normalization corrections,
-    and thus are specified on the same scale as the observed intensities
-    (_pd_meas.counts_* or _pd_meas.intensity_*, and _pd_calc.intensity_total).
+    and thus are specified on the same scale as the other calculated intensities
+    such as _pd_calc.intensity_total. Indeed the sum of
+    _pd_proc.intensity_bkg_calc and _pd_calc.intensity_net should be
+    _pd_calc.intensity_total.
 
     If more than one type of background is specified for a particular
     diffractogram, then it is assumed they are linearly additive.


### PR DESCRIPTION
From doing writing things in vol G

Clarifying that the computed background values should include all normalization corrections, and thus are specified on the same scale as the calculated intensities given by  `_pd_calc.intensity_total`; indeed the sum of `_pd_proc.intensity_bkg_calc` and `_pd_calc.intensity_net` should be `_pd_calc.intensity_total`.

Removed mention of `_pd_meas.*`