### PR TITLE
Change key: pd_qpa_external_std

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6129,8 +6129,8 @@ save_PD_PROC
 
     loop_
       _category_key.name
-         '_pd_proc.point_id'
          '_pd_proc.diffractogram_id'
+         '_pd_proc.point_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14345,9 +14345,9 @@ save_REFLN
 
     loop_
       _category_key.name
-         '_refln.diffractogram_id'
          '_refln.id'
          '_pd_refln.phase_id'
+         '_refln.diffractogram_id'
          '_refln.structure_id'
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6132,8 +6132,8 @@ save_PD_PROC
 
     loop_
       _category_key.name
-         '_pd_proc.diffractogram_id'
          '_pd_proc.point_id'
+         '_pd_proc.diffractogram_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -15,7 +15,7 @@ data_CIF_POW
     _dictionary.title             CIF_POW
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2026-06-18
+    _dictionary.date              2026-06-24
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
     _dictionary.ddl_conformance   4.2.0
@@ -13039,7 +13039,7 @@ save_PD_QPA_EXTERNAL_STD
     _definition.id                PD_QPA_EXTERNAL_STD
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-06-20
+    _definition.update            2026-06-24
     _description.text
 ;
     This category identifies the external diffractogram used for
@@ -13057,12 +13057,13 @@ save_PD_QPA_EXTERNAL_STD
 ;
     _name.category_id             PD_GROUP
     _name.object_id               PD_QPA_EXTERNAL_STD
-    _category_key.name            '_pd_qpa_external_std.diffractogram_id'
+    _category_key.name            '_pd_qpa_external_std.instr_id'
 
     _description_example.case
 ;
          data_ext_std_diffractogram
             _audit.schema                Custom
+            _pd_instr.id                 labmachine
             _pd_diffractogram.id         THE_REFERENCE
             _pd_diffractogram.instr_id   labmachine
             _pd_diffractogram.spec_id    REF_spec
@@ -13080,12 +13081,14 @@ save_PD_QPA_EXTERNAL_STD
             NIST_ALUMINA_676A   99.02   1.11
 
             _pd_qpa_external_std.k_factor           293.36
+            _pd_qpa_external_std.diffractogram_id   THE_REFERENCE
             _pd_char.mass_atten_coef_mu_calc        3159
             _pd_qpa_overall.method                  external_standard
 
 
          data_diffractogram_block
             _audit.schema                Custom
+            _pd_instr.id                 labmachine
             _pd_diffractogram.id         DIFFRACTOGRAM_2
             _pd_diffractogram.instr_id   labmachine
             _pd_diffractogram.spec_id    UNK_spec
@@ -13095,7 +13098,6 @@ save_PD_QPA_EXTERNAL_STD
             _pd_prep.char_id  UNK_char
             _pd_spec.id       UNK_spec
             _pd_spec.prep_id  UNK_prep
-
 
             loop_
             _pd_phase_mass.phase_id
@@ -13111,17 +13113,15 @@ save_PD_QPA_EXTERNAL_STD
 ;
          In the first block, the K factor, or diffractometer constant, is
          calculated from a diffraction pattern of a previously characterised
-         standard, collected under set conditions; see the
-         _pd_qpa_overall.method enumeration external_standard.
+         standard, collected under set conditions on the given instrument; see
+         the _pd_qpa_overall.method enumeration external_standard.
 
          In the second block, a diffraction pattern containing two phases
          (PHASE_1 and PHASE_2) has been quantified using the external standard
          algorithm after Rietveld refinement. Knowing the instrument id value
          used to collect the diffractogram of the unknown, the
-         _pd_qpa_external_std.diffractogram_id values can be looked at to find
-         one that has the same instrument id value, and thus the
-         _pd_qpa_external_std.k_factor value can be used to calculate the
-         absolute mass percent of the phases present in the
+         _pd_qpa_external_std.k_factor value can be looked up directly and used
+         to calculate the absolute mass percent of the phases present in the
          diffractogram.
 
          A Custom _audit.schema is required due to looping _pd_phase.id values.
@@ -13141,6 +13141,24 @@ save_pd_qpa_external_std.diffractogram_id
     _name.category_id             pd_qpa_external_std
     _name.object_id               diffractogram_id
     _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_external_std.instr_id
