### PR TITLE
Rejig (most) examples to remove requirement for _audit.schema Custom

### DIFF
--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -10513,7 +10513,8 @@ save_PD_PHASE_MASS
          associated with one diffractogram and three phases.
 
          Blocks containing information about more than one phase or
-         diffractogram must set a non-default value for _audit.schema.
+         diffractogram must set a non-default value for _audit.schema. If a
+         summary block is desired, this is the method.
 ;
 ;
          data_b1
@@ -10534,23 +10535,34 @@ save_PD_PHASE_MASS
 ;
          Identical as previous example, but values distributed amongst
          blocks so as to maintain the default value of _audit.schema.
+         This is the preferred methodology.
 ;
 ;
-         _audit.schema         Custom
-
+         data_b1
          _pd_diffractogram.id  ANOTHER_DIFFRACTOGRAM
+         _pd_phase.id          PHASE_1
+
+         _pd_phase_mass.percent   45.45
+         _pd_phase_mass.absolute  30.36
+         _pd_phase_mass.original  40.49
+
+         data_b2
+         _pd_diffractogram.id  ANOTHER_DIFFRACTOGRAM
+         _pd_phase.id          PHASE_2
 
          _pd_qpa_internal_std.mass_percent    25.000
-         _pd_qpa_internal_std.phase_id        PHASE_2
 
-         loop_
-         _pd_phase_mass.phase_id
-         _pd_phase_mass.percent
-         _pd_phase_mass.absolute
-         _pd_phase_mass.original
-         PHASE_1   45.45   30.36   40.49
-         PHASE_2   37.42   25.00    0
-         PHASE_3   17.13   11.44   15.26
+         _pd_phase_mass.percent   37.42
+         _pd_phase_mass.absolute  25.00
+         _pd_phase_mass.original   0
+
+         data_b3
+         _pd_diffractogram.id  ANOTHER_DIFFRACTOGRAM
+         _pd_phase.id          PHASE_3
+
+         _pd_phase_mass.percent   17.13
+         _pd_phase_mass.absolute  11.44
+         _pd_phase_mass.original  15.26
 ;
 ;
          Tabulation of quantitative phase analysis data.
@@ -10561,9 +10573,6 @@ save_PD_PHASE_MASS
          _pd_phase_mass.absolute. We can then calculate the original mass
          percentages, those present in the sample before adding the internal
          standard, given by _pd_phase_mass.original.
-
-         Blocks containing information about more than one phase or
-         diffractogram must set a non-default value for _audit.schema.
 ;
 
 save_

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -10630,31 +10630,20 @@ save_PD_PHASE_MASS
          This is the preferred methodology.
 ;
 ;
-         data_b1
+         data_all_results
+         _audit_schema         Custom
          _pd_diffractogram.id  ANOTHER_DIFFRACTOGRAM
-         _pd_phase.id          PHASE_1
-
-         _pd_phase_mass.percent   45.45
-         _pd_phase_mass.absolute  30.36
-         _pd_phase_mass.original  40.49
-
-         data_b2
-         _pd_diffractogram.id  ANOTHER_DIFFRACTOGRAM
-         _pd_phase.id          PHASE_2
 
          _pd_qpa_internal_std.mass_percent    25.000
 
-         _pd_phase_mass.percent   37.42
-         _pd_phase_mass.absolute  25.00
-         _pd_phase_mass.original   0
-
-         data_b3
-         _pd_diffractogram.id  ANOTHER_DIFFRACTOGRAM
-         _pd_phase.id          PHASE_3
-
-         _pd_phase_mass.percent   17.13
-         _pd_phase_mass.absolute  11.44
-         _pd_phase_mass.original  15.26
+         loop_
+         _pd_phase_mass.phase_id
+         _pd_phase_mass.percent
+         _pd_phase_mass.absolute
+         _pd_phase_mass.original
+         PHASE_1  45.45  30.36  40.49
+         PHASE_2  37.42  25.00   0
+         PHASE_3  17.13  11.44  15.26
 ;
 ;
          Tabulation of quantitative phase analysis data.

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -10163,13 +10163,16 @@ save_PD_PEAK_OVERALL
     _category_key.name            '_pd_peak_overall.id'
     _description_example.case
 ;
