### PR TITLE
_pd_diffractogram links to imgCIF

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
     branches: [ master ]
     paths-ignore:
             - '.github/**'
-  workflow_dispatch:   
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -27,7 +27,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
         - name: checkout
           uses: actions/checkout@v4
-          
+
       # Check syntax of all CIF files
         - name: check_syntax
           uses: COMCIFS/cif_syntax_check_action@master
@@ -43,7 +43,7 @@ jobs:
         with:
                  path: ~/.julia
                  key: ${{ runner.os }}-julia-v2
-                 
+
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
@@ -77,13 +77,13 @@ jobs:
         run: |
                julia -e 'using Pkg; Pkg.status()'
                for file in main/*.dic
-               do      
+               do
                   echo "Checking $file"
                   julia -O0 ./julia_cif_tools/linter.jl -i $PWD/cif_core $file cif_core/ddl.dic
-                  if [ $? != 0 ] 
-                  then 
+                  if [ $? != 0 ]
+                  then
                     exit 1 ;
-                  fi 
+                  fi
                done
   ddlm:
     runs-on: ubuntu-latest
@@ -97,6 +97,12 @@ jobs:
         with:
           repository: COMCIFS/cif_core
           path: cif-dictionaries/cif_core
+
+      - name: Checkout the imgCIF dictionary
+        uses: actions/checkout@v4
+        with:
+          repository: COMCIFS/imgCIF
+          path: cif-dictionaries/imgCIF
 
       - name: Checkout the multiblock coreCIF dictionary
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,12 +98,6 @@ jobs:
           repository: COMCIFS/cif_core
           path: cif-dictionaries/cif_core
 
-      - name: Checkout the imgCIF dictionary
-        uses: actions/checkout@v4
-        with:
-          repository: COMCIFS/imgCIF
-          path: cif-dictionaries/imgCIF
-
       - name: Checkout the multiblock coreCIF dictionary
         uses: actions/checkout@v4
         with:

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -44,6 +44,10 @@ save_PD_GROUP
     _import.get
         [
           {
+           'dupl':Ignore  'file':cif_img.dic  'mode':Full
+           'save':HEAD
+          },
+          {
            'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
            'save':MULTIBLOCK_CORE
           }

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6313,28 +6313,6 @@ save_pd_diffractogram.diffrn_id
 
 save_
 
-save_pd_diffractogram.scan_id
-
-    _definition.id                '_pd_diffractogram.scan_id'
-    _definition.update            2025-07-01
-    _description.text
-;
-    A code which identifies the imgCIF scan which was processed to form this
-    diffractogram.
-
-    The frames which constitute this scan can be determined from the relevant
-    imgCIF data.
-;
-    _name.category_id             pd_diffractogram
-    _name.object_id               scan_id
-    _name.linked_item_id          '_diffrn_scan.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_pd_diffractogram.id
 
     _definition.id                '_pd_diffractogram.id'
@@ -6375,6 +6353,28 @@ save_pd_diffractogram.instr_id
     _name.linked_item_id          '_pd_instr.id'
     _type.purpose                 Link
     _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_diffractogram.scan_id
+
+    _definition.id                '_pd_diffractogram.scan_id'
+    _definition.update            2025-07-01
+    _description.text
+;
+    A code which identifies the imgCIF scan which was processed to form this
+    diffractogram.
+
+    The frames which constitute this scan can be determined from the relevant
+    imgCIF data.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               scan_id
+    _name.linked_item_id          '_diffrn_scan.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14376,7 +14376,7 @@ save_
 
        Update PD_DIFFRACTOGRAM to link to the imgCIF scan from which the
        diffractogram was created.
-       
+
        Removed _pd_calib_detected_intensity.id as data item and category
        key of PD_CALIB_DETECTED_INTENSITY.
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -44,9 +44,7 @@ save_PD_GROUP
     _import.get
         [
           {
-           'dupl':Ignore
-'file':https://raw.githubusercontent.com/COMCIFS/imgCIF/refs/heads/master/cif_img.dic
-           'mode':Full 'save':HEAD
+           'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':HEAD
           }
           {
            'dupl':Ignore  'file':multi_block_core.dic  'mode':Full

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -44,9 +44,10 @@ save_PD_GROUP
     _import.get
         [
           {
-           'dupl':Ignore  'file':cif_img.dic  'mode':Full
-           'save':HEAD
-          } 
+           'dupl':Ignore
+'file':https://raw.githubusercontent.com/COMCIFS/imgCIF/refs/heads/master/cif_img.dic
+           'mode':Full 'save':HEAD
+          }
           {
            'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
            'save':MULTIBLOCK_CORE
@@ -13370,7 +13371,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-06-23
+         2.5.0                    2025-07-01
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -46,7 +46,7 @@ save_PD_GROUP
           {
            'dupl':Ignore  'file':cif_img.dic  'mode':Full
            'save':HEAD
-          },
+          } 
           {
            'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
            'save':MULTIBLOCK_CORE

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6291,6 +6291,27 @@ save_PD_DIFFRACTOGRAM
 
 save_
 
+save_pd_diffractogram.diffrn_frame_data_id
+
+    _definition.id                '_pd_diffractogram.diffrn_frame_data_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code which identifies the imgCIF frame which was processed to form this
+    diffractogram.
+
+    See also _pd_diffractogram.diffrn_scan_id.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               diffrn_frame_data_id
+    _name.linked_item_id          '_diffrn_frame_data.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_pd_diffractogram.diffrn_id
 
     _definition.id                '_pd_diffractogram.diffrn_id'
@@ -6303,6 +6324,27 @@ save_pd_diffractogram.diffrn_id
     _name.category_id             pd_diffractogram
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_pd_diffractogram.diffrn_scan_id
+
+    _definition.id                '_pd_diffractogram.diffrn_scan_id'
+    _definition.update            2025-06-30
+    _description.text
+;
+    A code which identifies the imgCIF scan which was processed to form this
+    diffractogram.
+
+    See also _pd_diffractogram.diffrn_frame_data_id.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               diffrn_scan_id
+    _name.linked_item_id          '_diffrn_scan.id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6417,11 +6417,9 @@ save_pd_diffractogram.scan_id
     _definition.update            2025-07-01
     _description.text
 ;
-    A code which identifies the imgCIF scan which was processed to form this
-    diffractogram.
-
-    The frames which constitute this scan can be determined from the relevant
-    imgCIF data.
+    The identifier for the group of imgCIF images used to produce the
+    diffractogram. Each group of images is known as a scan, and the images
+    belonging to each scan are described using imgCIF data names.
 ;
     _name.category_id             pd_diffractogram
     _name.object_id               scan_id
@@ -13704,7 +13702,7 @@ save_
 
        Update PD_DIFFRACTOGRAM to link to the imgCIF scan from which the
        diffractogram was created.
-       
+
        Update PD_INSTR and PD_INSTR_DETECTOR descriptions.
 
        Added _pd_instr.radiation_id and _pd_instr_detector.instr_id.

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6294,27 +6294,6 @@ save_PD_DIFFRACTOGRAM
 
 save_
 
-save_pd_diffractogram.diffrn_frame_data_id
-
-    _definition.id                '_pd_diffractogram.diffrn_frame_data_id'
-    _definition.update            2025-07-01
-    _description.text
-;
-    A code which identifies the imgCIF frame which was processed to form this
-    diffractogram.
-
-    See also _pd_diffractogram.diffrn_scan_id.
-;
-    _name.category_id             pd_diffractogram
-    _name.object_id               diffrn_frame_data_id
-    _name.linked_item_id          '_diffrn_frame_data.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_pd_diffractogram.diffrn_id
 
     _definition.id                '_pd_diffractogram.diffrn_id'
@@ -6334,19 +6313,20 @@ save_pd_diffractogram.diffrn_id
 
 save_
 
-save_pd_diffractogram.diffrn_scan_id
+save_pd_diffractogram.scan_id
 
-    _definition.id                '_pd_diffractogram.diffrn_scan_id'
+    _definition.id                '_pd_diffractogram.scan_id'
     _definition.update            2025-07-01
     _description.text
 ;
     A code which identifies the imgCIF scan which was processed to form this
     diffractogram.
 
-    See also _pd_diffractogram.diffrn_frame_data_id.
+    The frames which constitute this scan can be determined from the relevant
+    imgCIF data.
 ;
     _name.category_id             pd_diffractogram
-    _name.object_id               diffrn_scan_id
+    _name.object_id               scan_id
     _name.linked_item_id          '_diffrn_scan.id'
     _type.purpose                 Link
     _type.source                  Assigned
@@ -13556,5 +13536,6 @@ save_
 
        Added _pd_meas_overall.step_count_time.
 
-       Update PD_DIFFRACTOGRAM to accomodate links to imgCIF scans and frames.
+       Update PD_DIFFRACTOGRAM to link to the imgCIF scan from which the
+       diffractogram was created.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-06-23
+    _dictionary.date              2025-07-01
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -6294,7 +6294,7 @@ save_
 save_pd_diffractogram.diffrn_frame_data_id
 
     _definition.id                '_pd_diffractogram.diffrn_frame_data_id'
-    _definition.update            2023-10-16
+    _definition.update            2025-07-01
     _description.text
 ;
     A code which identifies the imgCIF frame which was processed to form this
@@ -6334,7 +6334,7 @@ save_
 save_pd_diffractogram.diffrn_scan_id
 
     _definition.id                '_pd_diffractogram.diffrn_scan_id'
-    _definition.update            2025-06-30
+    _definition.update            2025-07-01
     _description.text
 ;
     A code which identifies the imgCIF scan which was processed to form this
@@ -13552,4 +13552,6 @@ save_
        information about the wavelength.
 
        Added _pd_meas_overall.step_count_time.
+
+       Update PD_DIFFRACTOGRAM to accomodate links to imgCIF scans and frames.
 ;


### PR DESCRIPTION
from https://github.com/COMCIFS/MultiBlock_Dictionary/pull/31#issuecomment-3018233983

>`_pd_diffractogram` will want to point to `_diffrn_scan.scan_id` and `_diffrn_scan_frame.frame_id` if it is derived from a 2D measurement and there is more than one scan + frame.

Starting the process to allow a diffractogram to link to the specifc imgCIF frame and/or scan from which it was originally measured