### PR TITLE
removed _pd_calib_detected_intensity.id

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-23
+    _dictionary.date              2025-06-27
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -2621,7 +2621,7 @@ save_PD_CALIB_DETECTED_INTENSITY
     _definition.id                PD_CALIB_DETECTED_INTENSITY
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-01-21
+    _definition.update            2025-06-27
     _description.text
 ;
     This section defines the parameters used for the intensity calibration of
@@ -2646,11 +2646,7 @@ save_PD_CALIB_DETECTED_INTENSITY
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_DETECTED_INTENSITY
-
-    loop_
-      _category_key.name
-         '_pd_calib_detected_intensity.detector_id'
-         '_pd_calib_detected_intensity.id'
+    _category_key.name            '_pd_calib_detected_intensity.detector_id'
 
 save_
 
@@ -2741,24 +2737,6 @@ save_pd_calib_detected_intensity.diffractogram_id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-
-save_
-
-save_pd_calib_detected_intensity.id
-
-    _definition.id                '_pd_calib_detected_intensity.id'
-    _definition.update            2023-01-21
-    _description.text
-;
-    A code to uniquely identify each intensity calibration.
-;
-    _name.category_id             pd_calib_detected_intensity
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _enumeration.default          .
 
 save_
 
@@ -13324,7 +13302,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-23
+         2.5.0                    2025-06-27
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -13510,4 +13488,7 @@ save_
        information about the wavelength.
 
        Added _pd_meas_overall.step_count_time.
+
+       Removed _pd_calib_detected_intensity.id cas dataitem and category key
+       of PD_CALIB_DETECTED_INTENSITY.
 ;


### PR DESCRIPTION
From contemplations whilst writing volG

This is a category for the overall intensity calibration of a detector. 1 value per detector, with detector_id as key, so makes no sense to be also keyed on an opaque ID.