-         _pd_peak_overall.id        PEAK_GROUP_1
+         _pd_diffractogram.id   UNKNOWN_PEAKS
+
+         _pd_peak_overall.id    PEAK_GROUP_1
          _pd_peak.special_details
     ;
           Peak positions allowed to refine freely. Peak widths
           constrained to follow UVW relationship. Peak shape
           constrained to be Lorentzian.
     ;
+
          loop_
          _pd_peak.id
          _pd_peak.2theta_centroid

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -10997,32 +10997,36 @@ save_PD_PREF_ORIENT_MARCH_DOLLASE
       _description_example.case
       _description_example.detail
 ;
-         _audit.schema                Custom
+         data_p1
+         _pd_diffractogram.id  DIFFPAT_1
+         _pd_phase.id          PHASE_1
 
          loop_
          _pd_pref_orient_March_Dollase.id
-         _pd_pref_orient_March_Dollase.diffractogram_id
-         _pd_pref_orient_March_Dollase.phase_id
          _pd_pref_orient_March_Dollase.hkl
          _pd_pref_orient_March_Dollase.r
          _pd_pref_orient_March_Dollase.r_su
-         1   DIFFPAT_1   PHASE_1   [ 1 0 4 ]   0.79   0.12
-         2   DIFFPAT_1   PHASE_2   [ 0 0 1 ]   0.66   0.15
+         1   [ 1 0 4 ]   0.79   0.12
+
+         data_p2
+         _pd_diffractogram.id  DIFFPAT_1
+         _pd_phase.id          PHASE_2
+
+         _pd_pref_orient_March_Dollase.id   1
+         _pd_pref_orient_March_Dollase.hkl  [ 0 0 1 ]
+         _pd_pref_orient_March_Dollase.r    0.66(15)
 ;
 ;
-         Showing a fully qualified reporting of the preferred-orientation
-         corrections for a phase with a _pd_phase.id of 'PHASE_1' a phase
-         with a _pd_phase.id of 'PHASE_2', both belonging to a diffractogram
-         with a _pd_diffractogram.id of 'DIFFPAT_1.
+         Reporting the preferred-orientation corrections for phases PHASE_1
+         and PHASE_2, both from diffractogram DIFFPAT_1.
 
          The first phase has the preferred-orientation direction of 104, with a
          March r parameter value of 0.79 with a standard uncertainty of 0.12.
 
-         The second phase has the preferred-orientation direction of 001, with a
-         March r parameter value of 0.66 with a standard uncertainty of 0.15.
-
-         As information about more than one phase is present in the data block
-         _audit.schema takes a non-default value.
+         The second phase has the preferred-orientation direction of 001, with
+         a March r parameter value of 0.66 with a standard uncertainty of 0.15.
+         It is permissible to allocate values to Loop data names as if they
+         were Set data names if there is only a single row of data.
 ;
 ;
          _pd_diffractogram.id   DIFFPAT_A

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -2926,17 +2926,17 @@ save_PD_CALIB_INCIDENT_INTENSITY
         _pd_calib_incident_intensity.incident_intensity      453.3
         _pd_calib_incident_intensity.incident_intensity_su     1.6
         _pd_calib_incident_intensity.diffractogram_id        STANDARD_30ffb964
-        _pd_calib_incident_intensity.phase_id                SRM1796_15341c3a
+        _pd_calib_incident_intensity.phase_id                SRM1976_15341c3a
 ;
 ;
         In the instrument identified as 9deaa4f1, the intensity incident on the
         specimen is 453.3 ± 1.6. This was determined through an analysis of
         the diffractogram, STANDARD_30ffb964, which contains the phase,
-        SRM1796_15341c3a.
+        SRM1976_15341c3a.
 ;
 ;
