### PR TITLE
Return imgCIF to checking workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,12 @@ jobs:
           repository: COMCIFS/MultiBlock_Dictionary
           path: cif-dictionaries/MultiBlock_Dictionary
 
+      - name: Checkout DDLm imgCIF dictionary
+        uses: actions/checkout@v4
+        with:
+            repository: COMCIFS/imgCIF
+            path: cif-dictionaries/imgCIF
+            
       - name: check_ddlm
         uses: COMCIFS/dictionary_check_action@main
         id: ddlm_check

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -44,7 +44,7 @@ save_PD_GROUP
     _import.get
         [
           {
-           'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':HEAD
+           'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':CIF_IMG_HEAD
           }
           {
            'dupl':Ignore  'file':multi_block_core.dic  'mode':Full

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,7 +14,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2025-08-04
+    _dictionary.date              2025-09-17
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -32,7 +32,7 @@ save_PD_GROUP
     _definition.id                PD_GROUP
     _definition.scope             Category
     _definition.class             Head
-    _definition.update            2024-12-13
+    _definition.update            2025-09-17
     _description.text
 ;
     Groups all of the categories of definitions in the powder
@@ -6908,7 +6908,7 @@ save_pd_diffractogram.scan_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -8730,7 +8730,7 @@ save_pd_instr_detector.diffrn_detector_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -14683,4 +14683,7 @@ save_
        and _pd_pref_orient_spherical_harmonics.geom to _pd_pref_orient.geom.
 
        Added _structure.phase_id.
+
+       Fixed imgCIF import head category name. Corrected types of
+       links to _diffrn_scan.id and _diffrn_detector.id.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14441,7 +14441,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2025-08-04
+         2.5.0                    2025-09-17
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
Now that imgCIF [has been updated to conform to DDLm style](https://github.com/COMCIFS/imgCIF/pull/17) we can return it to the checking workflow. As well as returning imgCIF to the workflow, the present PR: corrects dates; fixes two types that did not match imgCIF; and fixes the imgCIF head category name.

The one remaining error should be the single imgCIF data name that uses `_esd` in a SU data name, as do all such mmCIF data names.