### PR TITLE
Update multiblock coreCIF dictionary details

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Check out the multiblock coreCIF dictionary
         uses: actions/checkout@v6
         with:
-          repository: COMCIFS/cif_multiblock
-          path: cif-dictionaries/cif_multiblock
+          repository: COMCIFS/cif_core_multiblock
+          path: cif-dictionaries/cif_core_multiblock
 
       - name: Check out the DDLm imgCIF dictionary
         uses: actions/checkout@v6

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -15,7 +15,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2026-05-19
+    _dictionary.date              2026-06-18
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -34,7 +34,7 @@ save_PD_GROUP
     _definition.id                PD_GROUP
     _definition.scope             Category
     _definition.class             Head
-    _definition.update            2026-05-02
+    _definition.update            2026-06-18
     _description.text
 ;
     Groups all of the categories of definitions in the powder
@@ -46,8 +46,8 @@ save_PD_GROUP
     _import.get
         [
           {
-           'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
-           'save':MULTIBLOCK_CORE
+           'dupl':Ignore  'file':cif_core_multiblock.dic  'mode':Full
+           'save':CIF_CORE_MULTIBLOCK_HEAD
           }
           {
            'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':CIF_IMG_HEAD
@@ -14487,7 +14487,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-05-19
+         2.5.0                    2026-06-18
 ;
        ## Retain above version number and increment date until final
        ## release


### PR DESCRIPTION
Note, that GitHub actions might still report failure to import multiblock coreCIF until the imgCIF dictionary is updated accordingly (see issue https://github.com/COMCIFS/imgCIF/issues/27).