-        _pd_instr.id           a3643812
-        _pd_diffractogram.id   WHITE_POWDER
+        _pd_diffractogram.id        WHITE_POWDER
+        _pd_diffractogram.instr_id  a3643812
 
         loop_
         _pd_data.point_id

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -6853,6 +6853,8 @@ save_PD_DIFFRACTOGRAM
       _description_example.case
       _description_example.detail
 ;
+         data_combined
+
          _diffrn.id                    highTemp
          _diffrn.ambient_temperature   1273
          _diffrn.ambient_pressure      101.3

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -4884,6 +4884,8 @@ save_PD_DATA
       _description_example.case
       _description_example.detail
 ;
+         _pd_diffractogram.id  histogram01
+
          loop_
          _pd_data.point_id
          _pd_meas.2theta_scan
@@ -4909,6 +4911,8 @@ save_PD_DATA
          with the data name _pd_diffractogram.id given in that data block.
 ;
 ;
+         _pd_diffractogram.id  pattern02
+
          loop_
          _pd_data.point_id
          _pd_meas.time_of_flight
@@ -4941,7 +4945,9 @@ save_PD_DATA
          with the data name _pd_diffractogram.id given in that data block.
 ;
 ;
-         loop_
+        _pd_diffractogram.id  diffractogram03
+
+        loop_
          _pd_data.point_id
          _pd_meas.2theta_scan
          _pd_proc.2theta_corrected
@@ -4968,6 +4974,8 @@ save_PD_DATA
          with the data name _pd_diffractogram.id given in that data block.
 ;
 ;
+         _pd_diffractogram.id  rawdata04
+
          loop_
          _pd_data.point_id
          _pd_meas.2theta_scan

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -2911,6 +2911,8 @@ save_PD_CALIB_INCIDENT_INTENSITY
       _description_example.case
       _description_example.detail
 ;
+        _audit_dataset.id   b007cf82-6338-4387-9abb-2825c6bf37b6
+
         _pd_calib_incident_intensity.instr_id           a3643812
         _pd_calib_incident_intensity.incident_counts    4231
         _pd_calib_incident_intensity.special_details    'From beam monitor.'
@@ -2935,6 +2937,8 @@ save_PD_CALIB_INCIDENT_INTENSITY
         SRM1976_15341c3a.
 ;
 ;
+        _audit_dataset.id   b007cf82-6338-4387-9abb-2825c6bf37b6
+
         _pd_diffractogram.id        WHITE_POWDER
         _pd_diffractogram.instr_id  a3643812
 
@@ -2957,6 +2961,9 @@ save_PD_CALIB_INCIDENT_INTENSITY
         the incident intensity calibration linked to that instrument.
         The SU values have also been calculated for the
         _pd_proc.intensity_total values.
+
+        Identical _audit_dataset.id value show that the identical
+        instrument id values must refer to the same instrument.
 ;
 
 save_

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -11326,43 +11326,60 @@ save_PD_PREF_ORIENT_SPHERICAL_HARMONICS
       _description_example.case
       _description_example.detail
 ;
-         _audit.schema          Custom
+         data_s1
+         _pd_diffractogram.id   DIFFPAT_A
+         _pd_phase.id           PHASE_A
 
          loop_
          _pd_pref_orient_spherical_harmonics.id
-         _pd_pref_orient_spherical_harmonics.phase_id
-         _pd_pref_orient_spherical_harmonics.diffractogram_id
          _pd_pref_orient_spherical_harmonics.y_ij
          _pd_pref_orient_spherical_harmonics.c_ij
          _pd_pref_orient_spherical_harmonics.c_ij_su
