### PR TITLE
rekey PD_CALIB_DETECTED_INTENSITY and add examples

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2675,13 +2675,11 @@ save_PD_CALIB_DETECTED_INTENSITY
          loop_
          _pd_calib_detected_intensity.detector_id
          _pd_calib_detected_intensity.detector_response
-         _pd_calib_detected_intensity.diffractogram_id
-         _pd_calib_detected_intensity.phase_id
          _pd_calib_detected_intensity.special_details
-         1_4913c6ed   1       . . 'Scanned through direct beam.'
-         2_4913c6ed   0.973   . . 'Scanned through direct beam.'
-         3_4913c6ed   0.997   . . 'Scanned through direct beam.'
-         4_4913c6ed   1.039   . . 'Scanned through direct beam.'
+         1_4913c6ed   1       'Scanned through direct beam.'
+         2_4913c6ed   0.973   'Scanned through direct beam.'
+         3_4913c6ed   0.997   'Scanned through direct beam.'
+         4_4913c6ed   1.039   'Scanned through direct beam.'
 ;
 ;
          A multi-detector system was scanned through the direct beam to

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2652,6 +2652,8 @@ save_PD_CALIB_DETECTED_INTENSITY
       _description_example.case
       _description_example.detail
 ;
+         _audit_dataset.id   cb6a263b-c573-4ec3-848e-cfa7e44f3ec6
+
          loop_
          _pd_calib_detected_intensity.detector_id
          _pd_calib_detected_intensity.detector_response
@@ -2688,6 +2690,27 @@ save_PD_CALIB_DETECTED_INTENSITY
          divided by the given response to obtain the actual value. No
          diffraction pattern or phase was involved in the derivation of the
          response values.
+;
+;
+        _audit_dataset.id   cb6a263b-c573-4ec3-848e-cfa7e44f3ec6
+        _pd_diffractogram.id   APATTERN
+
+         loop_
+         _pd_data.point_id
+         _pd_meas.detector_id
+         _pd_meas.2theta_scan
+         _pd_meas.intensity_total
+         1   A   10.00   1243.42(47)
+         2   B   10.01   1364.36(57)
+         3   A   10.02   1324.35(87)
+         4   B   10.03   1298.36(74)
+         #...
+;
+;
+         Given identical _audit_dataset.id values and detector IDs, the
+         detector responses of 1 and 1.035 for detectors A and B can be
+         applied to this diffractogram to give the processed intensities
+         ready for analysis.
 ;
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2621,7 +2621,7 @@ save_PD_CALIB_DETECTED_INTENSITY
     _definition.id                PD_CALIB_DETECTED_INTENSITY
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-01-21
+    _definition.update            2025-06-27
     _description.text
 ;
     This section defines the parameters used for the intensity calibration of
@@ -2646,11 +2646,7 @@ save_PD_CALIB_DETECTED_INTENSITY
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_CALIB_DETECTED_INTENSITY
-
-    loop_
-      _category_key.name
-         '_pd_calib_detected_intensity.detector_id'
-         '_pd_calib_detected_intensity.id'
+    _category_key.name            '_pd_calib_detected_intensity.detector_id'
 
 save_
 
@@ -2741,24 +2737,6 @@ save_pd_calib_detected_intensity.diffractogram_id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-
-save_
-
-save_pd_calib_detected_intensity.id
-
-    _definition.id                '_pd_calib_detected_intensity.id'
-    _definition.update            2023-01-21
-    _description.text
-;
-    A code to uniquely identify each intensity calibration.
-;
-    _name.category_id             pd_calib_detected_intensity
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _enumeration.default          .
 
 save_
 
@@ -13510,4 +13488,7 @@ save_
        information about the wavelength.
 
        Added _pd_meas_overall.step_count_time.
+
+       Removed _pd_calib_detected_intensity.id as data item and category key
+       of PD_CALIB_DETECTED_INTENSITY.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2660,8 +2660,8 @@ save_PD_CALIB_DETECTED_INTENSITY
          _pd_calib_detected_intensity.detector_response_su
          _pd_calib_detected_intensity.diffractogram_id
          _pd_calib_detected_intensity.phase_id
-         A   1       .       DIFFRACTOGRAM_A   676A
-         B   1.035   0.013   DIFFRACTOGRAM_B   676A
+         A   1        .        DIFFRACTOGRAM_A   676A
+         B   1.0350   0.0006   DIFFRACTOGRAM_B   676A
 ;
 ;
          The two detectors, A and B, have responses of 1 and 1.035,
