### PR TITLE
Add the `DICTIONARY_AUTHOR` loop

### DIFF
--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -14728,15 +14728,15 @@ save_
       _dictionary_author.name
       _dictionary_author.id_orcid
       _dictionary_author.email
-         1         'Toby, Brian'                .                          .
-         2         'Hall, Sydney R.'            .                          .
-         3         'Brown, I. David.'           .                          .
-         4         'McMahon, Brian'             0000-0003-0391-0002        .
-         5         'Langford, Ian'              .                          .
-         6         'Hester, James R.'           0000-0002-2004-8672        .
-         7         'Vaitkus, Antanas'           0000-0002-5944-1391        .
-         8         'Rowles, Matthew R.'         0000-0002-7448-6774        .
-         9         'Schriener, Walter'          .                          .
+         1         'Toby, Brian'                .                           .
+         2         'Hall, Sydney R.'            .                           .
+         3         'Brown, I. David.'           .                           .
+         4         'McMahon, Brian'             0000-0003-0391-0002         .
+         5         'Langford, Ian'              .                           .
+         6         'Hester, James R.'           0000-0002-2004-8672         .
+         7         'Vaitkus, Antanas'           0000-0002-5944-1391         .
+         8         'Rowles, Matthew R.'         0000-0002-7448-6774         .
+         9         'Schriener, Walter'          .                           .
 
     loop_
       _dictionary_audit.version

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -14728,24 +14728,15 @@ save_
       _dictionary_author.name
       _dictionary_author.id_orcid
       _dictionary_author.email
-         1               'Toby, Brian'                      .
-         .
-         2               'Hall, Sydney R.'                  .
-         .
-         3               'Brown, I. David.'                 .
-         .
-         4               'McMahon, Brian'                   0000-0003-0391-0002
-         .
-         5               'Langford, Ian'                    .
-         .
-         6               'Hester, James R.'                 0000-0002-2004-8672
-         .
-         7               'Vaitkus, Antanas'                 0000-0002-5944-1391
-         .
-         8               'Rowles, Matthew R.'               0000-0002-7448-6774
-         .
-         9               'Schriener, Walter'                .
-         .
+         1         'Toby, Brian'                .                          .
+         2         'Hall, Sydney R.'            .                          .
+         3         'Brown, I. David.'           .                          .
+         4         'McMahon, Brian'             0000-0003-0391-0002        .
+         5         'Langford, Ian'              .                          .
+         6         'Hester, James R.'           0000-0002-2004-8672        .
+         7         'Vaitkus, Antanas'           0000-0002-5944-1391        .
+         8         'Rowles, Matthew R.'         0000-0002-7448-6774        .
+         9         'Schriener, Walter'          .                          .
 
     loop_
       _dictionary_audit.version

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -14724,6 +14724,30 @@ save_structure.phase_id
 save_
 
     loop_
+      _dictionary_author.id
+      _dictionary_author.name
+      _dictionary_author.id_orcid
+      _dictionary_author.email
+         1               'Toby, Brian'                      .
+         .
+         2               'Hall, Sydney R.'                  .
+         .
+         3               'Brown, I. David.'                 .
+         .
+         4               'McMahon, Brian'                   0000-0003-0391-0002
+         .
+         5               'Langford, Ian'                    .
+         .
+         6               'Hester, James R.'                 0000-0002-2004-8672
+         .
+         7               'Vaitkus, Antanas'                 0000-0002-5944-1391
+         .
+         8               'Rowles, Matthew R.'               0000-0002-7448-6774
+         .
+         9               'Schriener, Walter'                0000-0002-3272-3161
+         .
+
+    loop_
       _dictionary_audit.version
       _dictionary_audit.date
       _dictionary_audit.revision

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -14744,7 +14744,7 @@ save_
          .
          8               'Rowles, Matthew R.'               0000-0002-7448-6774
          .
-         9               'Schriener, Walter'                0000-0002-3272-3161
+         9               'Schriener, Walter'                .
          .
 
     loop_

--- a/cif_pd.dic
+++ b/cif_pd.dic
@@ -15,7 +15,7 @@ data_CIF_PD
     _dictionary.title             CIF_PD
     _dictionary.class             Instance
     _dictionary.version           2.5.0
-    _dictionary.date              2026-07-05
+    _dictionary.date              2026-07-07
     _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_pd/master/cif_pd.dic
     _dictionary.ddl_conformance   4.2.0
@@ -14787,7 +14787,7 @@ save_
 
        Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
 ;
-         2.5.0                    2026-07-05
+         2.5.0                    2026-07-07
 ;
        ## Retain above version number and increment date until final
        ## release
@@ -15055,4 +15055,6 @@ save_
        categories and to allow non-linear calibrations.
 
        Convert PD_PHASE_MASS to Set category.
+
+       Add DICTIONARY_AUTHOR loop.
 ;


### PR DESCRIPTION
From #266 

In no way can this be considered complete or in the correct order. I just put all the names in the order I initially wrote them down in.

Emails intentionally not included until explicit permission is given. I have also not included ORCIDs unless previously used in core.