-         a   PHASE_A DIFFPAT_A   [0 0]   1.0     .
-         b   PHASE_A DIFFPAT_A   [2 0]   1.538   0.013
-         c   PHASE_B DIFFPAT_A   [0 0]   1.0     .
-         d   PHASE_B DIFFPAT_A   [4 1]  -0.066   0.010
-         e   PHASE_A DIFFPAT_B   [0 0]   1.0     .
-         f   PHASE_A DIFFPAT_B   [2 0]   1.630   0.014
-;
-;
-         Showing a fully qualified reporting of the preferred-orientation
-         corrections for phases with the _pd_phase.id of 'PHASE_A' and 'PHASE_B'
-         present in the diffractograms with the _pd_diffractogram.id of
-         'DIFFPAT_A' and 'DIFFPAT_B'.
+         a   [0 0]   1.0     .
+         b   [2 0]   1.538   0.013
 
-         In diffractogram 'DIFFPAT_A', both 'PHASE_A' and 'PHASE_B' have
+         data_s2
+         _pd_diffractogram.id   DIFFPAT_A
+         _pd_phase.id           PHASE_B
+
+         loop_
+         _pd_pref_orient_spherical_harmonics.id
+         _pd_pref_orient_spherical_harmonics.y_ij
+         _pd_pref_orient_spherical_harmonics.c_ij
+         I   [0 0]   1.0
+         II  [4 1]  -0.066(10)
+
+         data_s13
+         _pd_diffractogram.id   DIFFPAT_B
+         _pd_phase.id           PHASE_A
+
+         loop_
+         _pd_pref_orient_spherical_harmonics.id
+         _pd_pref_orient_spherical_harmonics.y_ij
+         _pd_pref_orient_spherical_harmonics.c_ij
+         _pd_pref_orient_spherical_harmonics.c_ij_su
+         q   [0 0]   1.0     .
+         w   [2 0]   1.630   0.014
+;
+;
+         Reporting the preferred-orientation corrections for phases PHASE_A
+         and PHASE_B, both in diffractograms DIFFPAT_A and DIFFPAT_B.
+
+         In diffractogram DIFFPAT_A, both PHASE_A and PHASE_B have
          corrections applied, with the non-(0,0) order/term pairs taking the
          values (2,0) and (4,1), with coefficients of 1.538(13) and -0.066(10),
          respectively.
 
-         In diffractogram 'DIFFPAT_B', only 'PHASE_A' has corrections applied,
+         In diffractogram DIFFPAT_B, only PHASE_A has corrections applied,
          with the non-(0,0) order/term pair taking the value (2,0), with a
          coefficient of 1.630(14).
-
-         As information for more than one phase is contained in the data block,
-         _audit.schema has non-default value 'Custom'.
 ;
 ;
          _pd_diffractogram.id  DIFFPAT_A
          _pd_phase.id          PHASE_A
+
+         _pd_pref_orient.geom  cap
+         _pd_pref_orient.spherical_harmonics_texture_index  1.5688
 
          loop_
          _pd_pref_orient_spherical_harmonics.id
@@ -11383,6 +11400,10 @@ save_PD_PREF_ORIENT_SPHERICAL_HARMONICS
          order/term pairs of (0,0), (2,0), (4,0), and (4, -3), and their
          magnitudes and standard uncertainties are 1.0, 1.538(13), 0.913(16),
          and -0.166(10), respectively.
+
+         The correction applied corresponds to the capillary geometry.
+         The texture index is also given, indicating the severity of the
+         preferred orientation.
 ;
 
 save_

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -7174,8 +7174,8 @@ save_PD_INSTR
 
         The radiation used in the instrument is defined by data names from the
         DIFFRN_RADIATION_WAVELENGTH category. In this case, it is pure Cu K\a~1~
-        radiation with a wavelength of 1.540596 Å. It is linked to the instrument
-        through the value of _pd_instr.radiation_id.
+        radiation with a wavelength of 1.540596 Å. It is linked to the
+        instrument through the value of _pd_instr.radiation_id.
 ;
 ;
         _diffrn_radiation.id   Cobalt_tube

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -9727,6 +9727,8 @@ save_PD_PEAK
       _description_example.case
       _description_example.detail
 ;
+         _pd_diffractogram.id  PEAKYPLOT
+
          loop_
          _pd_peak.id
          _pd_peak.2theta_centroid
@@ -9745,6 +9747,14 @@ save_PD_PEAK
          uncertainty (eg 1023 ± 7).
 ;
 ;
