### PR TITLE
switch IMGCIF and MULTI_BLOCK import order

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8720,7 +8720,7 @@ save_
 save_pd_instr_detector.diffrn_detector_id
 
     _definition.id                '_pd_instr_detector.diffrn_detector_id'
-    _definition.update            2025-06-26
+    _definition.update            2026-05-02
     _description.text
 ;
     Identifier of a detector used for data collection described using data names
@@ -8732,7 +8732,7 @@ save_pd_instr_detector.diffrn_detector_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
 
 save_
 
@@ -14698,5 +14698,8 @@ save_
        MULTIBLOCK_CORE is first. This changes the order in which categories
        are defined so that CIF_IMG_HEAD cannot block definitions in
        MULTIBLOCK_CORE.
+
+       Updated type contents of _pd_instr_detector.diffrn_detector_id
+       to match linked data item.
 
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -15,7 +15,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2026-04-30
+    _dictionary.date              2026-05-02
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -34,7 +34,7 @@ save_PD_GROUP
     _definition.id                PD_GROUP
     _definition.scope             Category
     _definition.class             Head
-    _definition.update            2025-09-23
+    _definition.update            2026-05-02
     _description.text
 ;
     Groups all of the categories of definitions in the powder
@@ -46,11 +46,11 @@ save_PD_GROUP
     _import.get
         [
           {
-           'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':CIF_IMG_HEAD
-          }
-          {
            'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
            'save':MULTIBLOCK_CORE
+          }
+          {
+           'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':CIF_IMG_HEAD
           }
         ]
 
@@ -14443,7 +14443,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-04-30
+         2.5.0                    2026-05-02
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -14693,4 +14693,10 @@ save_
 
        Changed the _name.object_id attribute of _pd_instr.beam_size_ax and
        _pd_instr.beam_size_eq.
+
+       Changed import order of MULTIBLOCK_CORE and CIF_IMG_HEAD such that
+       MULTIBLOCK_CORE is first. This changes the order in which categories
+       are defined so that CIF_IMG_HEAD cannot block definitions in
+       MULTIBLOCK_CORE.
+
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8732,7 +8732,7 @@ save_pd_instr_detector.diffrn_detector_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -8720,7 +8720,7 @@ save_
 save_pd_instr_detector.diffrn_detector_id
 
     _definition.id                '_pd_instr_detector.diffrn_detector_id'
-    _definition.update            2026-05-02
+    _definition.update            2025-06-26
     _description.text
 ;
     Identifier of a detector used for data collection described using data names
@@ -14698,8 +14698,4 @@ save_
        MULTIBLOCK_CORE is first. This changes the order in which categories
        are defined so that CIF_IMG_HEAD cannot block definitions in
        MULTIBLOCK_CORE.
-
-       Updated type contents of _pd_instr_detector.diffrn_detector_id
-       to match linked data item.
-
 ;


### PR DESCRIPTION
see (3) in https://github.com/COMCIFS/cif_multiblock/issues/42#issuecomment-4294003919 and https://github.com/COMCIFS/cif_multiblock/pull/43#event-25023284185

Order change ensures that MULTIBLOCK is defined before CIFIMG, making sure that CIFIMG doesn't override anything in MULTI