+
+    _definition.id                '_pd_qpa_external_std.instr_id'
+    _definition.update            2026-06-24
+    _description.text
+;
+    The instrument (see _pd_instr.id) to which the external standard relates.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               instr_id
+    _name.linked_item_id          '_pd_instr.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -14563,7 +14581,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-06-18
+         2.5.0                    2026-06-24
 ;
        ## Retain above version number and increment date until final
        ## release

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -160,9 +160,9 @@ save_CHEMICAL_CONN_BOND
 
     loop_
       _category_key.name
+         '_chemical_conn_bond.phase_id'
          '_chemical_conn_bond.atom_1'
          '_chemical_conn_bond.atom_2'
-         '_chemical_conn_bond.phase_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5049,8 +5049,8 @@ save_PD_CALC
 
     loop_
       _category_key.name
-         '_pd_calc.diffractogram_id'
          '_pd_calc.point_id'
+         '_pd_calc.diffractogram_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3474,7 +3474,7 @@ save_PD_CALIB_XCOORD
     _definition.id                PD_CALIB_XCOORD
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-24
+    _definition.update            2025-06-19
     _description.text
 ;
     This category allows for the calibration of various X-coordinate axes
@@ -3518,8 +3518,8 @@ save_PD_CALIB_XCOORD
 
     loop_
       _category_key.name
-         '_pd_calib_xcoord.detector_id'
          '_pd_calib_xcoord.id'
+         '_pd_calib_xcoord.xcoord_overall_id'
 
     loop_
       _description_example.case
@@ -3535,24 +3535,22 @@ save_PD_CALIB_XCOORD
              _pd_calib_xcoord.id
              _pd_calib_xcoord.nominal_2theta
              _pd_calib_xcoord.actual_2theta
-             _pd_calib_xcoord.detector_id
-              a   10.01   10.011  A
-              b   10.03   10.032  A
-              c   10.05   10.053  A
-              d   10.07   10.074  A
+              a   10.01   10.011
+              b   10.03   10.032
+              c   10.05   10.053
+              d   10.07   10.074
               # ...
 
              loop_
              _pd_data.point_id
              _pd_meas.2theta_scan
-             _pd_meas.detector_id
              _pd_proc.2theta_corrected
              _pd_meas.counts_total
              _pd_calc.intensity_total
-             1   10.01  A  10.011  1234    1234.1
-             2   10.03  A  10.033  1235    1235.3
-             3   10.05  A  10.055  1352    1236.5
-             4   10.07  A  10.077  1324    1237.7
+             1   10.01   10.011  1234    1234.1
+             2   10.03   10.033  1235    1235.3
+             3   10.05   10.055  1352    1236.5
+             4   10.07   10.077  1324    1237.7
              # ...
 
          data_unknownsample
@@ -3564,11 +3562,10 @@ save_PD_CALIB_XCOORD
              _pd_meas.2theta_scan
              _pd_proc.2theta_corrected
              _pd_meas.counts_total
-             _pd_meas.detector_id
-             A   10.02   10.022  3134  A
-             B   10.04   10.044  3335  A
-             C   10.06   10.066  3452  A
-             D   10.08   10.088  3324  A
+             A   10.02   10.022  3134
+             B   10.04   10.044  3335
+             C   10.06   10.066  3452
+             D   10.08   10.088  3324
              # ...
 ;
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1967,8 +1967,8 @@ save_PD_CALC_COMPONENT
     loop_
       _category_key.name
          '_pd_calc_component.diffractogram_id'
-         '_pd_calc_component.point_id'
          '_pd_calc_component.phase_id'
+         '_pd_calc_component.point_id'
 
     _description_example.case
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4865,8 +4865,8 @@ save_PD_DATA
 
     loop_
       _category_key.name
-         '_pd_data.diffractogram_id'
          '_pd_data.point_id'
+         '_pd_data.diffractogram_id'
 
     loop_
       _description_example.case

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3474,7 +3474,7 @@ save_PD_CALIB_XCOORD
     _definition.id                PD_CALIB_XCOORD
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-19
+    _definition.update            2026-06-24
     _description.text
 ;
     This category allows for the calibration of various X-coordinate axes
@@ -3518,8 +3518,8 @@ save_PD_CALIB_XCOORD
 
     loop_
       _category_key.name
+         '_pd_calib_xcoord.detector_id'
          '_pd_calib_xcoord.id'
-         '_pd_calib_xcoord.xcoord_overall_id'
 
     loop_
       _description_example.case