+         _pd_diffractogram.id        PEAKYPLOT
+         _pd_diffractogram.instr_id  Cu_workhorse
+
+         _pd_instr.id            Cu_workhorse
+         _pd_instr.radiation_id  Cu_tube
+
+         _diffrn_radiation.id  Cu_tube
+
          loop_
          _diffrn_radiation_wavelength.id
          _diffrn_radiation_wavelength.value
@@ -9773,6 +9783,10 @@ save_PD_PEAK
          d-spacing from the data's original 2θ results is given in the final
          column, which corresponds to 1.540596 Å, as given in the top-most
          loop.
+
+         The individual data names at the top are to associate the radiation
+         source with the instrument, and the instrument with the diffractogram,
+         allowing for the correct wavelength to be specified in the peak loop.
 ;
 
 save_

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -7140,6 +7140,7 @@ save_PD_INSTR
         _pd_instr.dist_mono_spec              402
         _pd_instr.dist_src_mono                39
         _pd_instr.beam_size_ax                 10.5
+        _pd_instr.radiation_id                Hires_tube
         _pd_instr.slit_ax_mono_spec            10.0
         _pd_instr.slit_eq_mono_spec             0.5
         _pd_instr.soller_ax_mono_spec           2.5
@@ -7173,7 +7174,8 @@ save_PD_INSTR
 
         The radiation used in the instrument is defined by data names from the
         DIFFRN_RADIATION_WAVELENGTH category. In this case, it is pure Cu K\a~1~
-        radiation with a wavelength of 1.540596 Å.
+        radiation with a wavelength of 1.540596 Å. It is linked to the instrument
+        through the value of _pd_instr.radiation_id.
 ;
 ;
         _diffrn_radiation.id   Cobalt_tube
@@ -7197,6 +7199,7 @@ save_PD_INSTR
         _pd_instr.detector_circle_radius   117.5
         _pd_instr.dist_src_spec            117.5
         _pd_instr.beam_size_ax               9.8
+        _pd_instr.radiation_id             Cobalt_tube
         _pd_instr.slit_ax_src_spec           9.5
         _pd_instr.soller_ax_src_spec         5.0
         _pd_instr.source_size_ax             8.5
@@ -7223,7 +7226,8 @@ save_PD_INSTR
         The radiation used in the instrument is defined by data names from the
         DIFFRN_RADIATION_WAVELENGTH category. In this case, it is Co K\a
         radiation as described by the constituent seven wavelengths, as
-        described by G. Hölzer et al. Phys. Rev. A 56, 4554.
+        described by G. Hölzer et al. Phys. Rev. A 56, 4554. It is linked to
+        the instrument through the value of _pd_instr.radiation_id.
 ;
 
 save_

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -13524,24 +13524,27 @@ save_PD_QPA_INTERNAL_STD
 
     _description_example.case
 ;
-         _audit.schema          Custom
+         data_int_std
          _pd_diffractogram.id   DIFFRACTOGRAM_1
+         _pd_phase.id           NIST_ALUMINA_676A
 
-         loop_
-         _pd_phase_mass.phase_id
-         _pd_phase_mass.absolute
-         _pd_phase_mass.absolute_su
-         PHASE_1             42.81   0.56
-         PHASE_2             14.73   0.24
-         NIST_ALUMINA_676A   24.76   0.28
+         _pd_qpa_internal_std.mass_percent              25.000(2)
+         _pd_qpa_internal_std.crystallinity_percent     99.02(111)
 
-         _pd_qpa_internal_std.mass_percent              25.000
-         _pd_qpa_internal_std.mass_percent_su            0.002
-         _pd_qpa_internal_std.crystallinity_percent     99.02
-         _pd_qpa_internal_std.crystallinity_percent_su   1.11
-         _pd_qpa_internal_std.phase_id                  NIST_ALUMINA_676A
-
+         _pd_phase_mass.absolute  24.76(28)
          _pd_qpa_overall.method   ZMV
