### PR TITLE
PD_PREF_ORIENT corrections

### DIFF
--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -10744,8 +10744,8 @@ save_pd_pref_orient.geom
     The functional form of the March-Dollase or spherical harmonics
     correction depends on whether the data were collected in symmetric
     or asymmetric reflection or transmission, or capillary geometries.
-    See Section 3, Rowles & Buckley (2017) J. Appl. Cryst. (2017).
-    50, 240-251, for further discussion.
+    See Section 3, Rowles & Buckley (2017) J. Appl. Cryst. 50, 240-251,
+    for further discussion.
 
     In most Rietveld software, 'symmetric reflection' is the
     default implementation.

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -10699,11 +10699,9 @@ save_PD_PREF_ORIENT
     to a histogram.
 
     March-Dollase and spherical harmonics corrections can be given explicitly.
-    For other methods, use the _pd_pref_orient.special_details.
+    See PD_PREF_ORIENT_MARCH_DOLLASE and PD_PREF_ORIENT_SPHERICAL_HARMONICS.
 
-    See Dollase, W. A. (1986). J. Appl. Cryst. 19, 267-272 and
-    Jarvinen, M. (1993). J. Appl. Cryst. 26, 525-531 for
-    further information.
+    For other methods, use the _pd_pref_orient.special_details.
 ;
     _name.category_id             CIF_PD_HEAD
     _name.object_id               PD_PREF_ORIENT


### PR DESCRIPTION
Removed references from category description and added pointers to PD_PREF_ORIENT_MARCH_DOLLASE and PD_PREF_ORIENT_SPHERICAL_HARMONICS.

Corrected typo in _pd_pref_orient.geom description reference