### PR TITLE
added _pd_meas_overall.step_count_time

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-20
+    _dictionary.date              2025-06-22
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -8446,46 +8446,6 @@ save_pd_meas.special_details
 
 save_
 
-save_pd_meas_overall.step_count_time
-
-    _definition.id                '_pd_meas_overall.step_count_time'
-    _definition.update            2025-06-22
-    _description.text
-;
-    The count time in seconds for each intensity measurement where
-    the count time is constant for each step in the diffractogram.
-
-    Where the step count time is not constant for each point, use
-    _pd_meas.step_count_time.
-;
-    _name.category_id             pd_meas_overall
-    _name.object_id               step_count_time
-    _type.purpose                 Measurand
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   seconds
-
-save_
-
-save_pd_meas_overall.step_count_time_su
-
-    _definition.id                '_pd_meas_overall.step_count_time_su'
-    _definition.update            2025-06-22
-    _description.text
-;
-    Standard uncertainty of _pd_meas_overall.step_count_time.
-;
-    _name.category_id             pd_meas_overall
-    _name.object_id               step_count_time_su
-    _name.linked_item_id          '_pd_meas_overall.step_count_time'
-    _units.code                   seconds
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
 save_pd_meas.units_of_intensity
 
     _definition.id                '_pd_meas.units_of_intensity'
@@ -8530,6 +8490,46 @@ save_pd_meas_overall.diffractogram_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_pd_meas_overall.step_count_time
+
+    _definition.id                '_pd_meas_overall.step_count_time'
+    _definition.update            2025-06-22
+    _description.text
+;
+    The count time in seconds for each intensity measurement where
+    the count time is constant for each step in the diffractogram.
+
+    Where the step count time is not constant for each point, use
+    _pd_meas.step_count_time.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               step_count_time
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   seconds
+
+save_
+
+save_pd_meas_overall.step_count_time_su
+
+    _definition.id                '_pd_meas_overall.step_count_time_su'
+    _definition.update            2025-06-22
+    _description.text
+;
+    Standard uncertainty of _pd_meas_overall.step_count_time.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               step_count_time_su
+    _name.linked_item_id          '_pd_meas_overall.step_count_time'
+    _units.code                   seconds
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5491,10 +5491,14 @@ save_pd_meas.step_count_time
 
     _definition.id                '_pd_meas.step_count_time'
     _alias.definition_id          '_pd_meas_step_count_time'
-    _definition.update            2023-01-06
+    _definition.update            2025-06-22
     _description.text
 ;
     The count time in seconds for each intensity measurement.
+
+    Use this item for measurements where the count time
+    varies for different points; where the step count time is
+    constant, prefer _pd_meas_overall.step_count_time.
 ;
     _name.category_id             pd_meas
     _name.object_id               step_count_time
@@ -8439,6 +8443,46 @@ save_pd_meas.special_details
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_pd_meas_overall.step_count_time
+
+    _definition.id                '_pd_meas_overall.step_count_time'
+    _definition.update            2025-06-22
+    _description.text
+;
+    The count time in seconds for each intensity measurement where
+    the count time is constant for each step in the diffractogram.
+
+    Where the step count time is not constant for each point, use
+    _pd_meas.step_count_time.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               step_count_time
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   seconds
+
+save_
+
+save_pd_meas_overall.step_count_time_su
+
+    _definition.id                '_pd_meas_overall.step_count_time_su'
+    _definition.update            2025-06-22
+    _description.text
+;
+    Standard uncertainty of _pd_meas_overall.step_count_time.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               step_count_time_su
+    _name.linked_item_id          '_pd_meas_overall.step_count_time'
+    _units.code                   seconds
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -12870,7 +12914,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-20
+         2.5.0                    2025-06-22
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -13040,4 +13084,6 @@ save_
 
        Added examples to PD_CALC_OVERALL, PD_CALIB_INCIDENT_INTENSITY, PD_CHAR,
        _pd_diffractogram.id, PD_PHASE_MASS, PD_PROC_LS, PD_SPEC.