@@ -3535,22 +3535,24 @@ save_PD_CALIB_XCOORD
              _pd_calib_xcoord.id
              _pd_calib_xcoord.nominal_2theta
              _pd_calib_xcoord.actual_2theta
-              a   10.01   10.011
-              b   10.03   10.032
-              c   10.05   10.053
-              d   10.07   10.074
+             _pd_calib_xcoord.detector_id
+              a   10.01   10.011  A
+              b   10.03   10.032  A
+              c   10.05   10.053  A
+              d   10.07   10.074  A
               # ...
 
              loop_
              _pd_data.point_id
              _pd_meas.2theta_scan
+             _pd_meas.detector_id
              _pd_proc.2theta_corrected
              _pd_meas.counts_total
              _pd_calc.intensity_total
-             1   10.01   10.011  1234    1234.1
-             2   10.03   10.033  1235    1235.3
-             3   10.05   10.055  1352    1236.5
-             4   10.07   10.077  1324    1237.7
+             1   10.01  A  10.011  1234    1234.1
+             2   10.03  A  10.033  1235    1235.3
+             3   10.05  A  10.055  1352    1236.5
+             4   10.07  A  10.077  1324    1237.7
              # ...
 
          data_unknownsample
@@ -3562,10 +3564,11 @@ save_PD_CALIB_XCOORD
              _pd_meas.2theta_scan
              _pd_proc.2theta_corrected
              _pd_meas.counts_total
-             A   10.02   10.022  3134
-             B   10.04   10.044  3335
-             C   10.06   10.066  3452
-             D   10.08   10.088  3324
+             _pd_meas.detector_id
+             A   10.02   10.022  3134  A
+             B   10.04   10.044  3335  A
+             C   10.06   10.066  3452  A
+             D   10.08   10.088  3324  A
              # ...
 ;
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -347,8 +347,8 @@ save_PD_AMORPHOUS
 
     loop_
       _category_key.name
-         '_pd_amorphous.peak_id'
          '_pd_amorphous.diffractogram_id'
+         '_pd_amorphous.peak_id'
 
     _description_example.case
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5049,8 +5049,8 @@ save_PD_CALC
 
     loop_
       _category_key.name
-         '_pd_calc.point_id'
          '_pd_calc.diffractogram_id'
+         '_pd_calc.point_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3131,8 +3131,8 @@ save_PD_CALIB_OFFSET
 
     loop_
       _category_key.name
-         '_pd_calib_offset.id'
          '_pd_calib_offset.detector_id'
+         '_pd_calib_offset.id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5334,8 +5334,8 @@ save_PD_MEAS
 
     loop_
       _category_key.name
-         '_pd_meas.diffractogram_id'
          '_pd_meas.point_id'
+         '_pd_meas.diffractogram_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -4862,8 +4862,8 @@ save_PD_DATA
 
     loop_
       _category_key.name
-         '_pd_data.point_id'
          '_pd_data.diffractogram_id'
+         '_pd_data.point_id'
 
     loop_
       _description_example.case

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -3131,8 +3131,8 @@ save_PD_CALIB_OFFSET
 
     loop_
       _category_key.name
-         '_pd_calib_offset.detector_id'
          '_pd_calib_offset.id'
+         '_pd_calib_offset.detector_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -5331,8 +5331,8 @@ save_PD_MEAS
 
     loop_
       _category_key.name
-         '_pd_meas.point_id'
          '_pd_meas.diffractogram_id'
+         '_pd_meas.point_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -347,8 +347,8 @@ save_PD_AMORPHOUS
 
     loop_
       _category_key.name
-         '_pd_amorphous.diffractogram_id'
          '_pd_amorphous.peak_id'
+         '_pd_amorphous.diffractogram_id'
 
     _description_example.case
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -13062,8 +13062,16 @@ save_PD_QPA_EXTERNAL_STD
     _description_example.case
 ;
          data_ext_std_diffractogram
+            _audit.schema                Custom
             _pd_diffractogram.id         THE_REFERENCE
             _pd_diffractogram.instr_id   labmachine
+            _pd_diffractogram.spec_id    REF_spec
+
+            _pd_char.id       REF_char
+            _pd_prep.id       REF_prep
+            _pd_prep.char_id  REF_char
+            _pd_spec.id       REF_spec
+            _pd_spec.prep_id  REF_prep
 
             loop_
             _pd_phase_mass.phase_id