@@ -2700,17 +2700,17 @@ save_PD_CALIB_DETECTED_INTENSITY
          _pd_meas.detector_id
          _pd_meas.2theta_scan
          _pd_meas.intensity_total
-         1   A   10.00   1243.42(47)
-         2   B   10.01   1364.36(57)
-         3   A   10.02   1324.35(87)
-         4   B   10.03   1298.36(74)
+         _pd_proc.intensity_total
+         1   A   10.00   1243.42(47)   1243.42(47)
+         2   B   10.01   1364.36(57)   1318.22(94)
+         3   A   10.02   1324.35(87)   1324.35(87)
+         4   B   10.03   1298.36(74)   1254.45(102)
          #...
 ;
 ;
-         Given identical _audit_dataset.id values and detector IDs, the
-         detector responses of 1 and 1.035 for detectors A and B can be
-         applied to diffractogram APATTERN to give the processed intensities
-         ready for analysis.
+         The detector responses of 1 and 1.035 for detectors A and B given
+         in the first example have been applied to the raw measurements of
+         APATTERN to give processed intensities ready for analysis.
 ;
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2648,6 +2648,48 @@ save_PD_CALIB_DETECTED_INTENSITY
     _name.object_id               PD_CALIB_DETECTED_INTENSITY
     _category_key.name            '_pd_calib_detected_intensity.detector_id'
 
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _pd_calib_detected_intensity.detector_id
+         _pd_calib_detected_intensity.detector_response
+         _pd_calib_detected_intensity.detector_response_su
+         _pd_calib_detected_intensity.diffractogram_id
+         _pd_calib_detected_intensity.phase_id
+         A   1       .       DIFFRACTOGRAM_A   676A
+         B   1.035   0.013   DIFFRACTOGRAM_B   676A
+;
+;
+         The two detectors, A and B, have responses of 1 and 1.035,
+         respectively, meaning that their measured intensities must be divided
+         by these values to retreive their true values. These response values
+         were derived from an analysis of the diffraction patterns
+         DIFFRACTOGRAM_A and DIFFRACTOGRAM_A, both of which contain the phase
+         676A.
+;
+;
+         loop_
+         _pd_calib_detected_intensity.detector_id
+         _pd_calib_detected_intensity.detector_response
+         _pd_calib_detected_intensity.diffractogram_id
+         _pd_calib_detected_intensity.phase_id
+         _pd_calib_detected_intensity.special_details
+         1_4913c6ed   1       . . 'Scanned through direct beam.'
+         2_4913c6ed   0.973   . . 'Scanned through direct beam.'
+         3_4913c6ed   0.997   . . 'Scanned through direct beam.'
+         4_4913c6ed   1.039   . . 'Scanned through direct beam.'
+;
+;
+         A multi-detector system was scanned through the direct beam to
+         calibrate the response of each detector to a constant-intensity
+         source. The measured intensity derived from each detector must be
+         divided by the given response to obtain the actual value. No
+         diffraction pattern or phase was involved in the derivation of the
+         response values.
+;
+
 save_
 
 save_pd_calib_detected_intensity.detector_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2656,11 +2656,8 @@ save_pd_calib_detected_intensity.detector_id
     _definition.update            2023-06-09
     _description.text
 ;
-    A code which identifies the detector or channel number in a
-    position-sensitive, energy-dispersive or other multiple-detector
-    instrument for which the individual instrument geometry is being
-    defined. This code should match the code name used for
-    _pd_instr_detector.id.
+    A code which identifies the detector to which the response is being defined.
+    This code should match the code name used for _pd_instr_detector.id.
 ;
     _name.category_id             pd_calib_detected_intensity
     _name.object_id               detector_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -2668,7 +2668,7 @@ save_PD_CALIB_DETECTED_INTENSITY
          respectively, meaning that their measured intensities must be divided
          by these values to retreive their true values. These response values
          were derived from an analysis of the diffraction patterns
-         DIFFRACTOGRAM_A and DIFFRACTOGRAM_A, both of which contain the phase
+         DIFFRACTOGRAM_A and DIFFRACTOGRAM_B, both of which contain the phase
          676A.
 ;
 ;
@@ -2709,7 +2709,7 @@ save_PD_CALIB_DETECTED_INTENSITY
 ;
          Given identical _audit_dataset.id values and detector IDs, the
          detector responses of 1 and 1.035 for detectors A and B can be
-         applied to this diffractogram to give the processed intensities
+         applied to diffractogram APATTERN to give the processed intensities
          ready for analysis.
 ;
 


### PR DESCRIPTION
This is a category for the overall intensity calibration of a detector. 1 value per detector, so makes no sense to be also keyed on an opaque ID.