### PR TITLE
alter key `pd_qpa_external_std`

### DIFF
--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -13151,24 +13151,6 @@ save_PD_QPA_EXTERNAL_STD
 
 save_
 
-save_pd_qpa_external_std.instr_id
-
-    _definition.id                '_pd_qpa_external_std.instr_id'
-    _definition.update            2026-07-06
-    _description.text
-;
-    The instrument (see _pd_instr.id) to which the external standard relates.
-;
-    _name.category_id             pd_qpa_external_std
-    _name.object_id               instr_id
-    _name.linked_item_id          '_pd_instr.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
 save_pd_qpa_external_std.diffractogram_id
 
     _definition.id                '_pd_qpa_external_std.diffractogram_id'
@@ -13181,6 +13163,24 @@ save_pd_qpa_external_std.diffractogram_id
     _name.category_id             pd_qpa_external_std
     _name.object_id               diffractogram_id
     _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_external_std.instr_id
+
+    _definition.id                '_pd_qpa_external_std.instr_id'
+    _definition.update            2026-07-06
+    _description.text
+;
+    The instrument (see _pd_instr.id) to which the external standard relates.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               instr_id
+    _name.linked_item_id          '_pd_instr.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -13060,7 +13060,7 @@ save_PD_QPA_EXTERNAL_STD
     _definition.id                PD_QPA_EXTERNAL_STD
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-06-20
+    _definition.update            2026-06-07
     _description.text
 ;
     This category identifies the external diffractogram used for
@@ -13078,7 +13078,7 @@ save_PD_QPA_EXTERNAL_STD
 ;
     _name.category_id             CIF_PD_HEAD
     _name.object_id               PD_QPA_EXTERNAL_STD
-    _category_key.name            '_pd_qpa_external_std.diffractogram_id'
+    _category_key.name            '_pd_qpa_external_std.instr_id'
 
     _description_example.case
 ;
@@ -13127,9 +13127,28 @@ save_PD_QPA_EXTERNAL_STD
          _pd_qpa_external_std.k_factor value can be used to calculate the
          absolute mass percent of the phases present in the
          diffractogram.
+         coefficient of the unknown specimen.
 
          A Custom _audit.schema is required due to looping _pd_phase.id values.
 ;
+
+save_
+
+save_pd_qpa_external_std.instr_id
+
+    _definition.id                '_pd_qpa_external_std.instr_id'
+    _definition.update            2026-07-06
+    _description.text
+;
+    The instrument (see _pd_instr.id) to which the external standard relates.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               instr_id
+    _name.linked_item_id          '_pd_instr.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -14571,7 +14590,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-07-05
+         2.5.0                    2026-07-06
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -14839,4 +14858,6 @@ save_
        categories and to allow non-linear calibrations.
 
        Convert PD_PHASE_MASS to Set category.
+
+       Altered key of pd_qpa_external_std to be _pd_qpa_external_std.instr_id.
 ;

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -13277,7 +13277,7 @@ save_PD_QPA_EXTERNAL_STD
 
     _description_example.case
 ;
-         data_ext_std_diffractogram
+         data_ext_std_values
             _pd_diffractogram.id         THE_REFERENCE
             _pd_diffractogram.instr_id   labmachine
             _pd_diffractogram.spec_id    REF_spec
@@ -13328,7 +13328,9 @@ save_PD_QPA_EXTERNAL_STD
          In the first block, the K factor, or diffractometer constant, is
          calculated from a diffraction pattern of a previously characterised
          standard, collected under set conditions on the given instrument; see
-         the _pd_qpa_overall.method enumeration external_standard.
+         the _pd_qpa_overall.method enumeration external_standard. The
+         reference diffraction pattern is given in another block, not shown
+         here, identified with the diffractogram id of THE_REFERENCE.
 
          In the second block, a diffraction pattern is given, along with
          information about the instrument, specimen used, and quantification

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -13085,51 +13085,68 @@ save_PD_QPA_EXTERNAL_STD
          data_ext_std_diffractogram
             _pd_diffractogram.id         THE_REFERENCE
             _pd_diffractogram.instr_id   labmachine
+            _pd_diffractogram.spec_id    REF_spec
 