@@ -13075,10 +13083,19 @@ save_PD_QPA_EXTERNAL_STD
             _pd_char.mass_atten_coef_mu_calc        3159
             _pd_qpa_overall.method                  external_standard
 
+
          data_diffractogram_block
             _audit.schema                Custom
             _pd_diffractogram.id         DIFFRACTOGRAM_2
             _pd_diffractogram.instr_id   labmachine
+            _pd_diffractogram.spec_id    UNK_spec
+
+            _pd_char.id       UNK_char
+            _pd_prep.id       UNK_prep
+            _pd_prep.char_id  UNK_char
+            _pd_spec.id       UNK_spec
+            _pd_spec.prep_id  UNK_prep
+
 
             loop_
             _pd_phase_mass.phase_id
@@ -13118,8 +13135,8 @@ save_pd_qpa_external_std.diffractogram_id
     _definition.update            2023-01-15
     _description.text
 ;
-    The diffractogram (see _pd_diffractogram.id) which is being used to
-    calculate the diffractometer constant.
+    The diffractogram (see _pd_diffractogram.id) used to calculate the
+    diffractometer constant.
 ;
     _name.category_id             pd_qpa_external_std
     _name.object_id               diffractogram_id

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -13085,7 +13085,6 @@ save_PD_QPA_EXTERNAL_STD
             _pd_char.mass_atten_coef_mu_calc        3159
             _pd_qpa_overall.method                  external_standard
 
-
          data_diffractogram_block
             _audit.schema                Custom
             _pd_instr.id                 labmachine

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1967,8 +1967,8 @@ save_PD_CALC_COMPONENT
     loop_
       _category_key.name
          '_pd_calc_component.diffractogram_id'
-         '_pd_calc_component.phase_id'
          '_pd_calc_component.point_id'
+         '_pd_calc_component.phase_id'
 
     _description_example.case
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -160,9 +160,9 @@ save_CHEMICAL_CONN_BOND
 
     loop_
       _category_key.name
-         '_chemical_conn_bond.phase_id'
          '_chemical_conn_bond.atom_1'
          '_chemical_conn_bond.atom_2'
+         '_chemical_conn_bond.phase_id'
 
 save_
 

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -13059,8 +13059,6 @@ save_PD_QPA_EXTERNAL_STD
     _description_example.case
 ;
          data_ext_std_diffractogram
-            _audit.schema                Custom
-            _pd_instr.id                 labmachine
             _pd_diffractogram.id         THE_REFERENCE
             _pd_diffractogram.instr_id   labmachine
             _pd_diffractogram.spec_id    REF_spec
@@ -13071,11 +13069,9 @@ save_PD_QPA_EXTERNAL_STD
             _pd_spec.id       REF_spec
             _pd_spec.prep_id  REF_prep
 
-            loop_
-            _pd_phase_mass.phase_id
-            _pd_phase_mass.absolute
-            _pd_phase_mass.absolute_su
-            NIST_ALUMINA_676A   99.02   1.11
+            _pd_phase.id  NIST_ALUMINA_676A
+            _pd_phase_mass.absolute     99.02
+            _pd_phase_mass.absolute_su   1.11
 
             _pd_qpa_external_std.k_factor           293.36
             _pd_qpa_external_std.diffractogram_id   THE_REFERENCE
@@ -13084,7 +13080,6 @@ save_PD_QPA_EXTERNAL_STD
 
          data_diffractogram_block
             _audit.schema                Custom
-            _pd_instr.id                 labmachine
             _pd_diffractogram.id         DIFFRACTOGRAM_2
             _pd_diffractogram.instr_id   labmachine
             _pd_diffractogram.spec_id    UNK_spec

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14308,9 +14308,9 @@ save_REFLN
 
     loop_
       _category_key.name
+         '_refln.diffractogram_id'
          '_refln.id'
          '_pd_refln.phase_id'
-         '_refln.diffractogram_id'
          '_refln.structure_id'
 
 save_


### PR DESCRIPTION
`pd_qpa_external_std` - originally keyed on `.diffractogram_id`. This was only used to get to the associated `.instr_id` value, so I decided to cut out the middleman and key it directly on `.instr_id`. This has the side-effect of requiring a new `_pd_instr.id` if a recalibration is required, but this was always implicitly there. `.diffractogram_id` demoted to linked, non-key data name. `.instr_id` added as category key. Updated the example to link the mass absorption coefficient of the specimen to the diffractogram though a `pd_char`, `pd_prep`, `pd_spec` chain.