+
+       Added _pd_meas_overall.step_count_time
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -13177,6 +13177,6 @@ save_
        the source of a refined wavelength value.
        _diffrn_radiation_wavelength.special_details added to record
        information about the wavelength.
-       
+
        Added _pd_meas_overall.step_count_time
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5015,7 +5015,8 @@ save_pd_meas.counts_background
     Note that counts-per-second values should be converted to
     total counts. If the counting time varies for different
     points, it may be included in the loop using
-    _pd_meas.step_count_time.
+    _pd_meas.step_count_time. A constant count time can be
+    recorded using _pd_meas_overall.step_count_time.
 
     Standard uncertainties should not be quoted for these values.
     If the standard uncertainties differ from the square root of
@@ -5052,7 +5053,8 @@ save_pd_meas.counts_container
     Note that counts-per-second values should be converted to
     total counts. If the counting time varies for different
     points, it may be included in the loop using
-    _pd_meas.step_count_time.
+    _pd_meas.step_count_time. A constant count time can be
+    recorded using _pd_meas_overall.step_count_time.
 
     Standard uncertainties should not be quoted for these values.
     If the standard uncertainties differ from the square root of
@@ -5088,7 +5090,8 @@ save_pd_meas.counts_monitor
     Note that counts-per-second values should be converted to
     total counts. If the counting time varies for different
     points, it may be included in the loop using
-    _pd_meas.step_count_time.
+    _pd_meas.step_count_time. A constant count time can be
+    recorded using _pd_meas_overall.step_count_time.
 
     Standard uncertainties should not be quoted for these values.
     If the standard uncertainties differ from the square root of
@@ -5125,7 +5128,8 @@ save_pd_meas.counts_total
     Note that counts-per-second values should be converted to
     total counts. If the counting time varies for different
     points, it may be included in the loop using
-    _pd_meas.step_count_time.
+    _pd_meas.step_count_time. A constant count time can be
+    recorded using _pd_meas_overall.step_count_time.
 
     Standard uncertainties should not be quoted for these values.
     If the standard uncertainties differ from the square root of
@@ -5211,6 +5215,11 @@ save_pd_meas.intensity_background
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
 
+    If the counting time varies for different points, it may
+    be included in the loop using _pd_meas.step_count_time.
+    A constant count time can be recorded using
+    _pd_meas_overall.step_count_time.
+
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead, make the
     corrections and record the result using
@@ -5264,6 +5273,11 @@ save_pd_meas.intensity_container
     values are not counts (use _pd_meas.counts_* for event-counting
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
+
+    If the counting time varies for different points, it may
+    be included in the loop using _pd_meas.step_count_time.
+    A constant count time can be recorded using
+    _pd_meas_overall.step_count_time.
 
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead, make the
@@ -5320,6 +5334,11 @@ save_pd_meas.intensity_monitor
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
 
+    If the counting time varies for different points, it may
+    be included in the loop using _pd_meas.step_count_time.
+    A constant count time can be recorded using
+    _pd_meas_overall.step_count_time.
+
     Corrections for background, detector dead time etc.
     should not have been made to these values. Instead, make the
     corrections and record the result using
@@ -5373,6 +5392,11 @@ save_pd_meas.intensity_total
     values are not counts (use _pd_meas.counts_* for event-counting
     measurements where the standard uncertainty is
     estimated as the square root of the number of counts).
+
+    If the counting time varies for different points, it may
+    be included in the loop using _pd_meas.step_count_time.
+    A constant count time can be recorded using
+    _pd_meas_overall.step_count_time.
 
     Corrections for background, detector dead time etc.,
     should not have been made to these values. Instead use


### PR DESCRIPTION
from my writing volG things

Added `_pd_meas_overall.step_count_time` to give a step count time on a per-diffractogram basis, and updated description of `_pd_meas.step_count_time` to say that you should prefer `_pd_meas_overall.step_count_time` if the step time is constant for each point.

There are a couple of examples in the powder chapter where `_pd_meas.step_count_time` (a loop category data name) is used in a Set-like manner to describe the count time of a diffractogram (containing looped `_pd_meas.* names) which is given in the same data block.

Don't think that is entirely kosher.

`_pd_meas_overall.step_count_time` solves this.