-            loop_
-            _pd_phase_mass.phase_id
-            _pd_phase_mass.absolute
-            _pd_phase_mass.absolute_su
-            NIST_ALUMINA_676A   99.02   1.11
+            _pd_char.id       REF_char
+            _pd_prep.id       REF_prep
+            _pd_prep.char_id  REF_char
+            _pd_spec.id       REF_spec
+            _pd_spec.prep_id  REF_prep
+
+            _pd_phase.id  NIST_ALUMINA_676A
+            _pd_phase_mass.absolute     99.02
+            _pd_phase_mass.absolute_su   1.11
 
             _pd_qpa_external_std.k_factor           293.36
+            _pd_qpa_external_std.diffractogram_id   THE_REFERENCE
             _pd_char.mass_atten_coef_mu_calc        3159
             _pd_qpa_overall.method                  external_standard
 
-         data_diffractogram_block
-            _audit.schema                Custom
+         data_diffraction_data
             _pd_diffractogram.id         DIFFRACTOGRAM_2
             _pd_diffractogram.instr_id   labmachine
+            _pd_diffractogram.spec_id    UNK_spec
 
-            loop_
-            _pd_phase_mass.phase_id
-            _pd_phase_mass.original
-            _pd_phase_mass.original_su
-            PHASE_1   42.81   0.56
-            PHASE_2   14.73   0.24
+            _pd_char.id       UNK_char
+            _pd_prep.id       UNK_prep
+            _pd_prep.char_id  UNK_char
+            _pd_spec.id       UNK_spec
+            _pd_spec.prep_id  UNK_prep
 
             _pd_char.mass_atten_coef_mu_calc        6940
             _pd_qpa_overall.method                  external_standard
+
+            # diffraction intensities go here
+
+         data_qpa_data_a
+            _pd_diffractogram.id   DIFFRACTOGRAM_2
+            _pd_phase.id           PHASE_1
+            _pd_phase_mass.original     42.81(56)
+
+         data_qpa_data_b
+            _pd_diffractogram.id   DIFFRACTOGRAM_2
+            _pd_phase.id           PHASE_2
+            _pd_phase_mass.original     14.73(24)
 ;
     _description_example.detail
 ;
          In the first block, the K factor, or diffractometer constant, is
          calculated from a diffraction pattern of a previously characterised
-         standard, collected under set conditions; see the
-         _pd_qpa_overall.method enumeration external_standard.
+         standard, collected under set conditions on the given instrument; see
+         the _pd_qpa_overall.method enumeration external_standard.
 
-         In the second block, a diffraction pattern containing two phases
-         (PHASE_1 and PHASE_2) has been quantified using the external standard
-         algorithm after Rietveld refinement. Knowing the instrument id value
-         used to collect the diffractogram of the unknown, the
-         _pd_qpa_external_std.diffractogram_id values can be looked at to find
-         one that has the same instrument id value, and thus the
-         _pd_qpa_external_std.k_factor value can be used to calculate the
-         absolute mass percent of the phases present in the
-         diffractogram.
+         In the second block, a diffraction pattern is given, along with
+         information about the instrument, specimen used, and quantification
+         method. These data are important to allow the K factor to be looked up
+         and to allow the quantification through finding the mass absorption
          coefficient of the unknown specimen.
 
-         A Custom _audit.schema is required due to looping _pd_phase.id values.
+         The results of the quantification are reported in the final two
+         data blocks. Knowing the instrument id value, the
+         _pd_qpa_external_std.k_factor value can be looked up directly and used
+         to calculate the absolute mass percent of the phases present in the
+         diffractogram, given knowledge of the specimen mass absorption
+         coefficient, allowing the reported value to be verified.
 ;
 
 save_


### PR DESCRIPTION
`pd_qpa_external_std` - originally keyed on `.diffractogram_id`. This was only used to get to the associated `.instr_id` value, so I decided to cut out the middleman and key it directly on `.instr_id`. This has the side-effect of requiring a new `_pd_instr.id` if a recalibration is required, but this was always implicitly there. `.diffractogram_id` demoted to linked, non-key data name. `.instr_id` added as category key. Updated the example to link the mass absorption coefficient of the specimen to the diffractogram though a `pd_char`, `pd_prep`, `pd_spec` chain.