### PR TITLE
PD_PROC_LS : updated description

### DIFF
--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -11921,7 +11921,7 @@ save_PD_PROC_LS
     _description.text
 ;
     This section is used to define parameters relevant to a
-    least-squares fit to a powder diffractogram, using a Rietveld
+    least-squares fit to a single powder diffractogram, using a Rietveld
     or other full-profile (e.g. Pawley or Le Bail methods) fit.
 
     Note that values in this section refer to full-pattern fitting.

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -11920,7 +11920,7 @@ save_PD_PROC_LS
     _definition.update            2025-06-19
     _description.text
 ;
-    This section is used to define parameters relevant to the 
+    This section is used to define parameters relevant to the
     least-squares fit to the powder diffractogram indicated
     by _pd_proc_ls.diffractogram_id, using a Rietveld
     or other full-profile (e.g. Pawley or Le Bail methods) fit.

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -11921,7 +11921,7 @@ save_PD_PROC_LS
     _description.text
 ;
     This section is used to define parameters relevant to a
-    least-squares fit to a single powder diffractogram, using a Rietveld
+    relevant to *the* least-squares fit to the powder diffractogram indicated by `_pd_proc_ls.diffractogram_id`, using a Rietveld
     or other full-profile (e.g. Pawley or Le Bail methods) fit.
 
     Note that values in this section refer to full-pattern fitting.

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -11920,11 +11920,15 @@ save_PD_PROC_LS
     _definition.update            2025-06-19
     _description.text
 ;
-    This section is used to define parameters relevant to a
-    relevant to *the* least-squares fit to the powder diffractogram indicated by `_pd_proc_ls.diffractogram_id`, using a Rietveld
+    This section is used to define parameters relevant to the 
+    least-squares fit to the powder diffractogram indicated
+    by _pd_proc_ls.diffractogram_id, using a Rietveld
     or other full-profile (e.g. Pawley or Le Bail methods) fit.
 
-    Note that values in this section refer to full-pattern fitting.
+    Note that values in this section refer to full-pattern fitting,
+    and are only valid when referring to, or calculated for, the
+    indicated powder diffractogram.
+
     Use the appropriate items for single-crystal analyses from the
     core CIF dictionary for structure refinements using diffraction
     intensities estimated from a powder diffractogram by

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -11929,8 +11929,8 @@ save_PD_PROC_LS
     core CIF dictionary for structure refinements using diffraction
     intensities estimated from a powder diffractogram by
     pattern-decomposition methods. Also note that many entries in
-    the core _refine_ls_ entries may also be useful (for example
-    _refine_ls_shift/su_*).
+    the core _refine_ls.* entries may also be useful (for example
+    _refine_ls.shift_over_su_*).
 ;
     _name.category_id             CIF_PD_HEAD
     _name.object_id               PD_PROC_LS


### PR DESCRIPTION
To emphasise that the r factors can only deal with one diffractogram at a time, as we have no concept of a "refinement" at the moment.

and to correct a DDL1 data name