### PR TITLE
update pd_meas.position descriptio

### DIFF
--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -6847,7 +6847,7 @@ save_PD_DIFFRACTOGRAM
             _pd_proc.intensity_total
             _pd_proc.ls_weight
             _pd_calc.intensity_total
-            _pd_proc.intensity_bkg_calc
+            _pd_calc.intensity_bkg
             5.01   43.364   0.0402   25.994961    25.994961
             5.04   38.007   0.0505   26.200290    26.200290
             5.07   38.318   0.0465   26.404083    26.404083
@@ -6904,7 +6904,7 @@ save_PD_DIFFRACTOGRAM
                _pd_proc.intensity_total
                _pd_proc.ls_weight
                _pd_calc.intensity_total
-               _pd_proc.intensity_bkg_calc
+               _pd_calc.intensity_bkg
                5.01   43.364   0.0402   25.994961    25.994961
                5.04   38.007   0.0505   26.200290    26.200290
                5.07   38.318   0.0465   26.404083    26.404083

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -5983,7 +5983,10 @@ save_pd_meas.position
     location where an intensity measurement is made.
     Used for detectors where a distance measurement is made
     as a direct observable, such as from a microdensitometer
-    trace from film or a strip chart recorder.
+    trace from film or a strip chart recorder. This is an
+    alternative to _pd_meas.2theta_scan, which should only be
+    used for instruments that record intensities directly
+    against 2θ.
 
     Calibration information, such as angle offsets or a
     function to convert this distance to a 2θ angle

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -15,7 +15,7 @@ data_CIF_PD
     _dictionary.title             CIF_PD
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2026-06-29
+    _dictionary.date              2026-07-05
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_pd/master/cif_pd.dic
     _dictionary.ddl_conformance   4.2.0
@@ -5976,23 +5976,19 @@ save_pd_meas.position
 
     _definition.id                '_pd_meas.position'
     _alias.definition_id          '_pd_meas_position'
-    _definition.update            2022-10-11
+    _definition.update            2026-07-05
     _description.text
 ;
     A linear distance in millimetres corresponding to the
     location where an intensity measurement is made.
     Used for detectors where a distance measurement is made
     as a direct observable, such as from a microdensitometer
-    trace from film or a strip chart recorder. This is an
-    alternative to _pd_meas.2theta_scan, which should only be
-    used for instruments that record intensities directly
-    against 2θ. For instruments where the position scale
-    is nonlinear, the data item _pd_meas.detector_id should
-    be used to record positions.
+    trace from film or a strip chart recorder.
 
     Calibration information, such as angle offsets or a
     function to convert this distance to a 2θ angle
-    or d-space, should be supplied with items from PD_CALIB.
+    or d-space, should be supplied with items from
+    PD_CALIB_XCOORD or PD_CALIBRATION.
 
     Do not confuse this with the instrument geometry
     descriptions given by _pd_instr.dist_*.
@@ -14543,7 +14539,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-06-29
+         2.5.0                    2026-07-05
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -14806,4 +14802,7 @@ save_
 
        Renamed dictionary from CIF_POW to CIF_PD and the head category from
        PD_GROUP to CIF_PD_HEAD.
+
+       Update description of _pd_meas.position to point to modern calibration
+       categories and to allow non-linear calibrations.
 ;

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -6843,7 +6843,7 @@ save_PD_DIFFRACTOGRAM
             _pd_proc.intensity_total
             _pd_proc.ls_weight
             _pd_calc.intensity_total
-            _pd_calc.intensity_bkg
+            _pd_proc.intensity_bkg_calc
             5.01   43.364   0.0402   25.994961    25.994961
             5.04   38.007   0.0505   26.200290    26.200290
             5.07   38.318   0.0465   26.404083    26.404083
@@ -6900,7 +6900,7 @@ save_PD_DIFFRACTOGRAM
                _pd_proc.intensity_total
                _pd_proc.ls_weight
                _pd_calc.intensity_total
-               _pd_calc.intensity_bkg
+               _pd_proc.intensity_bkg_calc
                5.01   43.364   0.0402   25.994961    25.994961
                5.04   38.007   0.0505   26.200290    26.200290
                5.07   38.318   0.0465   26.404083    26.404083


### PR DESCRIPTION
Removed reference to explicitly disallowing non-linear calibrations.
Updated calibration references to current categories.