### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     needs: syntax
 
     env:
-        JULIA_VERSION: '1.9'
+        JULIA_VERSION: '1.10'
         JULIA_DEP_FILE: 'julia_cif_tools/Project.toml'
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,34 +90,38 @@ jobs:
     runs-on: ubuntu-latest
     needs: syntax
 
-    steps:
-      - name: Get the cache
-        uses: actions/cache@v5
-        id: cache
-        with:
-          path: ~/.julia
-          key: ${{ runner.os }}-julia-v2
+    env:
+        JULIA_VERSION: '1.9'
+        JULIA_DEP_FILE: 'julia_cif_tools/Project.toml'
 
+    steps:
       - name: Install Julia
         uses: julia-actions/setup-julia@v3
         with:
-          version: '1.9'
-
-      - name: Install Julia packages
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("ArgParse")'
-
-      - name: Check out the target repository
-        uses: actions/checkout@v6
-        with:
-          path: main
+          version: ${{ env.JULIA_VERSION }}
 
       - name: Check out Julia tools
         uses: actions/checkout@v6
         with:
           repository: jamesrhester/julia_cif_tools
           path: julia_cif_tools
+    
+      - name: Get the cache
+        uses: actions/cache@v5
+        id: cache
+        with:
+          path: ~/.julia
+          key: ${{ runner.os }}-julia-${{ env.JULIA_VERSION }}-${{ hashFiles(env.JULIA_DEP_FILE) }}
+
+      - name: Install Julia packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          julia -e 'using Pkg, TOML; map(Pkg.add, collect(keys(TOML.parsefile("${{ env.JULIA_DEP_FILE }}")["deps"]))); Pkg.instantiate()'
+
+      - name: Check out the target repository
+        uses: actions/checkout@v6
+        with:
+          path: main
 
       - name: Check out the DDLm reference dictionary
         uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout
+      - name: Check out the target repository
         uses: actions/checkout@v6
 
       # Check syntax of all CIF files
@@ -42,40 +42,40 @@ jobs:
     needs: syntax
 
     steps:
-      - name: Checkout
+      - name: Check out the target repository
         uses: actions/checkout@v6
 
-      - name: Checkout the DDLm reference dictionary
+      - name: Check out the DDLm reference dictionary
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/DDLm
           path: cif-dictionaries/DDLm
 
-      - name: Checkout enumeration templates
+      - name: Check out enumeration templates
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/Enumeration_Templates
           path: cif-dictionaries/Enumeration_Templates
 
-      - name: Checkout attribute templates
+      - name: Check out attribute templates
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/Attribute_Templates
           path: cif-dictionaries/Attribute_Templates
 
-      - name: Checkout the coreCIF dictionary
+      - name: Check out the coreCIF dictionary
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/cif_core
           path: cif-dictionaries/cif_core
 
-      - name: Checkout the multiblock coreCIF dictionary
+      - name: Check out the multiblock coreCIF dictionary
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/cif_multiblock
           path: cif-dictionaries/cif_multiblock
 
-      - name: Checkout the DDLm imgCIF dictionary
+      - name: Check out the DDLm imgCIF dictionary
         uses: actions/checkout@v6
         with:
             repository: COMCIFS/imgCIF
@@ -108,36 +108,36 @@ jobs:
         run: |
           julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("ArgParse")'
 
-      - name: Checkout
+      - name: Check out the target repository
         uses: actions/checkout@v6
         with:
           path: main
 
-      - name: Checkout julia tools
+      - name: Check out Julia tools
         uses: actions/checkout@v6
         with:
           repository: jamesrhester/julia_cif_tools
           path: julia_cif_tools
 
-      - name: Checkout the DDLm reference dictionary
+      - name: Check out the DDLm reference dictionary
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/DDLm
           path: DDLm
 
-      - name: Checkout enumeration templates
+      - name: Check out enumeration templates
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/Enumeration_Templates
           path: enum
 
-      - name: Checkout attribute templates
+      - name: Check out attribute templates
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/Attribute_Templates
           path: templ
 
-      - name: Checkout the coreCIF dictionary
+      - name: Check out the coreCIF dictionary
         uses: actions/checkout@v6
         with:
           repository: COMCIFS/cif_core

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Check syntax of all CIF files
       - name: Check CIF syntax
@@ -43,40 +43,40 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout the DDLm reference dictionary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/DDLm
           path: cif-dictionaries/DDLm
 
       - name: Checkout enumeration templates
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/Enumeration_Templates
           path: cif-dictionaries/Enumeration_Templates
 
       - name: Checkout attribute templates
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/Attribute_Templates
           path: cif-dictionaries/Attribute_Templates
 
       - name: Checkout the coreCIF dictionary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/cif_core
           path: cif-dictionaries/cif_core
 
       - name: Checkout the multiblock coreCIF dictionary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/cif_multiblock
           path: cif-dictionaries/cif_multiblock
 
       - name: Checkout the DDLm imgCIF dictionary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
             repository: COMCIFS/imgCIF
             path: cif-dictionaries/imgCIF
@@ -92,14 +92,14 @@ jobs:
 
     steps:
       - name: Get the cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: ~/.julia
           key: ${{ runner.os }}-julia-v2
 
       - name: Install Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v3
         with:
           version: '1.9'
 
@@ -109,36 +109,36 @@ jobs:
           julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("ArgParse")'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: main
 
       - name: Checkout julia tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: jamesrhester/julia_cif_tools
           path: julia_cif_tools
 
       - name: Checkout the DDLm reference dictionary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/DDLm
           path: DDLm
 
       - name: Checkout enumeration templates
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/Enumeration_Templates
           path: enum
 
       - name: Checkout attribute templates
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/Attribute_Templates
           path: templ
 
       - name: Checkout the coreCIF dictionary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: COMCIFS/cif_core
           path: cif_core

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -15,7 +15,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2026-03-02
+    _dictionary.date              2026-04-27
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -14443,7 +14443,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-03-02
+         2.5.0                    2026-04-27
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
The actions were update to no longer depend on the now deprecated Node20.

Furthermore, the Julia caching system was updated to depend on the combination of the Julia version number and the hash of the dependency file.