+
+         data_b1
+         _pd_diffractogram.id   DIFFRACTOGRAM_1
+         _pd_phase.id           PHASE_1
+
+         _pd_phase_mass.absolute  42.81(56)
+
+         data_b1
+         _pd_diffractogram.id   DIFFRACTOGRAM_1
+         _pd_phase.id           PHASE_2
+
+         _pd_phase_mass.absolute  14.73(24)
 ;
     _description_example.detail
 ;

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -12701,36 +12701,38 @@ save_PD_QPA_CALIB_FACTOR
     _description_example.case
 ;
          data_phase_A
-             _pd_phase.id   PHASE_A
-             _pd_qpa_calib_factor.I_over_Ic   3.26
+             _pd_phase.id                    PHASE_A
+             _pd_qpa_calib_factor.I_over_Ic  3.26
 
          data_phase_B
-             _pd_phase.id   PHASE_B
-             _pd_qpa_calib_factor.I_over_Ic   4.79
+             _pd_phase.id                    PHASE_B
+             _pd_qpa_calib_factor.I_over_Ic  4.79
 
          data_phase_C
-             _pd_phase.id   PHASE_C
-             _pd_qpa_calib_factor.I_over_Ic   1.00
+             _pd_phase.id                    PHASE_C
+             _pd_qpa_calib_factor.I_over_Ic  1.00
 
-         data_diffractogram_block
-             _audit.schema          Custom
-             _pd_diffractogram.id   UNKNOWN_DIFFRACTOGRAM
+         data_diffractogram_block_I
+             _pd_diffractogram.id   UNKNOWN
+             _pd_phase.id           PHASE_A
 
-             loop_
-             _pd_phase_mass.phase_id
-             _pd_phase_mass.percent
-             PHASE_A   52.02(15)
-             PHASE_B   17.90(15)
-             PHASE_C   30.08(14)
+             _pd_phase_mass.percent           52.02(15)
+             _pd_qpa_overall.method          I/Ic
+             _pd_qpa_intensity_factor.value  242.54(81)
 
-             _pd_qpa_overall.method   I/Ic
+         data_diffractogram_block_II
+             _pd_diffractogram.id   UNKNOWN
+             _pd_phase.id           PHASE_B
 
-             loop_
-             _pd_qpa_intensity_factor.phase_id
-             _pd_qpa_intensity_factor.value
-             PHASE_A   242.54(81)
-             PHASE_B   122.6(12)
-             PHASE_C    43.02(25)
+             _pd_phase_mass.percent           17.90(15)
+             _pd_qpa_intensity_factor.value  122.6(12)
+
+         data_diffractogram_block_III
+             _pd_diffractogram.id   UNKNOWN
+             _pd_phase.id           PHASE_C
+
+             _pd_phase_mass.percent          30.08(14)
+             _pd_qpa_intensity_factor.value  43.02(25)
 ;
     _description_example.detail
 ;
@@ -12747,10 +12749,9 @@ save_PD_QPA_CALIB_FACTOR
          confirmed by following the I/Ic algorithm detailed in
          _pd_qpa_overall.method.
 
-         As there are loops containing data names linked to key data names of
-         Set categories (_pd_phase_mass.phase_id and
-         _pd_qpa_intensity_factor.phase_id), the _audit.schema value for the
-         last block must take the value 'Custom'
+         This example is the same as for PD_QPA_INTENSITY_FACTOR, but with
+         values distributed amongst blocks such that a custom _audit.schema
+         value is not needed.
 ;
 
 save_
@@ -13389,7 +13390,8 @@ save_PD_QPA_INTENSITY_FACTOR
          confirmed by following the I/Ic algorithm detailed in
          _pd_qpa_overall.method.
 
-         As we are looping data names linked to _pd_phase.id, the _audit.schema
+         This example is the same as for PD_QPA_CALIB_FACTOR, but as we are
+         looping data names linked to _pd_phase.id, the _audit.schema
          is set to Custom.
 ;
 

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -2489,6 +2489,8 @@ save_PD_CALIB_D_TO_TOF
       _description_example.case
       _description_example.detail
 ;
