### PR TITLE
Move looped PO items that should be Set

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -10550,7 +10550,6 @@ save_pd_pref_orient.geom
          strans                   'Symmetric transmission.'
          atrans                   'Asymmetric transmission.'
          cap                      'Capillary (Debye-Scherrer).'
-    _enumeration.default          srefln
 
 save_
 


### PR DESCRIPTION
Will close #247 

The POSH texture index is a single value derived from all the loop values, and so should be in a set cateegory

The POSH and POMD geom value is also a single value covering all the looped values. Also, no need to have two, when one would suffice.