+         _pd_diffractogram.id   TOF_DATA_BANK_1
+
          loop_
          _pd_calib_d_to_tof.id
          _pd_calib_d_to_tof.power
@@ -2504,6 +2506,8 @@ save_PD_CALIB_D_TO_TOF
                           + 0.08099 * d_spacing^2^
 ;
 ;
+         _pd_diffractogram.id   TOF_DATA_BANK_2
+
          loop_
          _pd_calib_d_to_tof.id
          _pd_calib_d_to_tof.power

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -13504,12 +13504,13 @@ save_PD_QPA_INTERNAL_STD
 
     This can be done as
 
-        W~p~^abs.^ = W~p~^rel.^ * (W~s~^known^ / W~s~^rel.^)
+        W~p~^abs.^ = W~p~^rel.^ * (W~s~^known^ * X~s~ / W~s~^rel.^)
 
     where p and s represent the analyte phase and standard phase, respectively,
     W is the weight fraction, 'abs.' is absolute, 'rel.' is relative, and
-    'known' is the known addition. Here, W~s~^rel.^ is the relative amount of
-    standard as calculated by the quantification algorithm.
+    'known' is the known addition. X~s~ is the crystallinity of the internal
+    standard. Here, W~s~^rel.^ is the relative amount of standard as calculated
+    by the quantification algorithm.
 
     For a review on quantitative phase analysis, see Chapter 3.9 of
     International Tables, Vol. H, and references therein.
@@ -13552,23 +13553,24 @@ save_PD_QPA_INTERNAL_STD
          some NIST SRM676a) has been quantified using the ZMV algorithm after
          Rietveld refinement.
 
-         The diffraction pattern was collected from a specimen containing
-         25.000 ± 0.002 wt% internal standard (i.e. 1 g added to 3 g of unknown
-         to make a specimen with total weight of 4 g). The internal standard is
-         known to be 99.02 ± 1.11 % crystalline, and so the reported value of
-         _pd_phase_mass.absolute for the standard is:
+         The diffraction pattern was collected from a specimen with a known
+         addition of 25.000 ± 0.002 wt% internal standard (i.e. 1 g added to
+         3 g of unknown to make a specimen with total weight of 4 g). The
+         internal standard is known to be 99.02 ± 1.11 % crystalline, and so
+         the reported value of _pd_phase_mass.absolute for the standard is:
          25.000 * 0.9902 = 24.76 wt%.
 
          The weight fractions derived from the ZMV algorithm were then scaled as
 
-            W~p~^absolute^ = W~p~^ZMV^ * (W~s~^known^ / W~s~^ZMV^)
+            W~p~^absolute^ = W~p~^ZMV^ * (W~s~^known^ * X~s~ / W~s~^ZMV^)
 
          where W is the weight percentage, p is the phase, s is the standard
-         'ZMV' is the weight fraction from the ZMV algorithm, and 'known' is the
-         known addition of standard (_pd_qpa_internal_std.mass_percent). These
-         are the values reported as _pd_phase_mass.absolute. Any difference
-         between the sum of the _pd_phase_mass.absolute values and 100 wt% can
-         be attributed to unanalysed or amorphous phases.
+         'ZMV' is the weight fraction from the ZMV algorithm, 'known' is the
+         known addition of standard (_pd_qpa_internal_std.mass_percent), and
+         X~s~ is the crystallinity of the internal standard. These are the
+         values reported as _pd_phase_mass.absolute. Any difference between
+         the sum of the _pd_phase_mass.absolute values and 100 wt% can be
+         attributed to unanalysed or amorphous phases.
 
          The crystal structure of the internal standard is described by the
          information linked to the _pd_phase.id data item with the value


### PR DESCRIPTION
From #313 

I have retained a couple as examples for the alternate behaviour.

I have not touched PD_CALIB_XCOORD or PD_QPA_EXTERNAL_STD, as there are outstanding PRs against those #315 #316 